### PR TITLE
Cleaning PuFromPort Cache on PU removal

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -23,6 +23,7 @@ type DataStore interface {
 	LockedModify(u interface{}, add func(a, b interface{}) interface{}, increment interface{}) (interface{}, error)
 	SetTimeOut(u interface{}, timeout time.Duration) (err error)
 	ToString() string
+	GetKeys() interface{}
 }
 
 // Cache is the structure that involves the map of entries. The cache
@@ -389,4 +390,18 @@ func (c *Cache) LockedModify(u interface{}, add func(a, b interface{}) interface
 
 	return e.value, nil
 
+}
+
+// GetKeys Returns list of keys
+func (c *Cache) GetKeys() interface{} {
+
+	keyList := make([]interface{}, 0)
+
+	c.Lock()
+	for k := range c.data {
+		keyList = append(keyList, k)
+	}
+	c.Unlock()
+
+	return keyList
 }

--- a/enforcer/datapath/datapath.go
+++ b/enforcer/datapath/datapath.go
@@ -286,6 +286,12 @@ func (d *Datapath) GetFilterQueue() *fqconfig.FilterQueue {
 	return d.filterQueue
 }
 
+// GetPuFromPortCache returns the puFromPort cache used by the data path
+func (d *Datapath) GetPuFromPortCache() cache.DataStore {
+
+	return d.puFromPort
+}
+
 // Start starts the application and network interceptors
 func (d *Datapath) Start() error {
 

--- a/enforcer/datapath/proxy/tcp/tcp.go
+++ b/enforcer/datapath/proxy/tcp/tcp.go
@@ -223,6 +223,11 @@ func (p *Proxy) GetFilterQueue() *fqconfig.FilterQueue {
 	return nil
 }
 
+// GetPuFromPortCache is a stub for TCP proxy
+func (p *Proxy) GetPuFromPortCache() cache.DataStore {
+	return nil
+}
+
 // Start is a stub for TCP proxy
 func (p *Proxy) Start() error {
 	return nil

--- a/enforcer/policyenforcer/interfaces.go
+++ b/enforcer/policyenforcer/interfaces.go
@@ -1,6 +1,7 @@
 package policyenforcer
 
 import (
+	"github.com/aporeto-inc/trireme-lib/cache"
 	"github.com/aporeto-inc/trireme-lib/enforcer/utils/fqconfig"
 	"github.com/aporeto-inc/trireme-lib/policy"
 )
@@ -16,6 +17,9 @@ type Enforcer interface {
 
 	// GetFilterQueue returns the current FilterQueueConfig.
 	GetFilterQueue() *fqconfig.FilterQueue
+
+	// GetPuFromPortCache returns the puFromPort cache used by the data path
+	GetPuFromPortCache() cache.DataStore
 
 	// Start starts the PolicyEnforcer.
 	Start() error

--- a/enforcer/policyenforcer/mock/mockpolicyenforcer.go
+++ b/enforcer/policyenforcer/mock/mockpolicyenforcer.go
@@ -7,6 +7,7 @@ package mockpolicyenforcer
 import (
 	reflect "reflect"
 
+	cache "github.com/aporeto-inc/trireme-lib/cache"
 	fqconfig "github.com/aporeto-inc/trireme-lib/enforcer/utils/fqconfig"
 	policy "github.com/aporeto-inc/trireme-lib/policy"
 	gomock "github.com/golang/mock/gomock"
@@ -79,6 +80,20 @@ func (m *MockEnforcer) GetFilterQueue() *fqconfig.FilterQueue {
 // nolint
 func (mr *MockEnforcerMockRecorder) GetFilterQueue() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilterQueue", reflect.TypeOf((*MockEnforcer)(nil).GetFilterQueue))
+}
+
+// GetPuFromPortCache mocks base method
+// nolint
+func (m *MockEnforcer) GetPuFromPortCache() cache.DataStore {
+	ret := m.ctrl.Call(m, "GetPuFromPortCache")
+	ret0, _ := ret[0].(cache.DataStore)
+	return ret0
+}
+
+// GetPuFromPortCache indicates an expected call of GetPuFromPortCache
+// nolint
+func (mr *MockEnforcerMockRecorder) GetPuFromPortCache() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPuFromPortCache", reflect.TypeOf((*MockEnforcer)(nil).GetPuFromPortCache))
 }
 
 // Start mocks base method

--- a/enforcer/proxy/enforcerproxy.go
+++ b/enforcer/proxy/enforcerproxy.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aporeto-inc/trireme-lib/cache"
 	"github.com/aporeto-inc/trireme-lib/collector"
 	"github.com/aporeto-inc/trireme-lib/constants"
 	"github.com/aporeto-inc/trireme-lib/crypto"
@@ -169,6 +170,11 @@ func (s *ProxyInfo) Unenforce(contextID string) error {
 // GetFilterQueue returns the current FilterQueueConfig.
 func (s *ProxyInfo) GetFilterQueue() *fqconfig.FilterQueue {
 	return s.filterQueue
+}
+
+// GetPuFromPortCache returns nil for Proxy.
+func (s *ProxyInfo) GetPuFromPortCache() cache.DataStore {
+	return nil
 }
 
 // Start starts the the remote enforcer proxy.

--- a/supervisor/iptablesctrl/acls_test.go
+++ b/supervisor/iptablesctrl/acls_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aporeto-inc/trireme-lib/cache"
 	"github.com/aporeto-inc/trireme-lib/constants"
 	"github.com/aporeto-inc/trireme-lib/enforcer/utils/fqconfig"
 	"github.com/aporeto-inc/trireme-lib/policy"
@@ -26,7 +27,7 @@ func matchSpec(term string, rulespec []string) error {
 func TestAddContainerChain(t *testing.T) {
 
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -85,7 +86,7 @@ func TestAddContainerChain(t *testing.T) {
 func TestAddChainRules(t *testing.T) {
 
 	Convey("Given an iptables controller for LocalContainer", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -136,7 +137,7 @@ func TestAddChainRules(t *testing.T) {
 	})
 
 	Convey("Given an iptables controller for LocalServer", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalServer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalServer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -197,7 +198,7 @@ func TestAddChainRules(t *testing.T) {
 func TestAddPacketTrap(t *testing.T) {
 
 	Convey("Given an iptables controller, when I test addPacketTrap for Local Container", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -253,7 +254,7 @@ func TestAddPacketTrap(t *testing.T) {
 	})
 
 	Convey("Given an iptables controller, when I test addPacketTrap for Local Server", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalServer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalServer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -299,7 +300,7 @@ func TestAddPacketTrap(t *testing.T) {
 func TestAddAppACLs(t *testing.T) {
 
 	Convey("Given an iptables controller ", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -447,7 +448,7 @@ func TestAddAppACLs(t *testing.T) {
 func TestAddNetAcls(t *testing.T) {
 
 	Convey("Given an iptables controller ", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -604,7 +605,7 @@ func TestAddNetAcls(t *testing.T) {
 func TestDeleteChainRules(t *testing.T) {
 
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -632,7 +633,7 @@ func TestDeleteChainRules(t *testing.T) {
 func TestDeleteAllContainerChains(t *testing.T) {
 
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -682,7 +683,7 @@ func TestDeleteAllContainerChains(t *testing.T) {
 func TestAcceptMarkedPackets(t *testing.T) {
 
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -714,7 +715,7 @@ func TestAcceptMarkedPackets(t *testing.T) {
 func TestRemoveMarkRule(t *testing.T) {
 
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -741,7 +742,7 @@ func TestRemoveMarkRule(t *testing.T) {
 
 func TestAddExclusionACLs(t *testing.T) {
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -786,7 +787,7 @@ func TestAddExclusionACLs(t *testing.T) {
 
 // func TestSetGlobalRules(t *testing.T) {
 // 	Convey("Given an iptables controller", t, func() {
-// 		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+// 		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 // 		iptables := provider.NewTestIptablesProvider()
 // 		i.ipt = iptables
 // 		ipsets := provider.NewTestIpsetProvider()
@@ -881,7 +882,7 @@ func TestAddExclusionACLs(t *testing.T) {
 
 func TestClearCaptureSynAckPackets(t *testing.T) {
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -907,7 +908,7 @@ func TestClearCaptureSynAckPackets(t *testing.T) {
 
 func TestUpdateTargetNetworks(t *testing.T) {
 	Convey("Given an iptables controller,", t, func() {
-		i, _ := NewInstance(&fqconfig.FilterQueue{}, constants.LocalContainer)
+		i, _ := NewInstance(&fqconfig.FilterQueue{}, constants.LocalContainer, cache.NewCache("acl test"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 		ipsets := provider.NewTestIpsetProvider()

--- a/supervisor/iptablesctrl/iptables.go
+++ b/supervisor/iptablesctrl/iptables.go
@@ -10,7 +10,9 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/aporeto-inc/trireme-lib/cache"
 	"github.com/aporeto-inc/trireme-lib/constants"
+	"github.com/aporeto-inc/trireme-lib/enforcer/pucontext"
 	"github.com/aporeto-inc/trireme-lib/enforcer/utils/fqconfig"
 	"github.com/aporeto-inc/trireme-lib/policy"
 	"github.com/bvandewalle/go-ipset/ipset"
@@ -57,10 +59,11 @@ type Instance struct {
 	appCgroupIPTableSection    string
 	appSynAckIPTableSection    string
 	mode                       constants.ModeType
+	puFromPort                 cache.DataStore
 }
 
 // NewInstance creates a new iptables controller instance
-func NewInstance(fqc *fqconfig.FilterQueue, mode constants.ModeType) (*Instance, error) {
+func NewInstance(fqc *fqconfig.FilterQueue, mode constants.ModeType, puFromPort cache.DataStore) (*Instance, error) {
 
 	ipt, err := provider.NewGoIPTablesProvider()
 	if err != nil {
@@ -80,7 +83,8 @@ func NewInstance(fqc *fqconfig.FilterQueue, mode constants.ModeType) (*Instance,
 		appAckPacketIPTableContext: "mangle",
 		netPacketIPTableContext:    "mangle",
 		appProxyIPTableContext:     "nat",
-		mode: mode,
+		mode:       mode,
+		puFromPort: puFromPort,
 	}
 
 	if mode == constants.LocalServer || mode == constants.RemoteContainer {
@@ -282,6 +286,11 @@ func (i *Instance) DeleteRules(version int, contextID string, ipAddresses policy
 		}
 		if err := ips.Destroy(); err != nil {
 			zap.L().Warn("Failed to clear puport set", zap.Error(err))
+		}
+
+		// remove ports associated with this pu from cache.
+		if err := i.clearPuPorts(); err != nil {
+			return err
 		}
 	}
 	dstPortSetName, srcPortSetName := i.getSetNamePair(proxyPortSetName)
@@ -489,6 +498,24 @@ func (i *Instance) SetTargetNetworks(current, networks []string) error {
 	// Insert the ACLS that point to the target networks
 	if err := i.setGlobalRules(i.appPacketIPTableSection, i.netPacketIPTableSection); err != nil {
 		return fmt.Errorf("Failed to update synack networks")
+	}
+
+	return nil
+}
+
+func (i *Instance) clearPuPorts() error {
+
+	puFromPortKeys := (i.puFromPort.GetKeys()).([]string)
+
+	for k := range puFromPortKeys {
+		pu, err := i.puFromPort.Get(k)
+		if err != nil || pu.(*pucontext.PUContext) != nil {
+			// key is not there or active pu
+			continue
+		}
+		if err := i.puFromPort.Remove(k); err != nil {
+			return fmt.Errorf("Unable to delete port from puFromPort cache")
+		}
 	}
 
 	return nil

--- a/supervisor/iptablesctrl/iptables.go
+++ b/supervisor/iptablesctrl/iptables.go
@@ -289,9 +289,7 @@ func (i *Instance) DeleteRules(version int, contextID string, ipAddresses policy
 		}
 
 		// remove ports associated with this pu from cache.
-		if err := i.clearPuPorts(); err != nil {
-			return err
-		}
+		i.clearPuPorts()
 	}
 	dstPortSetName, srcPortSetName := i.getSetNamePair(proxyPortSetName)
 	ips := ipset.IPSet{
@@ -503,7 +501,7 @@ func (i *Instance) SetTargetNetworks(current, networks []string) error {
 	return nil
 }
 
-func (i *Instance) clearPuPorts() error {
+func (i *Instance) clearPuPorts() {
 
 	puFromPortKeys := (i.puFromPort.GetKeys()).([]string)
 
@@ -514,11 +512,9 @@ func (i *Instance) clearPuPorts() error {
 			continue
 		}
 		if err := i.puFromPort.Remove(k); err != nil {
-			return fmt.Errorf("Unable to delete port from puFromPort cache")
+			zap.L().Warn("Cannot remove key, may already be deleted")
 		}
 	}
-
-	return nil
 }
 
 // Stop stops the supervisor

--- a/supervisor/iptablesctrl/iptables_test.go
+++ b/supervisor/iptablesctrl/iptables_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aporeto-inc/trireme-lib/cache"
 	"github.com/aporeto-inc/trireme-lib/constants"
 	"github.com/aporeto-inc/trireme-lib/enforcer/utils/fqconfig"
 	"github.com/aporeto-inc/trireme-lib/policy"
@@ -16,7 +17,7 @@ func TestNewInstance(t *testing.T) {
 	Convey("When I create a new iptables instance", t, func() {
 
 		Convey("If I create a local implemenetation and iptables exists", func() {
-			i, err := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+			i, err := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 			Convey("It should succeed", func() {
 				So(i, ShouldNotBeNil)
 				So(err, ShouldBeNil)
@@ -26,7 +27,7 @@ func TestNewInstance(t *testing.T) {
 		})
 
 		Convey("If I create a remote implemenetation and iptables exists", func() {
-			i, err := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.RemoteContainer)
+			i, err := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.RemoteContainer, cache.NewCache("iptables test cache"))
 			Convey("It should succeed", func() {
 				So(i, ShouldNotBeNil)
 				So(err, ShouldBeNil)
@@ -39,7 +40,7 @@ func TestNewInstance(t *testing.T) {
 
 func TestChainName(t *testing.T) {
 	Convey("When I test the creation of the name of the chain", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 		Convey("With a contextID of Context and version of 1", func() {
 			app, net, err := i.chainName("Context", 1)
 			So(err, ShouldBeNil)
@@ -56,7 +57,7 @@ func TestChainName(t *testing.T) {
 
 func TestDefaultIP(t *testing.T) {
 	Convey("Given an iptables controller with remote off ", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 		Convey("When I get the default IP address of a list that has the default namespace", func() {
 			addresslist := map[string]string{
 				policy.DefaultNamespace: "10.1.1.1",
@@ -81,7 +82,7 @@ func TestDefaultIP(t *testing.T) {
 	})
 
 	Convey("Given an iptables controller with remote on ", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 		Convey("When I get the default IP address of a list that has the default namespace", func() {
 			addresslist := map[string]string{
 				policy.DefaultNamespace: "10.1.1.1",
@@ -109,7 +110,7 @@ func TestDefaultIP(t *testing.T) {
 
 func TestConfigureRules(t *testing.T) {
 	Convey("Given an iptables controllers", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -245,7 +246,7 @@ func TestConfigureRules(t *testing.T) {
 
 func TestDeleteRules(t *testing.T) {
 	Convey("Given an iptables controllers", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -280,7 +281,7 @@ func TestDeleteRules(t *testing.T) {
 
 func TestUpdateRules(t *testing.T) {
 	Convey("Given an iptables controllers", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -406,7 +407,7 @@ func TestUpdateRules(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	Convey("Given an iptables controllers,", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalContainer, cache.NewCache("iptables test cache"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 
@@ -452,7 +453,7 @@ func TestStart(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	Convey("Given an iptables controller", t, func() {
-		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.RemoteContainer)
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.RemoteContainer, cache.NewCache("iptables test cache"))
 		iptables := provider.NewTestIptablesProvider()
 		i.ipt = iptables
 

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -61,6 +61,12 @@ func NewSupervisor(collector collector.EventCollector, enforcerInstance policyen
 		return nil, fmt.Errorf("Enforcer FilterQueues cannot be nil")
 	}
 
+	puFromPort := enforcerInstance.GetPuFromPortCache()
+
+	if puFromPort == nil {
+		return nil, fmt.Errorf("Enforcer puFromPort cannot be nil")
+	}
+
 	s := &Config{
 		mode:            mode,
 		impl:            nil,
@@ -76,7 +82,7 @@ func NewSupervisor(collector collector.EventCollector, enforcerInstance policyen
 	case constants.IPSets:
 		s.impl, err = ipsetctrl.NewInstance(s.filterQueue, false, mode)
 	default:
-		s.impl, err = iptablesctrl.NewInstance(s.filterQueue, mode)
+		s.impl, err = iptablesctrl.NewInstance(s.filterQueue, mode, puFromPort)
 	}
 
 	if err != nil {


### PR DESCRIPTION
#### Description
*Currently PuFromPort cache is populated during syn-ack processing and never cleaned up. This PR cleans up the cache on PU removal.

#### Test plan
*Outline the test plan used to test this change before merging it.*

> Fixes #.
