### PR TITLE
Fix seg fault in UpdateProxySets

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/ipsets.go
+++ b/controller/internal/supervisor/iptablesctrl/ipsets.go
@@ -98,7 +98,7 @@ func (i *Instance) updateProxySet(services *policy.ProxiedServicesInfo, portSetN
 	}
 
 	for _, net := range services.PublicIPPortPair {
-		if err := i.vipTargetSet.Add(net, 0); err != nil {
+		if err := vipTargetSet.Add(net, 0); err != nil {
 			zap.L().Error("Failed to add vip", zap.Error(err))
 			return fmt.Errorf("unable to add ip %s to target networks ipset: %s", net, err)
 		}
@@ -112,7 +112,7 @@ func (i *Instance) updateProxySet(services *policy.ProxiedServicesInfo, portSetN
 	}
 
 	for _, net := range services.PrivateIPPortPair {
-		if err := i.pipTargetSet.Add(net, 0); err != nil {
+		if err := pipTargetSet.Add(net, 0); err != nil {
 			zap.L().Error("Failed to add vip", zap.Error(err))
 			return fmt.Errorf("unable to add ip %s to target networks ipset: %s", net, err)
 		}

--- a/controller/internal/supervisor/iptablesctrl/iptables.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables.go
@@ -46,8 +46,6 @@ type Instance struct {
 	fqc                     *fqconfig.FilterQueue
 	ipt                     provider.IptablesProvider
 	ipset                   provider.IpsetProvider
-	vipTargetSet            provider.Ipset
-	pipTargetSet            provider.Ipset
 	targetSet               provider.Ipset
 	appPacketIPTableContext string
 	appProxyIPTableContext  string


### PR DESCRIPTION
handle to proxy ipset can be derived from the name of proxy ipset. No need for separate fields in the instance structure.

