### PR TITLE
Expose certificates to applications

### DIFF
--- a/common/service.go
+++ b/common/service.go
@@ -21,7 +21,7 @@ type Service struct {
 	Addresses []*net.IPNet `json:"addresses,omitempty"`
 
 	// FQDNs is the list of FQDNs for the service.
-	FQDNs []string
+	FQDNs []string `json:"fqdns,omitempty"`
 }
 
 // ConvertServicesToPortList converts an array of services to a port list

--- a/common/service.go
+++ b/common/service.go
@@ -19,6 +19,9 @@ type Service struct {
 
 	// Addresses are the IP addresses. An empty list means 0.0.0.0
 	Addresses []*net.IPNet `json:"addresses,omitempty"`
+
+	// FQDNs is the list of FQDNs for the service.
+	FQDNs []string
 }
 
 // ConvertServicesToPortList converts an array of services to a port list

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -161,7 +161,7 @@ func (p *AppProxy) Enforce(ctx context.Context, puID string, puInfo *policy.PUIn
 		}
 	}
 
-	if updated, err := p.processCertificateUpdates(puInfo, client); err != nil || !updated {
+	if _, err := p.processCertificateUpdates(puInfo, client); err != nil {
 		return fmt.Errorf("Certificates not updated:  %s ", err)
 	}
 

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -32,7 +32,7 @@ const (
 // ServerInterface describes the methods required by an application processor.
 type ServerInterface interface {
 	RunNetworkServer(ctx context.Context, l net.Listener, encrypted bool) error
-	UpdateSecrets(cert *tls.Certificate, ca *x509.CertPool, secrets secrets.Secrets)
+	UpdateSecrets(cert *tls.Certificate, ca *x509.CertPool, secrets secrets.Secrets, certPEM, keyPEM string)
 	ShutDown() error
 }
 
@@ -98,35 +98,17 @@ func (p *AppProxy) Enforce(ctx context.Context, puID string, puInfo *policy.PUIn
 	p.Lock()
 	defer p.Unlock()
 
-	apicache, jwtcache := buildCaches(puInfo.Policy.ExposedServices())
+	// First update the caches with the new policy information.
+	apicache, dependentCache, jwtcache := buildCaches(puInfo.Policy.ExposedServices(), puInfo.Policy.DependentServices())
 	p.exposedAPICache.AddOrUpdate(puID, apicache)
 	p.jwtcache.AddOrUpdate(puID, jwtcache)
+	p.dependentAPICache.AddOrUpdate(puID, dependentCache)
 
-	certPEM, keyPEM, caPEM := puInfo.Policy.ServiceCertificates()
-	if certPEM == "" || keyPEM == "" {
-		return nil
-	}
-
-	var caPool *x509.CertPool
-	if caPEM != "" {
-		caPool = cryptohelpers.LoadRootCertificates([]byte(caPEM))
-	} else {
-		caPool = p.systemCAPool
-	}
-
-	tlsCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
-	if err != nil {
-		return fmt.Errorf("Failed to update certificates during enforcement: %s", err)
-	}
-
-	// For updates we need to update the policy and certificates.
+	// For updates we need to update the certificates if we have new ones. Otherwise
+	// we return. There is nothing else to do in case of policy update.
 	if c, cerr := p.clients.Get(puID); cerr == nil {
-		// Update all the certificates from the new policy.
-		client := c.(*clientData)
-		for _, server := range client.netserver {
-			server.UpdateSecrets(&tlsCert, caPool, p.secrets)
-		}
-		return nil
+		_, perr := p.processCertificateUpdates(puInfo, c.(*clientData))
+		return perr
 	}
 
 	// Create the network listener and cache it so that we can terminate it later.
@@ -179,8 +161,8 @@ func (p *AppProxy) Enforce(ctx context.Context, puID string, puInfo *policy.PUIn
 		}
 	}
 
-	for _, server := range client.netserver {
-		server.UpdateSecrets(&tlsCert, caPool, p.secrets)
+	if updated, err := p.processCertificateUpdates(puInfo, client); err != nil || !updated {
+		return fmt.Errorf("Certificates not updated:  %s ", err)
 	}
 
 	// Add the client to the cache
@@ -200,6 +182,10 @@ func (p *AppProxy) Unenforce(ctx context.Context, puID string) error {
 
 	if err := p.exposedAPICache.Remove(puID); err != nil {
 		zap.L().Warn("Cannot find PU in the API cache")
+	}
+
+	if err := p.dependentAPICache.Remove(puID); err != nil {
+		zap.L().Warn("Cannot find PU in the Dependent API cache")
 	}
 
 	if err := p.jwtcache.Remove(puID); err != nil {
@@ -288,6 +274,37 @@ func (p *AppProxy) createNetworkListener(port string) (net.Listener, error) {
 	return net.ListenTCP("tcp", addr)
 }
 
+// processCertificateUpdates processes the certificate information and updates
+// the servers.
+func (p *AppProxy) processCertificateUpdates(puInfo *policy.PUInfo, client *clientData) (bool, error) {
+
+	// If there are certificates provided, we will need to update them for the
+	// services. If the certificates are nil, we ignore them.
+	certPEM, keyPEM, caPEM := puInfo.Policy.ServiceCertificates()
+	if certPEM == "" || keyPEM == "" {
+		return false, nil
+	}
+
+	// Process any updates on the cert pool
+	var caPool *x509.CertPool
+	if caPEM != "" {
+		caPool = cryptohelpers.LoadRootCertificates([]byte(caPEM))
+	} else {
+		caPool = p.systemCAPool
+	}
+
+	// Create the TLS certificate
+	tlsCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		return false, fmt.Errorf("Invalid certificates: %s", err)
+	}
+
+	for _, server := range client.netserver {
+		server.UpdateSecrets(&tlsCert, caPool, p.secrets, certPEM, keyPEM)
+	}
+	return true, nil
+}
+
 func serviceTypeToNetworkListenerType(serviceType policy.ServiceType) protomux.ListenerType {
 	switch serviceType {
 	case policy.ServiceHTTP:
@@ -306,9 +323,10 @@ func serviceTypeToApplicationListenerType(serviceType policy.ServiceType) protom
 	}
 }
 
-func buildCaches(services policy.ApplicationServicesList) (map[string]*urisearch.APICache, map[string]*x509.Certificate) {
+func buildCaches(services, dependentServices policy.ApplicationServicesList) (map[string]*urisearch.APICache, map[string]*urisearch.APICache, map[string]*x509.Certificate) {
 	apicache := map[string]*urisearch.APICache{}
 	jwtcache := map[string]*x509.Certificate{}
+	dependentCache := map[string]*urisearch.APICache{}
 
 	for _, service := range services {
 		if service.Type != policy.ServiceHTTP {
@@ -324,5 +342,15 @@ func buildCaches(services policy.ApplicationServicesList) (map[string]*urisearch
 		jwtcache[service.NetworkInfo.Ports.String()] = cert
 	}
 
-	return apicache, jwtcache
+	for _, service := range dependentServices {
+		uricache := urisearch.NewAPICache(service.HTTPRules)
+		for _, fqdn := range service.NetworkInfo.FQDNs {
+			if _, ok := dependentCache[fqdn]; ok {
+				continue
+			}
+			dependentCache[fqdn] = uricache
+		}
+	}
+
+	return apicache, dependentCache, jwtcache
 }

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -405,9 +405,13 @@ func (p *Config) isSecretsRequest(w http.ResponseWriter, r *http.Request) bool {
 
 	switch r.RequestURI {
 	case "/certificate":
-		w.Write([]byte(p.certPEM))
+		if _, err := w.Write([]byte(p.certPEM)); err != nil {
+			zap.L().Error("Unable to write response")
+		}
 	case "/key":
-		w.Write([]byte(p.keyPEM))
+		if _, err := w.Write([]byte(p.keyPEM)); err != nil {
+			zap.L().Error("Unable to write response")
+		}
 	default:
 		http.Error(w, fmt.Sprintf("Uknown"), http.StatusBadRequest)
 	}

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -38,6 +38,8 @@ type JWTClaims struct {
 type Config struct {
 	cert              *tls.Certificate
 	ca                *x509.CertPool
+	keyPEM            string
+	certPEM           string
 	secrets           secrets.Secrets
 	tokenaccessor     tokenaccessor.TokenAccessor
 	collector         collector.EventCollector
@@ -180,13 +182,15 @@ func (p *Config) ShutDown() error {
 }
 
 // UpdateSecrets updates the secrets
-func (p *Config) UpdateSecrets(cert *tls.Certificate, caPool *x509.CertPool, s secrets.Secrets) {
+func (p *Config) UpdateSecrets(cert *tls.Certificate, caPool *x509.CertPool, s secrets.Secrets, certPEM, keyPEM string) {
 	p.Lock()
 	defer p.Unlock()
 
 	p.cert = cert
 	p.ca = caPool
 	p.secrets = s
+	p.certPEM = certPEM
+	p.keyPEM = keyPEM
 }
 
 // GetCertificateFunc implements the TLS interface for getting the certificate. This
@@ -214,6 +218,10 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 	token, err := p.createClientToken(puContext)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Cannot handle request: %s", err), http.StatusForbidden)
+		return
+	}
+
+	if p.isSecretsRequest(w, r) {
 		return
 	}
 
@@ -364,6 +372,47 @@ func (p *Config) parseClientToken(puContext *pucontext.PUContext, token string, 
 	}
 
 	return fmt.Errorf("Not found")
+}
+
+func (p *Config) isSecretsRequest(w http.ResponseWriter, r *http.Request) bool {
+
+	data, err := p.dependentAPICache.Get(p.puContext)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Cannot handle request - unknown dependencies: %s", err), http.StatusForbidden)
+		return false
+	}
+
+	port := "80"
+	host := r.Host
+	if strings.Contains(r.Host, ":") {
+		host, port, err = net.SplitHostPort(r.Host)
+		if err != nil {
+			zap.L().Error("Invalid HTTP port parameter", zap.Error(err))
+			http.Error(w, fmt.Sprintf("Invalid HTTP port parameter: %s", err), http.StatusUnprocessableEntity)
+			return false
+		}
+	}
+
+	apiCache, ok := data.(map[string]*urisearch.APICache)[host+":"+port]
+	if !ok {
+		return false
+	}
+
+	// Look for a local request for certificates
+	if found, _ := apiCache.Find(r.Method, r.RequestURI); !found {
+		return false
+	}
+
+	switch r.RequestURI {
+	case "/certificate":
+		w.Write([]byte(p.certPEM))
+	case "/key":
+		w.Write([]byte(p.keyPEM))
+	default:
+		http.Error(w, fmt.Sprintf("Uknown"), http.StatusBadRequest)
+	}
+
+	return true
 }
 
 func getServerName(addr string) string {

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -92,7 +92,7 @@ func (p *Proxy) RunNetworkServer(ctx context.Context, listener net.Listener, enc
 }
 
 // UpdateSecrets updates the secrets of the connections.
-func (p *Proxy) UpdateSecrets(cert *tls.Certificate, caPool *x509.CertPool, s secrets.Secrets) {
+func (p *Proxy) UpdateSecrets(cert *tls.Certificate, caPool *x509.CertPool, s secrets.Secrets, certPEM, keyPEM string) {
 	p.Lock()
 	defer p.Unlock()
 


### PR DESCRIPTION
#### Description
Exposes the certificates that are known to Trireme to user space applications. Allows them to define an API endpoint (like 169.254.254.1) that is only local in the container or cgroup of the service and retrieve their certificates. 