### PR TITLE
Allow any name for host services

### DIFF
--- a/monitor/remoteapi/server/server.go
+++ b/monitor/remoteapi/server/server.go
@@ -221,12 +221,10 @@ func validateEvent(event *common.EventInfo) error {
 	if event.EventType == common.EventCreate || event.EventType == common.EventStart {
 		if event.HostService {
 			if event.NetworkOnlyTraffic {
-				if event.Name == "" || event.Name == "default" {
+				if event.Name == "" {
 					return fmt.Errorf("Service name must be provided and must not be default")
 				}
 				event.PUID = event.Name
-			} else {
-				event.PUID = "host"
 			}
 		} else {
 			if event.PUID == "" {

--- a/monitor/remoteapi/server/server_test.go
+++ b/monitor/remoteapi/server/server_test.go
@@ -224,7 +224,7 @@ func TestValidateEvent(t *testing.T) {
 			So(event.PUID, ShouldResemble, "mypu")
 		})
 
-		Convey("If I get a Create  with the HostService and no networktraffic only, I should get PUID of host", func() {
+		Convey("If I get a Create  with the HostService and no networktraffic only, I should get PUID with the same name", func() {
 			event := &common.EventInfo{
 				EventType:          common.EventCreate,
 				PID:                1,
@@ -235,7 +235,7 @@ func TestValidateEvent(t *testing.T) {
 
 			err := validateEvent(event)
 			So(err, ShouldBeNil)
-			So(event.PUID, ShouldResemble, "host")
+			So(event.PUID, ShouldResemble, "mypu")
 		})
 
 		Convey("If I get a Create  with the HostService and networktraffic only, I should get PUID as my name", func() {

--- a/monitor/remoteapi/server/server_test.go
+++ b/monitor/remoteapi/server/server_test.go
@@ -253,20 +253,6 @@ func TestValidateEvent(t *testing.T) {
 			So(event.PUID, ShouldResemble, "myservice")
 		})
 
-		Convey("If I get a Create  with the HostService and networktraffic only, and bad service name, I should get an error ", func() {
-			event := &common.EventInfo{
-				EventType:          common.EventCreate,
-				PID:                1,
-				HostService:        true,
-				NetworkOnlyTraffic: true,
-				Name:               "default",
-				PUID:               "mypu",
-			}
-
-			err := validateEvent(event)
-			So(err, ShouldNotBeNil)
-		})
-
 		Convey("If I get a Stop event and cgroup is in the right format, it should return nil.", func() {
 			event := &common.EventInfo{
 				EventType: common.EventStop,


### PR DESCRIPTION
#### Description
API was changing the name of the host service without a reason. 
