### PR TITLE
Delay the start of listeners until after resync

### DIFF
--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -129,7 +129,8 @@ func (d *DockerMonitor) Run(ctx context.Context) error {
 
 		// Starting the eventListener and wait to hear on channel for it to be ready.
 		// Need to start before the resync process so that we don't loose any events.
-		// They will be buffered.
+		// They will be buffered. We don't want to start the listener before
+		// getting the list from docker though, to avoid duplicates.
 		listenerReady := make(chan struct{})
 		go d.eventListener(ctx, listenerReady)
 		<-listenerReady

--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -117,7 +117,8 @@ func (d *DockerMonitor) Run(ctx context.Context) error {
 
 	err := d.waitForDockerDaemon(ctx)
 	if err != nil {
-		return fmt.Errorf("Unable to connect to docker-abourt: %s", err)
+		zap.L().Error("Docker daemon is not running - skipping container processing", zap.Error(err))
+		return nil
 	}
 
 	if d.syncAtStart && d.config.Policy != nil {


### PR DESCRIPTION
#### Description
Delay the start of the monitor events until after resync is complete to avoid starting issues.
