### PR TITLE
New: Add defaultCollector and use it as default when using NewTrireme

### DIFF
--- a/collector/default.go
+++ b/collector/default.go
@@ -5,6 +5,11 @@ import "strconv"
 // DefaultCollector implements a default collector infrastructure to syslog
 type DefaultCollector struct{}
 
+// NewDefaultCollector returns a default implementation of an EventCollector
+func NewDefaultCollector() EventCollector {
+	return &DefaultCollector{}
+}
+
 // CollectFlowEvent is part of the EventCollector interface.
 func (d *DefaultCollector) CollectFlowEvent(record *FlowRecord) {}
 

--- a/trireme.go
+++ b/trireme.go
@@ -123,6 +123,7 @@ func New(serverID string, opts ...Option) Trireme {
 
 	c := &config{
 		serverID:               serverID,
+		collector:              collector.NewDefaultCollector(),
 		mode:                   constants.RemoteContainer,
 		fq:                     fqconfig.NewFilterQueueWithDefaults(),
 		mutualAuth:             true,


### PR DESCRIPTION
#### Description
This PR introduces a clean `func` to create a `DefaultCollector`

It also uses the DefaultCollector when using the `newTrireme` helper