### PR TITLE
New: Use GoPkg.toml in Trireme-Lib

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,4 +1,4 @@
-[[override]]
+[[constraint]]
   name = "github.com/bvandewalle/go-ipset"
   revision = "0ee897a6d8bc6095299e9c03293ece091ef871de"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,11 @@
+[[override]]
+  name = "github.com/bvandewalle/go-ipset"
+  revision = "0ee897a6d8bc6095299e9c03293ece091ef871de"
+
+[[constraint]]
+  name = "github.com/aporeto-inc/netlink-go"
+  branch = "context"
+
+[[constraint]]
+  name = "github.com/aporeto-inc/tg"
+  version = "2.x"


### PR DESCRIPTION
This PR introduces a Gopkg.toml for Trireme-lib, listing the minimum required dependencies for Trireme-lib.

Discussion on dep for libaries: https://github.com/golang/dep/issues/208