### PR TITLE
Fixes for upgrade

### DIFF
--- a/internal/monitor/instance/cni/monitor.go
+++ b/internal/monitor/instance/cni/monitor.go
@@ -98,7 +98,7 @@ func (c *cniMonitor) SetupConfig(registerer registerer.Registerer, cfg interface
 	cniConfig = SetupDefaultConfig(cniConfig)
 
 	// Setup configuration
-	c.proc.contextStore = contextstore.NewFileContextStore(cniConfig.ContextStorePath)
+	c.proc.contextStore = contextstore.NewFileContextStore(cniConfig.ContextStorePath, nil)
 	if c.proc.contextStore == nil {
 		return fmt.Errorf("Unable to create new context store")
 	}

--- a/internal/monitor/instance/docker/monitor.go
+++ b/internal/monitor/instance/docker/monitor.go
@@ -271,7 +271,7 @@ func (d *dockerMonitor) SetupConfig(registerer registerer.Registerer, cfg interf
 	d.eventnotifications = make([]chan *events.Message, d.numberOfQueues)
 	d.stopprocessor = make([]chan bool, d.numberOfQueues)
 	d.NoProxyMode = dockerConfig.NoProxyMode
-	d.cstore = contextstore.NewFileContextStore(cstorePath)
+	d.cstore = contextstore.NewFileContextStore(cstorePath, nil)
 	for i := 0; i < d.numberOfQueues; i++ {
 		d.eventnotifications[i] = make(chan *events.Message, 1000)
 		d.stopprocessor[i] = make(chan bool)

--- a/internal/monitor/instance/linux/monitor.go
+++ b/internal/monitor/instance/linux/monitor.go
@@ -120,7 +120,7 @@ func (l *linuxMonitor) SetupConfig(registerer registerer.Registerer, cfg interfa
 	// Setup config
 	l.proc.host = linuxConfig.Host
 	l.proc.netcls = cgnetcls.NewCgroupNetController(linuxConfig.ReleasePath)
-	l.proc.contextStore = contextstore.NewFileContextStore(linuxConfig.StoredPath)
+	l.proc.contextStore = contextstore.NewFileContextStore(linuxConfig.StoredPath, l.proc.RemapData)
 	l.proc.storePath = linuxConfig.StoredPath
 
 	l.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_].{0,11}$")

--- a/internal/monitor/instance/uid/monitor.go
+++ b/internal/monitor/instance/uid/monitor.go
@@ -108,7 +108,7 @@ func (u *uidMonitor) SetupConfig(registerer registerer.Registerer, cfg interface
 
 	// Setup config
 	u.proc.netcls = cgnetcls.NewCgroupNetController(uidConfig.ReleasePath)
-	u.proc.contextStore = contextstore.NewFileContextStore(uidConfig.StoredPath)
+	u.proc.contextStore = contextstore.NewFileContextStore(uidConfig.StoredPath, u.proc.RemapData)
 	u.proc.storePath = uidConfig.StoredPath
 	u.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_].{0,11}$")
 	u.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_].{0,11}$")

--- a/policy/types.go
+++ b/policy/types.go
@@ -301,7 +301,10 @@ type Service struct {
 	Protocol uint8
 
 	// Ports are the corresponding ports
-	Ports *portspec.PortSpec
+	Ports *portspec.PortSpec `json:"Ports,omitempty"`
+
+	//Port is the service port. This has been deprecated and will be removed in later releases 01/13/2018
+	Port uint16
 }
 
 // ConvertServicesToPortList converts an array of services to a port list

--- a/utils/contextstore/contextstore_test.go
+++ b/utils/contextstore/contextstore_test.go
@@ -23,7 +23,7 @@ func cleanupstore(storebasePath string) {
 }
 
 func TestStore(t *testing.T) {
-	cstore := NewFileContextStore("./base")
+	cstore := NewFileContextStore("./base", nil)
 	defer cleanupstore("./base")
 
 	testdata := &testdatastruct{Data: 10}
@@ -45,7 +45,7 @@ func TestStore(t *testing.T) {
 
 func TestDestroyStore(t *testing.T) {
 
-	cstore := NewFileContextStore(storebasePath)
+	cstore := NewFileContextStore(storebasePath, nil)
 	defer cleanupstore("./base")
 
 	os.RemoveAll(storebasePath) //nolint
@@ -55,7 +55,7 @@ func TestDestroyStore(t *testing.T) {
 	}
 
 	//Reinit store
-	cstore = NewFileContextStore(storebasePath)
+	cstore = NewFileContextStore(storebasePath, nil)
 	testdata := &testdatastruct{Data: 10}
 	if err := cstore.Store(testcontextID, testdata); err != nil {
 		t.Errorf("Failed to store context %s", err.Error())
@@ -69,7 +69,7 @@ func TestDestroyStore(t *testing.T) {
 
 func TestRetrieve(t *testing.T) {
 
-	cstore := NewFileContextStore(storebasePath)
+	cstore := NewFileContextStore(storebasePath, nil)
 	defer cleanupstore("./base")
 
 	context := testdatastruct{}
@@ -98,7 +98,7 @@ func TestRetrieve(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 
-	cstore := NewFileContextStore(storebasePath)
+	cstore := NewFileContextStore(storebasePath, nil)
 	defer cleanupstore("./base")
 
 	err := cstore.Remove(testcontextID)
@@ -124,7 +124,7 @@ func TestRemove(t *testing.T) {
 
 func TestWalk(t *testing.T) {
 
-	cstore := NewFileContextStore(storebasePath)
+	cstore := NewFileContextStore(storebasePath, nil)
 	defer cleanupstore("./base")
 	testdata := &testdatastruct{Data: 10}
 	contextIDList := []string{"/test1", "/test2", "/test3"}

--- a/utils/portspec/portspec.go
+++ b/utils/portspec/portspec.go
@@ -11,9 +11,9 @@ import (
 
 // PortSpec is the specification of a port or port range
 type PortSpec struct {
-	Min   uint16
-	Max   uint16
-	value interface{}
+	Min   uint16      `json:"Min,omitempty"`
+	Max   uint16      `json:"Max,omitempty"`
+	value interface{} `json:"value,omitempty"`
 }
 
 // NewPortSpec creates a new port spec


### PR DESCRIPTION
#### Description
*Changes proposed in this pull request.*
The PR introduces a ondataerror function on ContextStore init. 
This is called during Retrieve which will call this function in case it encounters a data store format it does not understand. 
The Remap function will convert the code to the version the current version of trireme can handle. 

The code is intended primarily used in the upgrade path allowing us to fix up the context store for each processor at startup indepently 
#### Test plan
*Outline the test plan used to test this change before merging it.*

> Fixes #.
