### PR TITLE
Fix: DockerMonitor now uses the DefaultConfig method to initialize it…

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -121,7 +121,7 @@ func SubOptionMonitorDockerFlags(syncAtStart, killContainerOnPolicyError bool) f
 // OptionMonitorDocker provides a way to add a docker monitor and related configuration to be used with New().
 func OptionMonitorDocker(opts ...func(*dockermonitor.Config)) func(*monitor.Config) {
 
-	dc := &dockermonitor.Config{}
+	dc := dockermonitor.DefaultConfig()
 	// Collect all docker options
 	for _, opt := range opts {
 		opt(dc)


### PR DESCRIPTION
This PR makes sure that whenever the DockerMonitor is used as an option, it uses the correct method to create the defaultSet of Options.