### PR TITLE
Update syntoken and synServiceContext atomically

### DIFF
--- a/enforcer/datapath/tokenaccessor/tokenaccessor.go
+++ b/enforcer/datapath/tokenaccessor/tokenaccessor.go
@@ -100,7 +100,7 @@ func (t *tokenAccessor) CreateSynPacketToken(context *pucontext.PUContext, auth 
 
 	claims := &tokens.ConnectionClaims{
 		T:  context.Identity(),
-		EK: serviceContext,
+		EK: auth.LocalServiceContext,
 	}
 
 	if token, auth.LocalContext, err = t.getToken().CreateAndSign(false, claims); err != nil {

--- a/enforcer/datapath/tokenaccessor/tokenaccessor.go
+++ b/enforcer/datapath/tokenaccessor/tokenaccessor.go
@@ -92,7 +92,6 @@ func (t *tokenAccessor) CreateSynPacketToken(context *pucontext.PUContext, auth 
 		// Randomize the nonce and send it
 		auth.LocalContext, err = t.getToken().Randomize(token)
 		if err == nil {
-			//auth.LocalServiceContext = serviceContext
 			return token, nil
 		}
 		// If there is an error, let's try to create a new one

--- a/enforcer/pucontext/pucontext.go
+++ b/enforcer/pucontext/pucontext.go
@@ -181,25 +181,26 @@ func (p *PUContext) UpdateSynServiceContext(synServiceContext []byte) {
 }
 
 // GetCachedToken returns the cached syn packet token
-func (p *PUContext) GetCachedToken() ([]byte, error) {
+func (p *PUContext) GetCachedTokenAndServiceContext() ([]byte, []byte, error) {
 
 	p.RLock()
 	defer p.RUnlock()
 
 	if p.synExpiration.After(time.Now()) && len(p.synToken) > 0 {
-		return p.synToken, nil
+		return p.synToken, p.synServiceContext, nil
 	}
 
-	return nil, fmt.Errorf("eiixpired Token")
+	return nil, nil, fmt.Errorf("expired Token")
 }
 
 // UpdateCachedToken updates the local cached token
-func (p *PUContext) UpdateCachedToken(token []byte) {
+func (p *PUContext) UpdateCachedTokenAndServiceContext(token []byte, serviceContext []byte) {
 
 	p.Lock()
 
 	p.synToken = token
 	p.synExpiration = time.Now().Add(time.Millisecond * 500)
+	p.synServiceContext = serviceContext
 
 	p.Unlock()
 

--- a/enforcer/pucontext/pucontext.go
+++ b/enforcer/pucontext/pucontext.go
@@ -180,7 +180,7 @@ func (p *PUContext) UpdateSynServiceContext(synServiceContext []byte) {
 	p.Unlock()
 }
 
-// GetCachedToken returns the cached syn packet token
+// GetCachedTokenAndServiceContext returns the cached syn packet token
 func (p *PUContext) GetCachedTokenAndServiceContext() ([]byte, []byte, error) {
 
 	p.RLock()
@@ -193,7 +193,7 @@ func (p *PUContext) GetCachedTokenAndServiceContext() ([]byte, []byte, error) {
 	return nil, nil, fmt.Errorf("expired Token")
 }
 
-// UpdateCachedToken updates the local cached token
+// UpdateCachedTokenAndServiceContext updates the local cached token
 func (p *PUContext) UpdateCachedTokenAndServiceContext(token []byte, serviceContext []byte) {
 
 	p.Lock()


### PR DESCRIPTION
#### Description
*Currently syntoken and synServiceContext were not updated atomically during creation of token, resulting in races, resulting in incorrect encryption. 

#### Test plan
*Outline the test plan used to test this change before merging it.*

> Fixes #.
