### PR TITLE
No fatal failure

### DIFF
--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -375,8 +375,11 @@ func (s *RemoteEnforcer) Enforce(req rpcwrapper.Request, resp *rpcwrapper.Respon
 		return errors.New("unable to instantiate pu info")
 	}
 	if s.enforcer == nil {
-		zap.L().Fatal("Enforcer not initialized")
+		resp.Status = "Enforcer not initialied - cannot enforce"
+		zap.L().Error(resp.Status)
+		return fmt.Errorf(resp.Status)
 	}
+
 	if err := s.enforcer.Enforce(payload.ContextID, puInfo); err != nil {
 		resp.Status = err.Error()
 		return err


### PR DESCRIPTION
Remote enforcers should not fail with fatal if they are not initialized yet. 


