### PR TITLE
Fixed: Grab read lock when iterating

### DIFF
--- a/controller/internal/enforcer/applicationproxy/protomux/protomux.go
+++ b/controller/internal/enforcer/applicationproxy/protomux/protomux.go
@@ -174,6 +174,9 @@ func (m *MultiplexedListener) Serve(ctx context.Context) error {
 		close(m.done)
 		m.wg.Wait()
 
+		m.RLock()
+		defer m.RUnlock()
+
 		for _, l := range m.protomap {
 			close(l.connection)
 			// Drain the connections enqueued for the listener.


### PR DESCRIPTION
#### Description
Fixes the following panic:
```
fatal error: concurrent map iteration and map write

goroutine 202623 [running]:
runtime.throw(0x5635d4617539, 0x26)
	/usr/lib/go/src/runtime/panic.go:605 +0x97 fp=0xc425458500 sp=0xc4254584e0 pc=0x5635d3e678a7
runtime.mapiternext(0xc425458638)
	/usr/lib/go/src/runtime/hashmap.go:778 +0x6f3 fp=0xc425458598 sp=0xc425458500 pc=0x5635d3e456b3
runtime.mapiterinit(0x5635d4b155e0, 0xc42166c330, 0xc425458638)
	/usr/lib/go/src/runtime/hashmap.go:768 +0x276 fp=0xc425458600 sp=0xc425458598 pc=0x5635d3e44d66
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme-lib/controller/internal/enforcer/applicationproxy/protomux.(*MultiplexedListener).Serve.func1(0xc423cde380)
	/tmp/build/28865ff1/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme-lib/controller/internal/enforcer/applicationproxy/protomux/protomux.go:177 +0xad fp=0xc4254586a8 sp=0xc425458600 pc=0x5635d419271d
github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme-lib/controller/internal/enforcer/applicationproxy/protomux.(*MultiplexedListener).Serve(0xc423cde380, 0x5635d50b2b00, 0xc420018018, 0x5635d50a8f00, 0xc423b214a0)
	/tmp/build/28865ff1/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme-lib/controller/internal/enforcer/applicationproxy/protomux/protomux.go:195 +0x22d fp=0xc4254587b8 sp=0xc4254586a8 pc=0x5635d41921fd
runtime.goexit()
	/usr/lib/go/src/runtime/asm_amd64.s:2337 +0x1 fp=0xc4254587c0 sp=0xc4254587b8 pc=0x5635d3e99231
created by github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme-lib/controller/internal/enforcer/applicationproxy.(*AppProxy).Enforce
	/tmp/build/28865ff1/go/src/github.com/aporeto-inc/enforcerd/vendor/github.com/aporeto-inc/trireme-lib/controller/internal/enforcer/applicationproxy/applicationproxy.go:166 +0x11f9
```
All other access to `protomap` is protected by the same lock from the sweep I did.