### PR TITLE
Fixed: Not necessary to call logging APIs for trireme by default

### DIFF
--- a/internal/processmon/interfaces.go
+++ b/internal/processmon/interfaces.go
@@ -6,5 +6,5 @@ import "github.com/aporeto-inc/trireme-lib/enforcer/utils/rpcwrapper"
 type ProcessManager interface {
 	KillProcess(contextID string)
 	LaunchProcess(contextID string, refPid int, refNsPath string, rpchdl rpcwrapper.RPCClient, arg string, statssecret string, procMountPoint string) error
-	SetupLogAndProcessArgs(logToConsole bool, cmdArgs []string)
+	SetupLogAndProcessArgs(logToConsole, logWithID bool, cmdArgs []string)
 }

--- a/internal/processmon/mock/mockprocessmon.go
+++ b/internal/processmon/mock/mockprocessmon.go
@@ -66,12 +66,12 @@ func (mr *MockProcessManagerMockRecorder) LaunchProcess(contextID, refPid, refNs
 
 // SetupLogAndProcessArgs mocks base method
 // nolint
-func (m *MockProcessManager) SetupLogAndProcessArgs(logToConsole bool, cmdArgs []string) {
-	m.ctrl.Call(m, "SetupLogAndProcessArgs", logToConsole, cmdArgs)
+func (m *MockProcessManager) SetupLogAndProcessArgs(logToConsole, logWithID bool, cmdArgs []string) {
+	m.ctrl.Call(m, "SetupLogAndProcessArgs", logToConsole, logWithID, cmdArgs)
 }
 
 // SetupLogAndProcessArgs indicates an expected call of SetupLogAndProcessArgs
 // nolint
-func (mr *MockProcessManagerMockRecorder) SetupLogAndProcessArgs(logToConsole, cmdArgs interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupLogAndProcessArgs", reflect.TypeOf((*MockProcessManager)(nil).SetupLogAndProcessArgs), logToConsole, cmdArgs)
+func (mr *MockProcessManagerMockRecorder) SetupLogAndProcessArgs(logToConsole, logWithID, cmdArgs interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupLogAndProcessArgs", reflect.TypeOf((*MockProcessManager)(nil).SetupLogAndProcessArgs), logToConsole, logWithID, cmdArgs)
 }

--- a/internal/processmon/processmon.go
+++ b/internal/processmon/processmon.go
@@ -42,6 +42,8 @@ type processMon struct {
 	childExitStatus chan exitStatus
 	// logToConsole stores if we should log to console
 	logToConsole bool
+	// logWithID controls whether the context ID should be provided while create a remote command
+	logWithID bool
 	// launcProcessArgs are arguments that are provided to all processes launched by processmon
 	launcProcessArgs []string
 }
@@ -128,9 +130,10 @@ func (p *processMon) collectChildExitStatus() {
 }
 
 // SetupLogAndProcessArgs setups args that should be propagated to child processes
-func (p *processMon) SetupLogAndProcessArgs(logToConsole bool, args []string) {
+func (p *processMon) SetupLogAndProcessArgs(logToConsole, logWithID bool, args []string) {
 
 	p.logToConsole = logToConsole
+	p.logWithID = logWithID
 	p.launcProcessArgs = args
 }
 
@@ -223,7 +226,7 @@ func (p *processMon) getLaunchProcessCmd(arg string, contextID string) (*exec.Cm
 	}
 
 	cmdArgs := append([]string{arg}, p.launcProcessArgs...)
-	if !p.logToConsole {
+	if p.logWithID {
 		cmdArgs = append(cmdArgs, contextID)
 	}
 	zap.L().Debug("Enforcer executed",

--- a/trireme_wrappers.go
+++ b/trireme_wrappers.go
@@ -7,13 +7,13 @@ import (
 )
 
 // SetupCommandArgs sets up arguments to be passed to the remote trireme instances.
-func SetupCommandArgs(logToConsole bool, subProcessArgs []string) {
+func SetupCommandArgs(logToConsole, logWithID bool, subProcessArgs []string) {
 
 	h := processmon.GetProcessManagerHdl()
 	if h == nil {
 		panic("Unable to find process manager handle")
 	}
-	h.SetupLogAndProcessArgs(logToConsole, subProcessArgs)
+	h.SetupLogAndProcessArgs(logToConsole, logWithID, subProcessArgs)
 }
 
 // LaunchRemoteEnforcer launches a remote enforcer instance.


### PR DESCRIPTION
#### Description
With recent logging file changes it is mandatory to setup up logging calls. By default people consuming trireme shouldnt be forced to make such an api call.
