### PR TITLE
fixed: make TransmitterLabel a variable so it becomes configurable

### DIFF
--- a/enforcer/types.go
+++ b/enforcer/types.go
@@ -29,7 +29,7 @@ const (
 	AckProcessed
 )
 
-const (
+var (
 	// TransmitterLabel is the name of the label used to identify the Transmitter Context
 	TransmitterLabel = "AporetoContextID"
 )


### PR DESCRIPTION
Some other systems use a different tag.
