### PR TITLE
Fix: Error propagation in the remote and Correct PSKType for PSK secrets

### DIFF
--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -66,7 +66,8 @@ func NewAppProxy(tp tokenaccessor.TokenAccessor, c collector.EventCollector, puF
 		return nil, err
 	}
 
-	if ok := systemPool.AppendCertsFromPEM(s.PublicSecrets().CertAuthority()); !ok {
+	// We append the CA only if we are not in PSK mode as it doesn't provide a CA.
+	if ok := systemPool.AppendCertsFromPEM(s.PublicSecrets().CertAuthority()); !ok && (s.PublicSecrets().SecretsType() != secrets.PSKType) {
 		return nil, fmt.Errorf("Cannot append ca chain")
 	}
 

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -67,8 +67,10 @@ func NewAppProxy(tp tokenaccessor.TokenAccessor, c collector.EventCollector, puF
 	}
 
 	// We append the CA only if we are not in PSK mode as it doesn't provide a CA.
-	if ok := systemPool.AppendCertsFromPEM(s.PublicSecrets().CertAuthority()); !ok && (s.PublicSecrets().SecretsType() != secrets.PSKType) {
-		return nil, fmt.Errorf("Cannot append ca chain")
+	if s.PublicSecrets().SecretsType() != secrets.PSKType {
+		if ok := systemPool.AppendCertsFromPEM(s.PublicSecrets().CertAuthority()); !ok {
+			return nil, fmt.Errorf("error while adding provided CA")
+		}
 	}
 
 	return &AppProxy{

--- a/controller/internal/enforcer/proxy/enforcerproxy.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy.go
@@ -69,7 +69,7 @@ func (s *ProxyInfo) InitRemoteEnforcer(contextID string) error {
 	}
 
 	if resp.Status != "" {
-		return fmt.Errorf("failed to initialize remote enforcer: status: %s", resp.Status)
+		zap.L().Warn("received status while initializing the remote enforcer", zap.String("contextID", resp.Status))
 	}
 
 	s.Lock()

--- a/controller/internal/enforcer/proxy/enforcerproxy.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy.go
@@ -68,6 +68,10 @@ func (s *ProxyInfo) InitRemoteEnforcer(contextID string) error {
 		return fmt.Errorf("failed to initialize remote enforcer: status: %s: %s", resp.Status, err)
 	}
 
+	if resp.Status != "" {
+		return fmt.Errorf("failed to initialize remote enforcer: status: %s", resp.Status)
+	}
+
 	s.Lock()
 	s.initDone[contextID] = true
 	s.Unlock()

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -146,6 +146,9 @@ func (s *RemoteEnforcer) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.R
 			zap.Error(err),
 		)
 		resp.Status = fmt.Sprintf("Remote enforcer failed: unable to identify namespace: %s", err)
+		// TODO: resp.Status get overwritten at the end of this func. This is the only place where we don't return the status as error
+		// Could we get rid of status and just always return an error ?
+		//
 		// Dont return error to close RPC channel
 	}
 
@@ -156,6 +159,9 @@ func (s *RemoteEnforcer) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.R
 			zap.String("nsLogs", nsEnterLogMsg),
 		)
 		resp.Status = "not running in a namespace"
+		// TODO: resp.Status get overwritten at the end of this func. This is the only place where we don't return the status as error
+		// Could we get rid of status and just always return an error ?
+		//
 		// Dont return error to close RPC channel
 	}
 

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -115,7 +115,7 @@ func (s *RemoteEnforcer) setupEnforcer(req rpcwrapper.Request) error {
 		payload.ExternalIPCacheTimeout,
 		payload.PacketLogs,
 	); err != nil || s.enforcer == nil {
-		return errors.New("unable to setup enforcer: we don't know as this function does not return an error")
+		return fmt.Errorf("Error while initializing remote enforcer, %s", err)
 	}
 
 	return nil

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -89,6 +89,7 @@ func getCEnvVariable(name string) string {
 
 // setup an enforcer
 func (s *RemoteEnforcer) setupEnforcer(req rpcwrapper.Request) error {
+	var err error
 
 	if s.enforcer != nil {
 		return nil

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -178,12 +178,12 @@ func (s *RemoteEnforcer) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.R
 
 	if err := s.enforcer.Run(s.ctx); err != nil {
 		resp.Status = err.Error()
-		return nil
+		return fmt.Errorf(resp.Status)
 	}
 
 	if err := s.statsClient.Run(s.ctx); err != nil {
 		resp.Status = err.Error()
-		return nil
+		return fmt.Errorf(resp.Status)
 	}
 
 	resp.Status = ""

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -88,7 +88,7 @@ func getCEnvVariable(name string) string {
 }
 
 // setup an enforcer
-func (s *RemoteEnforcer) setupEnforcer(req rpcwrapper.Request) (err error) {
+func (s *RemoteEnforcer) setupEnforcer(req rpcwrapper.Request) error {
 
 	if s.enforcer != nil {
 		return nil

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -263,7 +263,7 @@ func (s *RemoteEnforcer) Supervise(req rpcwrapper.Request, resp *rpcwrapper.Resp
 
 	err := s.supervisor.Supervise(payload.ContextID, puInfo)
 	if err != nil {
-		zap.L().Error("Unable to initialize supervisor",
+		zap.L().Error("unable to initialize supervisor",
 			zap.String("ContextID", payload.ContextID),
 			zap.Error(err),
 		)
@@ -324,7 +324,7 @@ func (s *RemoteEnforcer) Enforce(req rpcwrapper.Request, resp *rpcwrapper.Respon
 	}
 
 	if s.enforcer == nil {
-		resp.Status = "Enforcer not initialied - cannot enforce"
+		resp.Status = "enforcer not initialized - cannot enforce"
 		zap.L().Error(resp.Status)
 		return fmt.Errorf(resp.Status)
 	}

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -173,7 +173,7 @@ func (s *RemoteEnforcer) InitEnforcer(req rpcwrapper.Request, resp *rpcwrapper.R
 
 	if err := s.setupEnforcer(req); err != nil {
 		resp.Status = err.Error()
-		return nil
+		return fmt.Errorf(resp.Status)
 	}
 
 	if err := s.enforcer.Run(s.ctx); err != nil {

--- a/controller/pkg/secrets/psksecrets.go
+++ b/controller/pkg/secrets/psksecrets.go
@@ -63,7 +63,7 @@ func (p *PSKSecrets) EncodingPEM() []byte {
 // PublicSecrets returns the secrets that are marshallable over the RPC interface.
 func (p *PSKSecrets) PublicSecrets() PublicSecrets {
 	return &PSKPublicSecrets{
-		Type:      PKIType,
+		Type:      PSKType,
 		SharedKey: p.SharedKey,
 	}
 }


### PR DESCRIPTION
This PR corrects:

1) Correct error propagation for the remote enforcer (took me 2 hours of debug to see that error)
2) the PSK Secret type to correctly identify itself