### PR TITLE
Kubernetes monitor

### DIFF
--- a/common/events.go
+++ b/common/events.go
@@ -81,6 +81,7 @@ type Event string
 const (
 	EventStart   Event = "start"
 	EventStop    Event = "stop"
+	EventUpdate  Event = "update"
 	EventCreate  Event = "create"
 	EventDestroy Event = "destroy"
 	EventPause   Event = "pause"
@@ -93,6 +94,7 @@ var (
 	EventMap = map[Event]*struct{}{
 		"start":   nil,
 		"stop":    nil,
+		"update":  nil,
 		"create":  nil,
 		"destroy": nil,
 		"pause":   nil,

--- a/monitor/config/config.go
+++ b/monitor/config/config.go
@@ -18,6 +18,7 @@ const (
 	LinuxProcess
 	LinuxHost
 	UID
+	Kubernetes
 )
 
 // MonitorConfig specifies the configs for monitors.

--- a/monitor/extractors/kubernetes.go
+++ b/monitor/extractors/kubernetes.go
@@ -108,6 +108,8 @@ func MergingKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.P
 		tags.AppendKeyValue(key, value)
 	}
 
+	originalRuntime.SetTags(tags)
+
 	zap.L().Debug("Merging runtime tags", zap.String("name", pod.GetName()), zap.String("namespace", pod.GetNamespace()), zap.Strings("tags", tags.GetSlice()))
 
 	return originalRuntime, true, nil

--- a/monitor/extractors/kubernetes.go
+++ b/monitor/extractors/kubernetes.go
@@ -77,7 +77,8 @@ func DefaultKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.P
 }
 
 // MergingKubernetesMetadataExtractor is a simple implementation of a Kubernetes Metadata extractor that merges all the tags coming
-// From both the docker and pods sources. It also activate all containers part of all Kubernetes pods (not only the infra)
+// From both the docker and pods sources. It also activate all containers part of all Kubernetes pods (not only the infra), effectively returning
+// true for every container.
 func MergingKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.Pod) (*policy.PURuntime, bool, error) {
 
 	if runtime == nil {

--- a/monitor/extractors/kubernetes.go
+++ b/monitor/extractors/kubernetes.go
@@ -1,9 +1,30 @@
 package extractors
 
 import (
+	"fmt"
+
 	"github.com/aporeto-inc/trireme-lib/policy"
+	"go.uber.org/zap"
 	api "k8s.io/api/core/v1"
 )
+
+// KubernetesPodNameIdentifier is the label used by Docker for the K8S pod name.
+const KubernetesPodNameIdentifier = "@usr:io.kubernetes.pod.name"
+
+// KubernetesPodNamespaceIdentifier is the label used by Docker for the K8S namespace.
+const KubernetesPodNamespaceIdentifier = "@usr:io.kubernetes.pod.namespace"
+
+// KubernetesContainerNameIdentifier is the label used by Docker for the K8S container name.
+const KubernetesContainerNameIdentifier = "@usr:io.kubernetes.container.name"
+
+// KubernetesInfraContainerName is the name of the infra POD.
+const KubernetesInfraContainerName = "POD"
+
+// UpstreamNameIdentifier is the identifier used to identify the nane on the resulting PU
+const UpstreamNameIdentifier = "k8s:name"
+
+// UpstreamNamespaceIdentifier is the identifier used to identify the nanespace on the resulting PU
+const UpstreamNamespaceIdentifier = "k8s:namespace"
 
 // KubernetesMetadataExtractorType is an extractor function for Kubernetes.
 // It takes as parameter a standard Docker runtime and a Pod Kubernetes definition and return a PolicyRuntime
@@ -11,6 +32,57 @@ import (
 type KubernetesMetadataExtractorType func(runtime policy.RuntimeReader, pod *api.Pod) (*policy.PURuntime, bool, error)
 
 // DefaultKubernetesMetadataExtractor is a default implementation for the medatadata extractor for Kubernetes
+// It only activates the POD//INFRA containers and strips all the labels from docker to only keep the ones from Kubernetes
 func DefaultKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.Pod) (*policy.PURuntime, bool, error) {
-	return nil, false, nil
+
+	if runtime == nil {
+		return nil, false, fmt.Errorf("empty runtime")
+	}
+
+	if pod == nil {
+		return nil, false, fmt.Errorf("empty pod")
+	}
+
+	// In this specific metadataExtractor we only want to activate the Infra Container for each pod.
+	process, err := isPodInfraContainer(runtime)
+	if err != nil {
+		return nil, false, fmt.Errorf("Error while processing Kubernetes pod %s", err)
+	}
+
+	if !process {
+		return nil, false, nil
+	}
+
+	podLabels := pod.GetLabels()
+	if podLabels == nil {
+		zap.L().Debug("couldn't get labels.")
+		return nil, false, nil
+	}
+
+	tags := policy.NewTagStoreFromMap(podLabels)
+	tags.AppendKeyValue(UpstreamNameIdentifier, pod.GetName())
+	tags.AppendKeyValue(UpstreamNamespaceIdentifier, pod.GetNamespace())
+
+	originalRuntime, ok := runtime.(*policy.PURuntime)
+	if !ok {
+		return nil, false, fmt.Errorf("Error casting puruntime")
+	}
+
+	newRuntime := originalRuntime.Clone()
+	newRuntime.SetTags(tags)
+
+	zap.L().Debug("kubernetes runtime tags", zap.String("name", pod.GetName()), zap.String("namespace", pod.GetNamespace()), zap.Strings("tags", newRuntime.Tags().GetSlice()))
+
+	return newRuntime, true, nil
+}
+
+// isPodInfraContainer returns true if the runtime represents the infra container for the POD
+func isPodInfraContainer(runtime policy.RuntimeReader) (bool, error) {
+	// The Infra container can be found by checking env. variable.
+	tagContent, ok := runtime.Tag(KubernetesContainerNameIdentifier)
+	if !ok || tagContent != KubernetesInfraContainerName {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/monitor/extractors/kubernetes.go
+++ b/monitor/extractors/kubernetes.go
@@ -76,6 +76,12 @@ func DefaultKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.P
 	return newRuntime, true, nil
 }
 
+// MergingKubernetesMetadataExtractor is a simple implementation of a Kubernetes Metadata extractor that merges all the tags coming
+// From both the docker and pods sources. It also activate all containers part of all Kubernetes pods (not only the infra)
+func MergingKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.Pod) (*policy.PURuntime, bool, error) {
+
+}
+
 // isPodInfraContainer returns true if the runtime represents the infra container for the POD
 func isPodInfraContainer(runtime policy.RuntimeReader) (bool, error) {
 	// The Infra container can be found by checking env. variable.

--- a/monitor/extractors/kubernetes.go
+++ b/monitor/extractors/kubernetes.go
@@ -1,0 +1,16 @@
+package extractors
+
+import (
+	"github.com/aporeto-inc/trireme-lib/policy"
+	api "k8s.io/api/core/v1"
+)
+
+// KubernetesMetadataExtractorType is an extractor function for Kubernetes.
+// It takes as parameter a standard Docker runtime and a Pod Kubernetes definition and return a PolicyRuntime
+// This extractor also provides an extra boolean parameter that is used as a token to decide if activation is required.
+type KubernetesMetadataExtractorType func(runtime policy.RuntimeReader, pod *api.Pod) (*policy.PURuntime, bool, error)
+
+// DefaultKubernetesMetadataExtractor is a default implementation for the medatadata extractor for Kubernetes
+func DefaultKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.Pod) (*policy.PURuntime, bool, error) {
+	return nil, false, nil
+}

--- a/monitor/extractors/kubernetes.go
+++ b/monitor/extractors/kubernetes.go
@@ -79,7 +79,7 @@ func DefaultKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.P
 // MergingKubernetesMetadataExtractor is a simple implementation of a Kubernetes Metadata extractor that merges all the tags coming
 // From both the docker and pods sources. It also activate all containers part of all Kubernetes pods (not only the infra)
 func MergingKubernetesMetadataExtractor(runtime policy.RuntimeReader, pod *api.Pod) (*policy.PURuntime, bool, error) {
-
+	return nil, false, nil
 }
 
 // isPodInfraContainer returns true if the runtime represents the infra container for the POD

--- a/monitor/extractors/kubernetes_test.go
+++ b/monitor/extractors/kubernetes_test.go
@@ -1,0 +1,96 @@
+package extractors
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aporeto-inc/trireme-lib/policy"
+	api "k8s.io/api/core/v1"
+)
+
+func TestDefaultKubernetesMetadataExtractor(t *testing.T) {
+
+	pod1 := &api.Pod{}
+	pod1.SetName("test")
+	pod1.SetNamespace("ns")
+	pod1.SetLabels(map[string]string{
+		"label": "one",
+	})
+
+	runtimeDocker := policy.NewPURuntimeWithDefaults()
+	tags := runtimeDocker.Tags()
+	tags.AppendKeyValue(KubernetesContainerNameIdentifier, "POD")
+	runtimeDocker.SetTags(tags)
+
+	runtimeResult := policy.NewPURuntimeWithDefaults()
+	tags = runtimeResult.Tags()
+	tags.AppendKeyValue("label", "one")
+	tags.AppendKeyValue(UpstreamNameIdentifier, "test")
+	tags.AppendKeyValue(UpstreamNamespaceIdentifier, "ns")
+
+	runtimeResult.SetTags(tags)
+
+	type args struct {
+		runtime policy.RuntimeReader
+		pod     *api.Pod
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *policy.PURuntime
+		want1   bool
+		wantErr bool
+	}{
+		{
+			name: "empty1",
+			args: args{
+				runtime: nil,
+				pod:     &api.Pod{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty2",
+			args: args{
+				runtime: policy.NewPURuntimeWithDefaults(),
+				pod:     nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Simple test, non Kubernetes Container",
+			args: args{
+				runtime: policy.NewPURuntimeWithDefaults(),
+				pod:     pod1,
+			},
+			want:    nil,
+			want1:   false,
+			wantErr: false,
+		},
+		{
+			name: "Simple test",
+			args: args{
+				runtime: runtimeDocker,
+				pod:     pod1,
+			},
+			want:    runtimeResult,
+			want1:   true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := DefaultKubernetesMetadataExtractor(tt.args.runtime, tt.args.pod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DefaultKubernetesMetadataExtractor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DefaultKubernetesMetadataExtractor() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("DefaultKubernetesMetadataExtractor() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/monitor/interfaces.go
+++ b/monitor/interfaces.go
@@ -35,6 +35,6 @@ type Implementation interface {
 	// by the consumer of the monitor
 	SetupHandlers(c *config.ProcessorConfig)
 
-	// ReSync should resynchronize PUs. This should be done while starting up.
-	ReSync(ctx context.Context) error
+	// Resync should resynchronize PUs. This should be done while starting up.
+	Resync(ctx context.Context) error
 }

--- a/monitor/internal/cni/monitor.go
+++ b/monitor/internal/cni/monitor.go
@@ -95,9 +95,9 @@ func (c *CniMonitor) SetupHandlers(m *config.ProcessorConfig) {
 	c.proc.config = m
 }
 
-// ReSync instructs the monitor to do a resync.
-func (c *CniMonitor) ReSync(ctx context.Context) error {
+// Resync instructs the monitor to do a resync.
+func (c *CniMonitor) Resync(ctx context.Context) error {
 
-	// TODO: Implement reSync
-	return fmt.Errorf("reSync not implemented")
+	// TODO: Implement resync
+	return fmt.Errorf("resync not implemented")
 }

--- a/monitor/internal/cni/processor.go
+++ b/monitor/internal/cni/processor.go
@@ -79,8 +79,8 @@ func (c *cniProcessor) Pause(ctx context.Context, eventInfo *common.EventInfo) e
 	return nil
 }
 
-// ReSync resyncs with all the existing services that were there before we start
-func (c *cniProcessor) ReSync(ctx context.Context, e *common.EventInfo) error {
+// Resync resyncs with all the existing services that were there before we start
+func (c *cniProcessor) Resync(ctx context.Context, e *common.EventInfo) error {
 	return nil
 }
 

--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -238,7 +238,7 @@ func (d *DockerMonitor) eventListener(ctx context.Context, listenerReady chan st
 	}
 }
 
-// ReSync resyncs all the existing containers on the Host, using the
+// Resync resyncs all the existing containers on the Host, using the
 // same process as when a container is initially spawn up
 func (d *DockerMonitor) Resync(ctx context.Context) error {
 

--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -240,7 +240,7 @@ func (d *DockerMonitor) eventListener(ctx context.Context, listenerReady chan st
 
 // ReSync resyncs all the existing containers on the Host, using the
 // same process as when a container is initially spawn up
-func (d *DockerMonitor) ReSync(ctx context.Context) error {
+func (d *DockerMonitor) Resync(ctx context.Context) error {
 
 	if !d.syncAtStart || d.config.Policy == nil {
 		zap.L().Debug("No synchronization of containers performed")

--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -53,7 +53,7 @@ func New() *DockerMonitor {
 	return &DockerMonitor{}
 }
 
-// SetupConfig provides a configuration to implmentations. Every implmentation
+// SetupConfig provides a configuration to implmentations. Every implementation
 // can have its own config type.
 func (d *DockerMonitor) SetupConfig(registerer registerer.Registerer, cfg interface{}) (err error) {
 

--- a/monitor/internal/docker/monitor_test.go
+++ b/monitor/internal/docker/monitor_test.go
@@ -570,7 +570,7 @@ func TestSyncContainers(t *testing.T) {
 
 		Convey("If I try to sync containers where when SyncAtStart is not set, I should get nil", func() {
 			dmi.syncAtStart = false
-			err := dmi.ReSync(context.Background())
+			err := dmi.Resync(context.Background())
 			So(err, ShouldBeNil)
 		})
 
@@ -579,7 +579,7 @@ func TestSyncContainers(t *testing.T) {
 			dmi.dockerClient.(*mockdocker.MockCommonAPIClient).EXPECT().
 				ContainerList(gomock.Any(), gomock.Any()).Return([]types.Container{types.Container{ID: ID}}, errors.New("error"))
 
-			err := dmi.ReSync(context.Background())
+			err := dmi.Resync(context.Background())
 			So(err, ShouldNotBeNil)
 		})
 
@@ -594,7 +594,7 @@ func TestSyncContainers(t *testing.T) {
 
 			mockPU.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("blah"))
 
-			err := dmi.ReSync(context.Background())
+			err := dmi.Resync(context.Background())
 
 			Convey("Then I should  get  error since we ignore bad containers", func() {
 				So(err, ShouldBeNil)
@@ -613,7 +613,7 @@ func TestSyncContainers(t *testing.T) {
 
 			mockPU.EXPECT().HandlePUEvent(gomock.Any(), ID[:12], tevents.EventStart, gomock.Any()).AnyTimes().Return(nil)
 
-			err := dmi.ReSync(context.Background())
+			err := dmi.Resync(context.Background())
 
 			Convey("Then I should not get no error ", func() {
 				So(err, ShouldBeNil)

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -13,12 +13,17 @@ type podCacheEntry struct {
 	runtime policy.RuntimeReader
 	// The latest known reference to the pod received from Kubernetes API
 	pod *api.Pod
+
+	// Lock for the specific entry
+	sync.RWMutex
 }
 
 // Cache keeps all the state needed for the integration.
 type cache struct {
 	// contextIDCache keeps a mapping between a POD/Namespace name and the corresponding contextID from Trireme.
 	podCache map[string]*podCacheEntry
+
+	// Lock for the whole cache
 	sync.RWMutex
 }
 

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -32,3 +32,10 @@ func newCache() *cache {
 func kubePodIdentifier(podName string, podNamespace string) string {
 	return podNamespace + "/" + podName
 }
+
+func (c *cache) getPodFromCache(podNamespace string, podName string) *podCacheEntry {
+	c.Lock()
+	defer c.Unlock()
+	kubeIdentifier := kubePodIdentifier(podName, podNamespace)
+	return c.podCache[kubeIdentifier]
+}

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -12,17 +12,11 @@ type puidCacheEntry struct {
 
 	// The latest reference to the runtime as received from DockerMonitor
 	runtime policy.RuntimeReader
-
-	// Lock for the specific entry
-	sync.RWMutex
 }
 
 type podCacheEntry struct {
 	// puIDs us a map containing a link to all the containers currently known to be part of that pod.
 	puIDs map[string]bool
-
-	// Lock for the specific entry
-	sync.RWMutex
 }
 
 // Cache keeps all the state needed for the integration.

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -8,7 +8,7 @@ import (
 )
 
 type podCacheEntry struct {
-	contextID string
+	puID string
 	// The latest reference to the runtime as received from DockerMonitor
 	runtime policy.RuntimeReader
 	// The latest known reference to the pod received from Kubernetes API

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -18,14 +18,14 @@ type podCacheEntry struct {
 // Cache keeps all the state needed for the integration.
 type cache struct {
 	// contextIDCache keeps a mapping between a POD/Namespace name and the corresponding contextID from Trireme.
-	podCache map[string]podCacheEntry
+	podCache map[string]*podCacheEntry
 	sync.RWMutex
 }
 
 // NewCache initialize a cache
 func newCache() *cache {
 	return &cache{
-		podCache: map[string]podCacheEntry{},
+		podCache: map[string]*podCacheEntry{},
 	}
 }
 

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -9,7 +9,7 @@ import (
 )
 
 type podCacheEntry struct {
-	puID string
+	puIDs map[string]bool
 	// The latest reference to the runtime as received from DockerMonitor
 	runtime policy.RuntimeReader
 	// The latest known reference to the pod received from Kubernetes API
@@ -54,7 +54,7 @@ func (c *cache) createPodEntry(podNamespace string, podName string, puID string,
 		cacheEntry = &podCacheEntry{}
 		c.podCache[kubeIdentifier] = cacheEntry
 	}
-	cacheEntry.puID = puID
+	cacheEntry.puIDs = map[string]bool{}
 	cacheEntry.runtime = runtime
 
 	c.puidCache[puID] = kubeIdentifier
@@ -104,12 +104,6 @@ func (c *cache) deletePodByKube(podNamespace string, podName string) error {
 
 	kubeIdentifier := kubePodIdentifier(podName, podNamespace)
 
-	cacheEntry, ok := c.podCache[kubeIdentifier]
-	if !ok {
-		return fmt.Errorf("pod not found in cache")
-	}
-
-	delete(c.puidCache, cacheEntry.puID)
 	delete(c.podCache, kubeIdentifier)
 
 	return nil
@@ -120,12 +114,6 @@ func (c *cache) deletePodByPUID(puid string) error {
 	c.Lock()
 	defer c.Unlock()
 
-	kubeIdentifier, ok := c.puidCache[puid]
-	if !ok {
-		return fmt.Errorf("puid not found in cache")
-	}
-
-	delete(c.podCache, kubeIdentifier)
 	delete(c.puidCache, puid)
 
 	return nil

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -48,6 +48,10 @@ func kubePodIdentifier(podName string, podNamespace string) string {
 
 // updatePUIDCache updates the cache with an entry coming from a container perspective
 func (c *cache) updatePUIDCache(podNamespace string, podName string, puID string, dockerRuntime policy.RuntimeReader, kubernetesRuntime policy.RuntimeReader) {
+	if podNamespace == "" || podName == "" || puID == "" {
+		return
+	}
+
 	c.Lock()
 	defer c.Unlock()
 

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -1,0 +1,34 @@
+package kubernetesmonitor
+
+import (
+	"sync"
+
+	"github.com/aporeto-inc/trireme-lib/policy"
+	api "k8s.io/api/core/v1"
+)
+
+type podCacheEntry struct {
+	contextID string
+	// The latest reference to the runtime as received from DockerMonitor
+	runtime policy.RuntimeReader
+	// The latest known reference to the pod received from Kubernetes API
+	pod *api.Pod
+}
+
+// Cache keeps all the state needed for the integration.
+type cache struct {
+	// contextIDCache keeps a mapping between a POD/Namespace name and the corresponding contextID from Trireme.
+	podCache map[string]podCacheEntry
+	sync.RWMutex
+}
+
+// NewCache initialize a cache
+func newCache() *cache {
+	return &cache{
+		podCache: map[string]podCacheEntry{},
+	}
+}
+
+func kubePodIdentifier(podName string, podNamespace string) string {
+	return podNamespace + "/" + podName
+}

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -38,9 +38,16 @@ func kubePodIdentifier(podName string, podNamespace string) string {
 	return podNamespace + "/" + podName
 }
 
-func (c *cache) getPodFromCache(podNamespace string, podName string) *podCacheEntry {
+// getOrCreatePodFromCache locks the cache in order to return the pod cache entry if found, or create it if not found
+func (c *cache) getOrCreatePodFromCache(podNamespace string, podName string) *podCacheEntry {
 	c.Lock()
 	defer c.Unlock()
+
 	kubeIdentifier := kubePodIdentifier(podName, podNamespace)
-	return c.podCache[kubeIdentifier]
+	cacheEntry, ok := c.podCache[kubeIdentifier]
+	if !ok {
+		cacheEntry = &podCacheEntry{}
+		c.podCache[kubeIdentifier] = cacheEntry
+	}
+	return cacheEntry
 }

--- a/monitor/internal/kubernetes/cache.go
+++ b/monitor/internal/kubernetes/cache.go
@@ -89,7 +89,7 @@ func (c *cache) getPUIDsbyPod(podNamespace string, podName string) []string {
 	kubeIdentifier := kubePodIdentifier(podName, podNamespace)
 	podEntry, ok := c.podCache[kubeIdentifier]
 	if !ok {
-		return nil
+		return []string{}
 	}
 
 	return keysFromMap(podEntry.puIDs)

--- a/monitor/internal/kubernetes/cache_test.go
+++ b/monitor/internal/kubernetes/cache_test.go
@@ -328,10 +328,160 @@ func Test_cache_getPUIDsbyPod(t *testing.T) {
 			c := &cache{
 				puidCache: tt.fields.puidCache,
 				podCache:  tt.fields.podCache,
-				RWMutex:   tt.fields.RWMutex,
+				RWMutex:   tt.fields.RWMutex, // nolint
 			}
 			if got := c.getPUIDsbyPod(tt.args.podNamespace, tt.args.podName); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("cache.getPUIDsbyPod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_cache_getDockerRuntimeByPUID(t *testing.T) {
+
+	puid1 := "12345"
+	pod1 := "test/test"
+	containerRuntime := policy.NewPURuntimeWithDefaults()
+	containerRuntime.SetPid(123)
+	puidEntry1 := &puidCacheEntry{
+		kubeIdentifier: pod1,
+		dockerRuntime:  containerRuntime,
+	}
+	podEntry1 := &podCacheEntry{
+		puIDs: map[string]bool{
+			puid1: true,
+		},
+	}
+
+	type fields struct {
+		puidCache map[string]*puidCacheEntry
+		podCache  map[string]*podCacheEntry
+		RWMutex   sync.RWMutex
+	}
+	type args struct {
+		puid string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   policy.RuntimeReader
+	}{
+		{
+			name: "simple get",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				puid: puid1,
+			},
+			want: containerRuntime,
+		},
+		{
+			name: "empty get",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				puid: "123123",
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests { // nolint
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				puidCache: tt.fields.puidCache,
+				podCache:  tt.fields.podCache,
+				RWMutex:   tt.fields.RWMutex, // nolint
+			}
+			if got := c.getDockerRuntimeByPUID(tt.args.puid); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("cache.getDockerRuntimeByPUID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_cache_getKubernetesRuntimeByPUID(t *testing.T) {
+
+	puid1 := "12345"
+	pod1 := "test/test"
+	containerRuntime := policy.NewPURuntimeWithDefaults()
+	containerRuntime.SetPid(123)
+	puidEntry1 := &puidCacheEntry{
+		kubeIdentifier:    pod1,
+		kubernetesRuntime: containerRuntime,
+	}
+	podEntry1 := &podCacheEntry{
+		puIDs: map[string]bool{
+			puid1: true,
+		},
+	}
+
+	type fields struct {
+		puidCache map[string]*puidCacheEntry
+		podCache  map[string]*podCacheEntry
+		RWMutex   sync.RWMutex
+	}
+	type args struct {
+		puid string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   policy.RuntimeReader
+	}{
+		{
+			name: "simple get",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				puid: puid1,
+			},
+			want: containerRuntime,
+		},
+		{
+			name: "empty get",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				puid: "123123",
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests { // nolint
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				puidCache: tt.fields.puidCache,
+				podCache:  tt.fields.podCache,
+				RWMutex:   tt.fields.RWMutex, // nolint
+			}
+			if got := c.getKubernetesRuntimeByPUID(tt.args.puid); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("cache.getKubernetesRuntimeByPUID() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/monitor/internal/kubernetes/cache_test.go
+++ b/monitor/internal/kubernetes/cache_test.go
@@ -244,13 +244,13 @@ func Test_cache_updatePUIDCache(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				puidCache: tt.fields.puidCache,
-				podCache:  tt.fields.podCache,
-				RWMutex:   tt.fields.RWMutex,
-			}
+	for _, tt := range tests { // nolint
+		t.Run(tt.name, func(t *testing.T) { // nolint
+			c := &cache{ // nolint
+				puidCache: tt.fields.puidCache, // nolint
+				podCache:  tt.fields.podCache,  // nolint
+				RWMutex:   tt.fields.RWMutex,   // nolint
+			} // nolint
 			c.updatePUIDCache(tt.args.podNamespace, tt.args.podName, tt.args.puID, tt.args.dockerRuntime, tt.args.kubernetesRuntime)
 			if !reflect.DeepEqual(c.puidCache, tt.fieldsResult.puidCache) {
 				t.Errorf("updatePUIDCache() field. got %v, want %v", c.puidCache, tt.fieldsResult.puidCache)

--- a/monitor/internal/kubernetes/cache_test.go
+++ b/monitor/internal/kubernetes/cache_test.go
@@ -324,12 +324,12 @@ func Test_cache_getPUIDsbyPod(t *testing.T) {
 	}
 
 	for _, tt := range tests { // nolint
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				puidCache: tt.fields.puidCache,
-				podCache:  tt.fields.podCache,
-				RWMutex:   tt.fields.RWMutex, // nolint
-			}
+		t.Run(tt.name, func(t *testing.T) { // nolint
+			c := &cache{ // nolint
+				puidCache: tt.fields.puidCache, // nolint
+				podCache:  tt.fields.podCache,  // nolint
+				RWMutex:   tt.fields.RWMutex,   // nolint
+			} // nolint
 			if got := c.getPUIDsbyPod(tt.args.podNamespace, tt.args.podName); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("cache.getPUIDsbyPod() = %v, want %v", got, tt.want)
 			}
@@ -399,12 +399,12 @@ func Test_cache_getDockerRuntimeByPUID(t *testing.T) {
 		},
 	}
 	for _, tt := range tests { // nolint
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				puidCache: tt.fields.puidCache,
-				podCache:  tt.fields.podCache,
-				RWMutex:   tt.fields.RWMutex, // nolint
-			}
+		t.Run(tt.name, func(t *testing.T) { // nolint
+			c := &cache{ // nolint
+				puidCache: tt.fields.puidCache, // nolint
+				podCache:  tt.fields.podCache,  // nolint
+				RWMutex:   tt.fields.RWMutex,   // nolint
+			} // nolint
 			if got := c.getDockerRuntimeByPUID(tt.args.puid); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("cache.getDockerRuntimeByPUID() = %v, want %v", got, tt.want)
 			}
@@ -474,12 +474,12 @@ func Test_cache_getKubernetesRuntimeByPUID(t *testing.T) {
 		},
 	}
 	for _, tt := range tests { // nolint
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				puidCache: tt.fields.puidCache,
-				podCache:  tt.fields.podCache,
-				RWMutex:   tt.fields.RWMutex, // nolint
-			}
+		t.Run(tt.name, func(t *testing.T) { // nolint
+			c := &cache{ // nolint
+				puidCache: tt.fields.puidCache, // nolint
+				podCache:  tt.fields.podCache,  // nolint
+				RWMutex:   tt.fields.RWMutex,   // nolint
+			} // nolint
 			if got := c.getKubernetesRuntimeByPUID(tt.args.puid); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("cache.getKubernetesRuntimeByPUID() = %v, want %v", got, tt.want)
 			}
@@ -561,12 +561,12 @@ func Test_cache_deletePodEntry(t *testing.T) {
 		},
 	}
 	for _, tt := range tests { // nolint
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				puidCache: tt.fields.puidCache,
-				podCache:  tt.fields.podCache,
-				RWMutex:   tt.fields.RWMutex, // nolint
-			}
+		t.Run(tt.name, func(t *testing.T) { // nolint
+			c := &cache{ // nolint
+				puidCache: tt.fields.puidCache, // nolint
+				podCache:  tt.fields.podCache,  // nolint
+				RWMutex:   tt.fields.RWMutex,   // nolint
+			} // nolint
 			c.deletePodEntry(tt.args.podNamespace, tt.args.podName)
 
 			if got := tt.fields.puidCache; !reflect.DeepEqual(got, tt.want1) {
@@ -650,12 +650,12 @@ func Test_cache_deletePUIDEntry(t *testing.T) {
 		},
 	}
 	for _, tt := range tests { // nolint
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cache{
-				puidCache: tt.fields.puidCache,
-				podCache:  tt.fields.podCache,
-				RWMutex:   tt.fields.RWMutex, // nolint
-			}
+		t.Run(tt.name, func(t *testing.T) { // nolint
+			c := &cache{ // nolint
+				puidCache: tt.fields.puidCache, // nolint
+				podCache:  tt.fields.podCache,  // nolint
+				RWMutex:   tt.fields.RWMutex,   // nolint
+			} // nolint
 			c.deletePUIDEntry(tt.args.puid)
 
 			if got := tt.fields.puidCache; !reflect.DeepEqual(got, tt.want1) {

--- a/monitor/internal/kubernetes/cache_test.go
+++ b/monitor/internal/kubernetes/cache_test.go
@@ -1,0 +1,263 @@
+package kubernetesmonitor
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/aporeto-inc/trireme-lib/policy"
+)
+
+func Test_cache_updatePUIDCache(t *testing.T) {
+
+	// Pregenerating a couple fake runtimes
+	runtime1 := policy.NewPURuntimeWithDefaults()
+	runtime1.SetPid(1)
+	runtime2 := policy.NewPURuntimeWithDefaults()
+	runtime2.SetPid(2)
+	runtime3 := policy.NewPURuntimeWithDefaults()
+	runtime3.SetPid(3)
+
+	type fields struct {
+		puidCache map[string]*puidCacheEntry
+		podCache  map[string]*podCacheEntry
+		RWMutex   sync.RWMutex
+	}
+	type args struct {
+		podNamespace      string
+		podName           string
+		puID              string
+		dockerRuntime     policy.RuntimeReader
+		kubernetesRuntime policy.RuntimeReader
+	}
+	type fieldsResult struct {
+		puidCache map[string]*puidCacheEntry
+		podCache  map[string]*podCacheEntry
+		RWMutex   sync.RWMutex
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		fieldsResult fields
+		args         args
+	}{
+		{
+			name: "test empty all",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			fieldsResult: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			args: args{
+				podNamespace:      "",
+				podName:           "",
+				puID:              "",
+				dockerRuntime:     policy.NewPURuntimeWithDefaults(),
+				kubernetesRuntime: policy.NewPURuntimeWithDefaults(),
+			},
+		},
+		{
+			name: "test empty NS",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			fieldsResult: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			args: args{
+				podNamespace:      "",
+				podName:           "xcvxcv",
+				puID:              "xcvxcv",
+				dockerRuntime:     policy.NewPURuntimeWithDefaults(),
+				kubernetesRuntime: policy.NewPURuntimeWithDefaults(),
+			},
+		},
+		{
+			name: "test empty Name",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			fieldsResult: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			args: args{
+				podNamespace:      "xcvxcv",
+				podName:           "",
+				puID:              "xcvxcv",
+				dockerRuntime:     policy.NewPURuntimeWithDefaults(),
+				kubernetesRuntime: policy.NewPURuntimeWithDefaults(),
+			},
+		},
+		{
+			name: "test empty PUID",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			fieldsResult: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			args: args{
+				podNamespace:      "xcvxcv",
+				podName:           "xcvxcv",
+				puID:              "",
+				dockerRuntime:     policy.NewPURuntimeWithDefaults(),
+				kubernetesRuntime: policy.NewPURuntimeWithDefaults(),
+			},
+		},
+		{
+			name: "test normal behavior",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{},
+				podCache:  map[string]*podCacheEntry{},
+			},
+			fieldsResult: fields{
+				puidCache: map[string]*puidCacheEntry{
+					"123456": &puidCacheEntry{
+						kubeIdentifier:    "namespace/name",
+						dockerRuntime:     runtime1,
+						kubernetesRuntime: runtime2,
+					},
+				},
+				podCache: map[string]*podCacheEntry{
+					"namespace/name": &podCacheEntry{
+						puIDs: map[string]bool{
+							"123456": true,
+						},
+					},
+				},
+			},
+			args: args{
+				podNamespace:      "namespace",
+				podName:           "name",
+				puID:              "123456",
+				dockerRuntime:     runtime1,
+				kubernetesRuntime: runtime2,
+			},
+		},
+		{
+			name: "test additive behavior",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					"123456": &puidCacheEntry{
+						kubeIdentifier:    "namespace/name",
+						dockerRuntime:     runtime1,
+						kubernetesRuntime: runtime2,
+					},
+				},
+				podCache: map[string]*podCacheEntry{
+					"namespace/name": &podCacheEntry{
+						puIDs: map[string]bool{
+							"123456": true,
+						},
+					},
+				},
+			},
+			fieldsResult: fields{
+				puidCache: map[string]*puidCacheEntry{
+					"123456": &puidCacheEntry{
+						kubeIdentifier:    "namespace/name",
+						dockerRuntime:     runtime1,
+						kubernetesRuntime: runtime2,
+					},
+					"abcdef": &puidCacheEntry{
+						kubeIdentifier:    "namespace2/name2",
+						dockerRuntime:     runtime3,
+						kubernetesRuntime: runtime2,
+					},
+				},
+				podCache: map[string]*podCacheEntry{
+					"namespace/name": &podCacheEntry{
+						puIDs: map[string]bool{
+							"123456": true,
+						},
+					},
+					"namespace2/name2": &podCacheEntry{
+						puIDs: map[string]bool{
+							"abcdef": true,
+						},
+					},
+				},
+			},
+			args: args{
+				podNamespace:      "namespace2",
+				podName:           "name2",
+				puID:              "abcdef",
+				dockerRuntime:     runtime3,
+				kubernetesRuntime: runtime2,
+			},
+		},
+		{
+			name: "test additive same pod",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					"123456": &puidCacheEntry{
+						kubeIdentifier:    "namespace/name",
+						dockerRuntime:     runtime1,
+						kubernetesRuntime: runtime2,
+					},
+				},
+				podCache: map[string]*podCacheEntry{
+					"namespace/name": &podCacheEntry{
+						puIDs: map[string]bool{
+							"123456": true,
+						},
+					},
+				},
+			},
+			fieldsResult: fields{
+				puidCache: map[string]*puidCacheEntry{
+					"123456": &puidCacheEntry{
+						kubeIdentifier:    "namespace/name",
+						dockerRuntime:     runtime1,
+						kubernetesRuntime: runtime2,
+					},
+					"abcdef": &puidCacheEntry{
+						kubeIdentifier:    "namespace/name",
+						dockerRuntime:     runtime3,
+						kubernetesRuntime: runtime2,
+					},
+				},
+				podCache: map[string]*podCacheEntry{
+					"namespace/name": &podCacheEntry{
+						puIDs: map[string]bool{
+							"123456": true,
+							"abcdef": true,
+						},
+					},
+				},
+			},
+			args: args{
+				podNamespace:      "namespace",
+				podName:           "name",
+				puID:              "abcdef",
+				dockerRuntime:     runtime3,
+				kubernetesRuntime: runtime2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				puidCache: tt.fields.puidCache,
+				podCache:  tt.fields.podCache,
+				RWMutex:   tt.fields.RWMutex,
+			}
+			c.updatePUIDCache(tt.args.podNamespace, tt.args.podName, tt.args.puID, tt.args.dockerRuntime, tt.args.kubernetesRuntime)
+			if !reflect.DeepEqual(c.puidCache, tt.fieldsResult.puidCache) {
+				t.Errorf("updatePUIDCache() field. got %v, want %v", c.puidCache, tt.fieldsResult.puidCache)
+			}
+			if !reflect.DeepEqual(c.podCache, tt.fieldsResult.podCache) {
+				t.Errorf("updatePUIDCache() field. got %v, want %v", c.podCache, tt.fieldsResult.podCache)
+			}
+		})
+	}
+}

--- a/monitor/internal/kubernetes/cache_test.go
+++ b/monitor/internal/kubernetes/cache_test.go
@@ -486,3 +486,185 @@ func Test_cache_getKubernetesRuntimeByPUID(t *testing.T) {
 		})
 	}
 }
+
+func Test_cache_deletePodEntry(t *testing.T) {
+
+	puid1 := "12345"
+	pod1 := "test/test"
+	containerRuntime := policy.NewPURuntimeWithDefaults()
+	containerRuntime.SetPid(123)
+	puidEntry1 := &puidCacheEntry{
+		kubeIdentifier:    pod1,
+		kubernetesRuntime: containerRuntime,
+	}
+	podEntry1 := &podCacheEntry{
+		puIDs: map[string]bool{
+			puid1: true,
+		},
+	}
+
+	type fields struct {
+		puidCache map[string]*puidCacheEntry
+		podCache  map[string]*podCacheEntry
+		RWMutex   sync.RWMutex
+	}
+	type args struct {
+		podNamespace string
+		podName      string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want1  map[string]*puidCacheEntry
+		want2  map[string]*podCacheEntry
+	}{
+		{
+			name: "simple delete",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				podName:      "test",
+				podNamespace: "test",
+			},
+			want1: map[string]*puidCacheEntry{
+				puid1: puidEntry1,
+			},
+			want2: map[string]*podCacheEntry{},
+		},
+		{
+			name: "non mexisting delete",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				podName:      "test2",
+				podNamespace: "test",
+			},
+			want1: map[string]*puidCacheEntry{
+				puid1: puidEntry1,
+			},
+			want2: map[string]*podCacheEntry{
+				pod1: podEntry1,
+			},
+		},
+	}
+	for _, tt := range tests { // nolint
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				puidCache: tt.fields.puidCache,
+				podCache:  tt.fields.podCache,
+				RWMutex:   tt.fields.RWMutex, // nolint
+			}
+			c.deletePodEntry(tt.args.podNamespace, tt.args.podName)
+
+			if got := tt.fields.puidCache; !reflect.DeepEqual(got, tt.want1) {
+				t.Errorf("after cache.deleteByPod = %v, want %v", got, tt.want1)
+			}
+			if got := tt.fields.podCache; !reflect.DeepEqual(got, tt.want2) {
+				t.Errorf("after cache.deleteByPod = %v, want %v", got, tt.want2)
+			}
+		})
+	}
+}
+
+func Test_cache_deletePUIDEntry(t *testing.T) {
+
+	puid1 := "12345"
+	pod1 := "test/test"
+	containerRuntime := policy.NewPURuntimeWithDefaults()
+	containerRuntime.SetPid(123)
+	puidEntry1 := &puidCacheEntry{
+		kubeIdentifier:    pod1,
+		kubernetesRuntime: containerRuntime,
+	}
+	podEntry1 := &podCacheEntry{
+		puIDs: map[string]bool{
+			puid1: true,
+		},
+	}
+
+	type fields struct {
+		puidCache map[string]*puidCacheEntry
+		podCache  map[string]*podCacheEntry
+		RWMutex   sync.RWMutex
+	}
+	type args struct {
+		puid string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want1  map[string]*puidCacheEntry
+		want2  map[string]*podCacheEntry
+	}{
+		{
+			name: "simple delete",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				puid: puid1,
+			},
+			want1: map[string]*puidCacheEntry{},
+			want2: map[string]*podCacheEntry{
+				pod1: podEntry1,
+			},
+		},
+		{
+			name: "non mexisting delete",
+			fields: fields{
+				puidCache: map[string]*puidCacheEntry{
+					puid1: puidEntry1,
+				},
+				podCache: map[string]*podCacheEntry{
+					pod1: podEntry1,
+				},
+			},
+			args: args{
+				puid: "123123",
+			},
+			want1: map[string]*puidCacheEntry{
+				puid1: puidEntry1,
+			},
+			want2: map[string]*podCacheEntry{
+				pod1: podEntry1,
+			},
+		},
+	}
+	for _, tt := range tests { // nolint
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cache{
+				puidCache: tt.fields.puidCache,
+				podCache:  tt.fields.podCache,
+				RWMutex:   tt.fields.RWMutex, // nolint
+			}
+			c.deletePUIDEntry(tt.args.puid)
+
+			if got := tt.fields.puidCache; !reflect.DeepEqual(got, tt.want1) {
+				t.Errorf("after cache.deleteByPod = %v, want %v", got, tt.want1)
+			}
+			if got := tt.fields.podCache; !reflect.DeepEqual(got, tt.want2) {
+				t.Errorf("after cache.deleteByPod = %v, want %v", got, tt.want2)
+			}
+
+		})
+	}
+}

--- a/monitor/internal/kubernetes/client.go
+++ b/monitor/internal/kubernetes/client.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// NewClient Generate and initialize a Kubernetes client
+// NewKubeClient Generate and initialize a Kubernetes client based on the parameter kubeconfig
 func NewKubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {

--- a/monitor/internal/kubernetes/client.go
+++ b/monitor/internal/kubernetes/client.go
@@ -3,45 +3,59 @@ package kubernetesmonitor
 import (
 	"fmt"
 
+	"go.uber.org/zap"
+	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// NewClient Generate and initialize a Trireme Client object
-func NewClient(kubeconfig string, nodename string) (*Client, error) {
-	Client := &Client{}
-	Client.localNode = nodename
-
-	if err := Client.InitKubernetesClient(kubeconfig); err != nil {
-		return nil, fmt.Errorf("Couldn't initialize Kubernetes Client: %v", err)
+// NewClient Generate and initialize a Kubernetes client
+func NewKubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("Error Building config from Kubeconfig: %v", err)
 	}
-	return Client, nil
+
+	return kubernetes.NewForConfig(config)
 }
 
-// InitKubernetesClient Initialize the Kubernetes client based on the parameter kubeconfig
-// if Kubeconfig is empty, try an in-cluster auth.
-func (c *Client) InitKubernetesClient(kubeconfig string) error {
+// CreateResourceController creates a controller for a specific ressource and namespace.
+// The parameter function will be called on Add/Delete/Update events
+func CreateResourceController(client cache.Getter, resource string, namespace string, apiStruct runtime.Object, selector fields.Selector,
+	addFunc func(addedApiStruct interface{}), deleteFunc func(deletedApiStruct interface{}), updateFunc func(oldApiStruct, updatedApiStruct interface{})) (cache.Store, cache.Controller) {
 
-	var config *restclient.Config
-	var err error
-
-	if kubeconfig == "" {
-		// TODO: Explicit InCluster config call.
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			return fmt.Errorf("Error Building InCluster config: %v", err)
-		}
-	} else {
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			return fmt.Errorf("Error Building config from Kubeconfig: %v", err)
-		}
+	handlers := cache.ResourceEventHandlerFuncs{
+		AddFunc:    addFunc,
+		DeleteFunc: deleteFunc,
+		UpdateFunc: updateFunc,
 	}
 
-	myClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("Error creating REST Kube Client: %v", err)
-	}
-	c.kubeClient = myClient
-	return nil
+	listWatch := cache.NewListWatchFromClient(client, resource, namespace, selector)
+	store, controller := cache.NewInformer(listWatch, apiStruct, 0, handlers)
+	return store, controller
+}
+
+// CreateLocalPodController creates a controller specifically for Pods.
+func (c *Client) CreateLocalPodController(namespace string,
+	addFunc func(addedApiStruct *api.Pod) error, deleteFunc func(deletedApiStruct *api.Pod) error, updateFunc func(oldApiStruct, updatedApiStruct *api.Pod) error) (cache.Store, cache.Controller) {
+
+	return CreateResourceController(c.KubeClient().Core().RESTClient(), "pods", namespace, &api.Pod{}, c.localNodeSelector(),
+		func(addedApiStruct interface{}) {
+			if err := addFunc(addedApiStruct.(*api.Pod)); err != nil {
+				zap.L().Error("Error while handling Add Pod", zap.Error(err))
+			}
+		},
+		func(deletedApiStruct interface{}) {
+			if err := deleteFunc(deletedApiStruct.(*api.Pod)); err != nil {
+				zap.L().Error("Error while handling Delete Pod", zap.Error(err))
+			}
+		},
+		func(oldApiStruct, updatedApiStruct interface{}) {
+			if err := updateFunc(oldApiStruct.(*api.Pod), updatedApiStruct.(*api.Pod)); err != nil {
+				zap.L().Error("Error while handling Update Pod", zap.Error(err))
+			}
+		})
 }

--- a/monitor/internal/kubernetes/client.go
+++ b/monitor/internal/kubernetes/client.go
@@ -1,0 +1,47 @@
+package kubernetesmonitor
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// NewClient Generate and initialize a Trireme Client object
+func NewClient(kubeconfig string, nodename string) (*Client, error) {
+	Client := &Client{}
+	Client.localNode = nodename
+
+	if err := Client.InitKubernetesClient(kubeconfig); err != nil {
+		return nil, fmt.Errorf("Couldn't initialize Kubernetes Client: %v", err)
+	}
+	return Client, nil
+}
+
+// InitKubernetesClient Initialize the Kubernetes client based on the parameter kubeconfig
+// if Kubeconfig is empty, try an in-cluster auth.
+func (c *Client) InitKubernetesClient(kubeconfig string) error {
+
+	var config *restclient.Config
+	var err error
+
+	if kubeconfig == "" {
+		// TODO: Explicit InCluster config call.
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return fmt.Errorf("Error Building InCluster config: %v", err)
+		}
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return fmt.Errorf("Error Building config from Kubeconfig: %v", err)
+		}
+	}
+
+	myClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("Error creating REST Kube Client: %v", err)
+	}
+	c.kubeClient = myClient
+	return nil
+}

--- a/monitor/internal/kubernetes/client.go
+++ b/monitor/internal/kubernetes/client.go
@@ -5,10 +5,11 @@ import (
 
 	"go.uber.org/zap"
 	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
+	kubecache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -24,25 +25,25 @@ func NewKubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
 
 // CreateResourceController creates a controller for a specific ressource and namespace.
 // The parameter function will be called on Add/Delete/Update events
-func CreateResourceController(client cache.Getter, resource string, namespace string, apiStruct runtime.Object, selector fields.Selector,
-	addFunc func(addedApiStruct interface{}), deleteFunc func(deletedApiStruct interface{}), updateFunc func(oldApiStruct, updatedApiStruct interface{})) (cache.Store, cache.Controller) {
+func CreateResourceController(client kubecache.Getter, resource string, namespace string, apiStruct runtime.Object, selector fields.Selector,
+	addFunc func(addedApiStruct interface{}), deleteFunc func(deletedApiStruct interface{}), updateFunc func(oldApiStruct, updatedApiStruct interface{})) (kubecache.Store, kubecache.Controller) {
 
-	handlers := cache.ResourceEventHandlerFuncs{
+	handlers := kubecache.ResourceEventHandlerFuncs{
 		AddFunc:    addFunc,
 		DeleteFunc: deleteFunc,
 		UpdateFunc: updateFunc,
 	}
 
-	listWatch := cache.NewListWatchFromClient(client, resource, namespace, selector)
-	store, controller := cache.NewInformer(listWatch, apiStruct, 0, handlers)
+	listWatch := kubecache.NewListWatchFromClient(client, resource, namespace, selector)
+	store, controller := kubecache.NewInformer(listWatch, apiStruct, 0, handlers)
 	return store, controller
 }
 
 // CreateLocalPodController creates a controller specifically for Pods.
-func (c *Client) CreateLocalPodController(namespace string,
-	addFunc func(addedApiStruct *api.Pod) error, deleteFunc func(deletedApiStruct *api.Pod) error, updateFunc func(oldApiStruct, updatedApiStruct *api.Pod) error) (cache.Store, cache.Controller) {
+func (m *KubernetesMonitor) CreateLocalPodController(namespace string,
+	addFunc func(addedApiStruct *api.Pod) error, deleteFunc func(deletedApiStruct *api.Pod) error, updateFunc func(oldApiStruct, updatedApiStruct *api.Pod) error) (kubecache.Store, kubecache.Controller) {
 
-	return CreateResourceController(c.KubeClient().Core().RESTClient(), "pods", namespace, &api.Pod{}, c.localNodeSelector(),
+	return CreateResourceController(m.kubeClient.Core().RESTClient(), "pods", namespace, &api.Pod{}, m.localNodeSelector(),
 		func(addedApiStruct interface{}) {
 			if err := addFunc(addedApiStruct.(*api.Pod)); err != nil {
 				zap.L().Error("Error while handling Add Pod", zap.Error(err))
@@ -58,4 +59,19 @@ func (c *Client) CreateLocalPodController(namespace string,
 				zap.L().Error("Error while handling Update Pod", zap.Error(err))
 			}
 		})
+}
+
+func (m *KubernetesMonitor) localNodeSelector() fields.Selector {
+	return fields.Set(map[string]string{
+		"spec.nodeName": m.localNode,
+	}).AsSelector()
+}
+
+// Pod returns the full pod object.
+func (m *KubernetesMonitor) Pod(podName string, namespace string) (*api.Pod, error) {
+	targetPod, err := m.kubeClient.Core().Pods(namespace).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting Kubernetes labels & IP for pod %v : %v ", podName, err)
+	}
+	return targetPod, nil
 }

--- a/monitor/internal/kubernetes/client_test.go
+++ b/monitor/internal/kubernetes/client_test.go
@@ -1,0 +1,186 @@
+package kubernetesmonitor
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aporeto-inc/trireme-lib/monitor/config"
+	"github.com/aporeto-inc/trireme-lib/monitor/extractors"
+	dockermonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
+	api "k8s.io/api/core/v1"
+	kubefields "k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	kubecache "k8s.io/client-go/tools/cache"
+)
+
+func TestNewKubeClient(t *testing.T) {
+	type args struct {
+		kubeconfig string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *kubernetes.Clientset
+		wantErr bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				kubeconfig: "/tmp/abcd",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewKubeClient(tt.args.kubeconfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewKubeClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewKubeClient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubernetesMonitor_Pod(t *testing.T) {
+
+	pod1 := &api.Pod{}
+	pod1.SetName("pod1")
+	pod1.SetNamespace("beer")
+
+	type fields struct {
+		dockerMonitor       *dockermonitor.DockerMonitor
+		kubeClient          kubernetes.Interface
+		localNode           string
+		handlers            *config.ProcessorConfig
+		cache               *cache
+		kubernetesExtractor extractors.KubernetesMetadataExtractorType
+		podStore            kubecache.Store
+		podController       kubecache.Controller
+		podControllerStop   chan struct{}
+		enableHostPods      bool
+	}
+	type args struct {
+		podName   string
+		namespace string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *api.Pod
+		wantErr bool
+	}{
+		{
+			name: "Query existing pod",
+			fields: fields{
+				kubeClient: kubefake.NewSimpleClientset(pod1),
+			},
+			args: args{
+				podName:   "pod1",
+				namespace: "beer",
+			},
+			want:    pod1,
+			wantErr: false,
+		},
+		{
+			name: "Query non existing pod",
+			fields: fields{
+				kubeClient: kubefake.NewSimpleClientset(pod1),
+			},
+			args: args{
+				podName:   "pod2",
+				namespace: "beer",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &KubernetesMonitor{
+				dockerMonitor:       tt.fields.dockerMonitor,
+				kubeClient:          tt.fields.kubeClient,
+				localNode:           tt.fields.localNode,
+				handlers:            tt.fields.handlers,
+				cache:               tt.fields.cache,
+				kubernetesExtractor: tt.fields.kubernetesExtractor,
+				podStore:            tt.fields.podStore,
+				podController:       tt.fields.podController,
+				podControllerStop:   tt.fields.podControllerStop,
+				enableHostPods:      tt.fields.enableHostPods,
+			}
+			got, err := m.Pod(tt.args.podName, tt.args.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("KubernetesMonitor.Pod() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KubernetesMonitor.Pod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubernetesMonitor_localNodeSelector(t *testing.T) {
+	type fields struct {
+		dockerMonitor       *dockermonitor.DockerMonitor
+		kubeClient          kubernetes.Interface
+		localNode           string
+		handlers            *config.ProcessorConfig
+		cache               *cache
+		kubernetesExtractor extractors.KubernetesMetadataExtractorType
+		podStore            kubecache.Store
+		podController       kubecache.Controller
+		podControllerStop   chan struct{}
+		enableHostPods      bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   kubefields.Selector
+	}{
+		{
+			name: "Normal string",
+			fields: fields{
+				localNode: "abc",
+			},
+			want: kubefields.Set(map[string]string{
+				"spec.nodeName": "abc",
+			}).AsSelector(),
+		},
+		{
+			name: "Empty string",
+			fields: fields{
+				localNode: "",
+			},
+			want: kubefields.Set(map[string]string{
+				"spec.nodeName": "",
+			}).AsSelector(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &KubernetesMonitor{
+				dockerMonitor:       tt.fields.dockerMonitor,
+				kubeClient:          tt.fields.kubeClient,
+				localNode:           tt.fields.localNode,
+				handlers:            tt.fields.handlers,
+				cache:               tt.fields.cache,
+				kubernetesExtractor: tt.fields.kubernetesExtractor,
+				podStore:            tt.fields.podStore,
+				podController:       tt.fields.podController,
+				podControllerStop:   tt.fields.podControllerStop,
+				enableHostPods:      tt.fields.enableHostPods,
+			}
+			if got := m.localNodeSelector(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KubernetesMonitor.localNodeSelector() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -1,22 +1,27 @@
 package kubernetesmonitor
 
-import dockerMonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
+import (
+	"github.com/aporeto-inc/trireme-lib/monitor/extractors"
+	dockerMonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
+)
 
 // Config is the config for the Kubernetes monitor
 type Config struct {
 	DockerConfig dockerMonitor.Config
 
-	EnableHostPods bool
-	Kubeconfig     string
-	Nodename       string
+	EventMetadataExtraxtor extractors.KubernetesMetadataExtractorType
+	EnableHostPods         bool
+	Kubeconfig             string
+	Nodename               string
 }
 
 // DefaultConfig provides a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		EnableHostPods: false,
-		Kubeconfig:     "",
-		Nodename:       "",
+		EventMetadataExtraxtor: extractors.DefaultKubernetesMetadataExtractor,
+		EnableHostPods:         false,
+		Kubeconfig:             "",
+		Nodename:               "",
 	}
 }
 

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -6,14 +6,14 @@ import (
 )
 
 // Config is the config for the Kubernetes monitor
-type Config struct { //nolint\
-	DockerConfig dockerMonitor.Config //nolint
+type Config struct {
+	DockerConfig dockerMonitor.Config
 
-	Kubeconfig             string                                     //nolint
-	Nodename               string                                     //nolint
-	EventMetadataExtractor extractors.KubernetesMetadataExtractorType //nolint
+	Kubeconfig             string
+	Nodename               string
+	EventMetadataExtractor extractors.KubernetesMetadataExtractorType
 
-	EnableHostPods bool //nolint
+	EnableHostPods bool
 }
 
 // DefaultConfig provides a default configuration

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -20,5 +20,5 @@ func DefaultConfig() *Config {
 
 // SetupDefaultConfig adds defaults to a partial configuration
 func SetupDefaultConfig(kubernetesConfig *Config) *Config {
-	return DefaultConfig()
+	return kubernetesConfig
 }

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -6,15 +6,17 @@ import dockerMonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker
 type Config struct {
 	DockerConfig dockerMonitor.Config
 
-	Kubeconfig string
-	Nodename   string
+	EnableHostPods bool
+	Kubeconfig     string
+	Nodename       string
 }
 
 // DefaultConfig provides a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		Kubeconfig: "",
-		Nodename:   "",
+		EnableHostPods: false,
+		Kubeconfig:     "",
+		Nodename:       "",
 	}
 }
 

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -9,7 +9,7 @@ import (
 type Config struct {
 	DockerConfig dockerMonitor.Config
 
-	EventMetadataExtraxtor extractors.KubernetesMetadataExtractorType
+	EventMetadataExtractor extractors.KubernetesMetadataExtractorType
 	EnableHostPods         bool
 	Kubeconfig             string
 	Nodename               string
@@ -18,7 +18,7 @@ type Config struct {
 // DefaultConfig provides a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		EventMetadataExtraxtor: extractors.DefaultKubernetesMetadataExtractor,
+		EventMetadataExtractor: extractors.DefaultKubernetesMetadataExtractor,
 		EnableHostPods:         false,
 		Kubeconfig:             "",
 		Nodename:               "",

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -1,4 +1,4 @@
-package kubernetes
+package kubernetesmonitor
 
 import dockerMonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
 

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -5,14 +5,20 @@ import dockerMonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker
 // Config is the config for the Kubernetes monitor
 type Config struct {
 	DockerConfig dockerMonitor.Config
+
+	Kubeconfig string
+	Nodename   string
 }
 
 // DefaultConfig provides a default configuration
 func DefaultConfig() *Config {
-	return &Config{}
+	return &Config{
+		Kubeconfig: "",
+		Nodename:   "",
+	}
 }
 
 // SetupDefaultConfig adds defaults to a partial configuration
-func SetupDefaultConfig(dockerConfig *Config) *Config {
+func SetupDefaultConfig(kubernetesConfig *Config) *Config {
 	return DefaultConfig()
 }

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -9,9 +9,10 @@ import (
 type Config struct {
 	DockerConfig dockerMonitor.Config
 
-	Kubeconfig             string
-	Nodename               string
-	EventMetadataExtractor extractors.KubernetesMetadataExtractorType
+	Kubeconfig          string
+	Nodename            string
+	KubernetesExtractor extractors.KubernetesMetadataExtractorType
+	DockerExtractor     extractors.DockerMetadataExtractor
 
 	EnableHostPods bool
 }
@@ -19,10 +20,11 @@ type Config struct {
 // DefaultConfig provides a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		EventMetadataExtractor: extractors.DefaultKubernetesMetadataExtractor,
-		EnableHostPods:         false,
-		Kubeconfig:             "",
-		Nodename:               "",
+		KubernetesExtractor: extractors.DefaultKubernetesMetadataExtractor,
+		DockerExtractor:     extractors.DefaultMetadataExtractor,
+		EnableHostPods:      false,
+		Kubeconfig:          "",
+		Nodename:            "",
 	}
 }
 

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -6,3 +6,13 @@ import dockerMonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker
 type Config struct {
 	DockerConfig dockerMonitor.Config
 }
+
+// DefaultConfig provides a default configuration
+func DefaultConfig() *Config {
+	return &Config{}
+}
+
+// SetupDefaultConfig adds defaults to a partial configuration
+func SetupDefaultConfig(dockerConfig *Config) *Config {
+	return DefaultConfig()
+}

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -6,15 +6,15 @@ import (
 )
 
 // Config is the config for the Kubernetes monitor
-type Config struct {
+type Config struct { // nolint
 	DockerConfig dockerMonitor.Config
 
-	Kubeconfig          string
-	Nodename            string
+	Kubeconfig     string
+	Nodename       string
+	EnableHostPods bool
+
 	KubernetesExtractor extractors.KubernetesMetadataExtractorType
 	DockerExtractor     extractors.DockerMetadataExtractor
-
-	EnableHostPods bool
 }
 
 // DefaultConfig provides a default configuration

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -6,13 +6,14 @@ import (
 )
 
 // Config is the config for the Kubernetes monitor
-type Config struct {
-	DockerConfig dockerMonitor.Config
+type Config struct { //nolint
+	Kubeconfig     string //nolint
+	Nodename       string //nolint
+	EnableHostPods bool   //nolint
 
-	EventMetadataExtractor extractors.KubernetesMetadataExtractorType
-	Kubeconfig             string
-	Nodename               string
-	EnableHostPods         bool
+	DockerConfig dockerMonitor.Config //nolint
+
+	EventMetadataExtractor extractors.KubernetesMetadataExtractorType //nolint
 }
 
 // DefaultConfig provides a default configuration

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -1,0 +1,8 @@
+package kubernetes
+
+import dockerMonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
+
+// Config is the config for the Kubernetes monitor
+type Config struct {
+	DockerConfig dockerMonitor.Config
+}

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -10,9 +10,9 @@ type Config struct {
 	DockerConfig dockerMonitor.Config
 
 	EventMetadataExtractor extractors.KubernetesMetadataExtractorType
-	EnableHostPods         bool
 	Kubeconfig             string
 	Nodename               string
+	EnableHostPods         bool
 }
 
 // DefaultConfig provides a default configuration

--- a/monitor/internal/kubernetes/config.go
+++ b/monitor/internal/kubernetes/config.go
@@ -6,14 +6,14 @@ import (
 )
 
 // Config is the config for the Kubernetes monitor
-type Config struct { //nolint
-	Kubeconfig     string //nolint
-	Nodename       string //nolint
-	EnableHostPods bool   //nolint
-
+type Config struct { //nolint\
 	DockerConfig dockerMonitor.Config //nolint
 
+	Kubeconfig             string                                     //nolint
+	Nodename               string                                     //nolint
 	EventMetadataExtractor extractors.KubernetesMetadataExtractorType //nolint
+
+	EnableHostPods bool //nolint
 }
 
 // DefaultConfig provides a default configuration

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -72,6 +72,7 @@ func (m *KubernetesMonitor) sendPodEvent(ctx context.Context, podEntry *podCache
 		return fmt.Errorf("puID not set yet, container not seen from docker yet")
 	}
 
+	// TODO: Also keep the KubernetesRuntime in cache ? Probably not needed to calculate the consolidatedTags every single time.
 	kubernetesRuntime, err := m.consolidateKubernetesTags(podEntry.runtime, podEntry.pod)
 	if err != nil {
 		return fmt.Errorf("error while processing Kubernetes pod for container %s %s", podEntry.puID, err)

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -12,6 +12,7 @@ import (
 // is responsible to update all components by explicitly adding a new PU.
 // Specifically for Kubernetes, The monitor handles the downstream events from Docker.
 func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, event common.Event, runtime policy.RuntimeReader) error {
+
 	process, err := isPodInfraContainer(runtime)
 	if err != nil {
 		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
@@ -26,5 +27,5 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
 	}
 
-	return m.HandlePUEvent(ctx, puID, event, kubernetesRuntime)
+	return m.handlers.Policy.HandlePUEvent(ctx, puID, event, kubernetesRuntime)
 }

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -27,5 +27,23 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
 	}
 
+	podName, ok := runtime.Tag(KubernetesPodNameIdentifier)
+	if !ok {
+		return fmt.Errorf("Error getting Kubernetes Pod name")
+	}
+	podNamespace, ok := runtime.Tag(KubernetesPodNamespaceIdentifier)
+	if !ok {
+		return fmt.Errorf("Error getting Kubernetes Pod namespace")
+	}
+
+	podEntry := m.cache.getOrCreatePodFromCache(podNamespace, podName)
+	podEntry.Lock()
+	defer podEntry.Unlock()
+
+	podEntry.runtime = kubernetesRuntime
+	if podEntry.pod != nil {
+		// Both runtime and Pods are here, activate
+	}
+
 	return m.handlers.Policy.HandlePUEvent(ctx, puID, event, kubernetesRuntime)
 }

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -21,11 +21,13 @@ import (
 func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, event common.Event, runtime policy.RuntimeReader) error {
 	zap.L().Debug("dockermonitor event", zap.String("puID", puID), zap.String("eventType", string(event)))
 
+	// We check first if this is a Kubernetes managed container
 	podName, podNamespace, err := getKubernetesInformation(runtime)
 	if err != nil {
 		return err
 	}
 
+	// We try to extract the Pod information from the cache
 	podEntry := m.cache.createPodEntry(podNamespace, podName, puID, runtime)
 	podEntry.Lock()
 	defer podEntry.Unlock()

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -90,7 +90,7 @@ func (m *KubernetesMonitor) sendPodEvent(ctx context.Context, podEntry *podCache
 	}
 
 	// TODO: Also keep the KubernetesRuntime in cache ? Probably not needed to calculate the consolidatedTags every single time.
-	kubernetesRuntime, managedContainer, err := m.metadataExtractor(podEntry.runtime, podEntry.pod)
+	kubernetesRuntime, managedContainer, err := m.kubernetesExtractor(podEntry.runtime, podEntry.pod)
 	if err != nil {
 		return fmt.Errorf("error while processing Kubernetes pod for container %s %s", podEntry.puID, err)
 	}

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -21,65 +21,17 @@ import (
 func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, event common.Event, runtime policy.RuntimeReader) error {
 	zap.L().Debug("dockermonitor event", zap.String("puID", puID), zap.String("eventType", string(event)))
 
-	switch event {
-	case common.EventStart:
-
-		podName, ok := runtime.Tag(KubernetesPodNameIdentifier)
-		if !ok {
-			return fmt.Errorf("Error getting Kubernetes Pod name")
-		}
-		podNamespace, ok := runtime.Tag(KubernetesPodNamespaceIdentifier)
-		if !ok {
-			return fmt.Errorf("Error getting Kubernetes Pod namespace")
-		}
-
-		podEntry := m.cache.createPodEntry(podNamespace, podName, puID, runtime)
-		podEntry.Lock()
-		defer podEntry.Unlock()
-
-		return m.sendPodEvent(ctx, podEntry, event)
-
-	case common.EventDestroy:
-		podEntry, err := m.cache.getPodByPUID(puID)
-		if err != nil {
-			// If the pod is not found in the cache, we issue a warning.
-			zap.L().Warn("error managing delete event. Not found in cache", zap.String("puID", puID), zap.String("eventType", string(event)), zap.Error(err))
-			return nil
-		}
-
-		podEntry.Lock()
-		defer podEntry.Unlock()
-
-		return m.sendPodEvent(ctx, podEntry, event)
-
-	default:
-		// Other events are irrelevant for the Kubernetes workflow
-		return nil
-	}
-}
-
-// sendPodEvent sends the eveng to the policy resolver based on the podEntry cached.
-func (m *KubernetesMonitor) sendPodEvent(ctx context.Context, podEntry *podCacheEntry, event common.Event) error {
-	if podEntry.puID == "" {
-		return fmt.Errorf("puID not set yet, container not seen from docker yet")
+	podName, podNamespace, err := getKubernetesInformation(runtime)
+	if err != nil {
+		return err
 	}
 
-	if podEntry.runtime == nil {
-		return fmt.Errorf("runtime not set for podEntry")
-	}
+	podEntry := m.cache.createPodEntry(podNamespace, podName, puID, runtime)
+	podEntry.Lock()
+	defer podEntry.Unlock()
 
-	// In case the pod is not there yet, we query Kubernetes API manually.
 	if podEntry.pod == nil {
 		zap.L().Debug("no pod cached, querying Kubernetes API")
-
-		podName, ok := podEntry.runtime.Tag(KubernetesPodNameIdentifier)
-		if !ok {
-			return fmt.Errorf("Error getting Kubernetes Pod name")
-		}
-		podNamespace, ok := podEntry.runtime.Tag(KubernetesPodNamespaceIdentifier)
-		if !ok {
-			return fmt.Errorf("Error getting Kubernetes Pod namespace")
-		}
 
 		pod, err := m.kubernetesClient.Pod(podName, podNamespace)
 		if err != nil {
@@ -89,16 +41,29 @@ func (m *KubernetesMonitor) sendPodEvent(ctx context.Context, podEntry *podCache
 		podEntry.pod = pod
 	}
 
-	// TODO: Also keep the KubernetesRuntime in cache ? Probably not needed to calculate the consolidatedTags every single time.
 	kubernetesRuntime, managedContainer, err := m.kubernetesExtractor(podEntry.runtime, podEntry.pod)
 	if err != nil {
-		return fmt.Errorf("error while processing Kubernetes pod for container %s %s", podEntry.puID, err)
+		return fmt.Errorf("error while processing Kubernetes pod for container %s %s", puID, err)
 	}
 
-	// We only manage containers marked so from the metadata extractor
 	if !managedContainer {
 		return nil
 	}
 
-	return m.handlers.Policy.HandlePUEvent(ctx, podEntry.puID, event, kubernetesRuntime)
+	return m.handlers.Policy.HandlePUEvent(ctx, puID, event, kubernetesRuntime)
+
+}
+
+// getKubernetesInformation returns the name and namespace from a standard Docker runtime, if the docker container is associated at all with Kubernetes
+func getKubernetesInformation(runtime policy.RuntimeReader) (string, string, error) {
+	podName, ok := runtime.Tag(KubernetesPodNameIdentifier)
+	if !ok {
+		return "", "", fmt.Errorf("Error getting Kubernetes Pod name")
+	}
+	podNamespace, ok := runtime.Tag(KubernetesPodNamespaceIdentifier)
+	if !ok {
+		return "", "", fmt.Errorf("Error getting Kubernetes Pod namespace")
+	}
+
+	return podName, podNamespace, nil
 }

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -9,6 +9,7 @@ import (
 
 // HandlePUEvent is called by all monitors when a PU event is generated. The implementer
 // is responsible to update all components by explicitly adding a new PU.
+// Specifically for Kubernetes, The monitor
 func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, event common.Event, runtime policy.RuntimeReader) error {
 	return nil
 }

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -41,12 +41,9 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 			return fmt.Errorf("Error getting Kubernetes Pod namespace")
 		}
 
-		podEntry := m.cache.getOrCreatePodByKube(podNamespace, podName)
+		podEntry := m.cache.createPodEntry(podNamespace, podName, puID, runtime)
 		podEntry.Lock()
 		defer podEntry.Unlock()
-
-		podEntry.puID = puID
-		podEntry.runtime = runtime
 
 		return m.sendPodEvent(ctx, podEntry, event)
 

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -21,7 +21,7 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 		return nil
 	}
 
-	kubernetesRuntime, err := consolidateKubernetesTags(runtime)
+	kubernetesRuntime, err := m.consolidateKubernetesTags(runtime)
 	if err != nil {
 		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
 	}

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -59,15 +59,7 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 
 // sendPodEvent sends the eveng to the policy resolver based on the podEntry cached.
 func (m *KubernetesMonitor) sendPodEvent(ctx context.Context, podEntry *podCacheEntry, puID string, event common.Event) error {
-	if podEntry.pod == nil {
-		return nil
-	}
-
-	if podEntry.runtime == nil {
-		return nil
-	}
-
-	kubernetesRuntime, err := m.consolidateKubernetesTags(podEntry.runtime)
+	kubernetesRuntime, err := m.consolidateKubernetesTags(podEntry.runtime, podEntry.pod)
 	if err != nil {
 		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
 	}

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -42,7 +42,8 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 		// The KubernetesMetadataExtractor combines the information coming from Docker (runtime)
 		// and from Kube (pod) in order to create a KubernetesRuntime.
 		// The managedContainer parameters define if this container should be ignored.
-		kubernetesRuntime, managedContainer, err := m.kubernetesExtractor(dockerRuntime, pod)
+		var managedContainer bool
+		kubernetesRuntime, managedContainer, err = m.kubernetesExtractor(dockerRuntime, pod)
 		if err != nil {
 			return fmt.Errorf("error while processing Kubernetes pod %s/%s for container %s %s", podNamespace, podName, puID, err)
 		}
@@ -58,7 +59,7 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 	} else {
 
 		// We check if this PUID was previously managed. We only sent the event upstream to the resolver if it was managed on create or start.
-		kubernetesRuntime := m.cache.getKubernetesRuntimeByPUID(puID)
+		kubernetesRuntime = m.cache.getKubernetesRuntimeByPUID(puID)
 		if kubernetesRuntime == nil {
 			zap.L().Debug("unmanaged Kubernetes container", zap.String("puID", puID))
 			return nil

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -1,4 +1,4 @@
-package kubernetes
+package kubernetesmonitor
 
 import (
 	"context"

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aporeto-inc/trireme-lib/common"
 	"github.com/aporeto-inc/trireme-lib/policy"
@@ -9,7 +10,21 @@ import (
 
 // HandlePUEvent is called by all monitors when a PU event is generated. The implementer
 // is responsible to update all components by explicitly adding a new PU.
-// Specifically for Kubernetes, The monitor
+// Specifically for Kubernetes, The monitor handles the downstream events from Docker.
 func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, event common.Event, runtime policy.RuntimeReader) error {
-	return nil
+	process, err := isPodContainer(runtime)
+	if err != nil {
+		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
+	}
+
+	if !process {
+		return nil
+	}
+
+	kubernetesRuntime, err := consolidateKubernetesTags(runtime)
+	if err != nil {
+		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
+	}
+
+	return m.HandlePUEvent(ctx, puID, event, kubernetesRuntime)
 }

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -12,7 +12,7 @@ import (
 // is responsible to update all components by explicitly adding a new PU.
 // Specifically for Kubernetes, The monitor handles the downstream events from Docker.
 func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, event common.Event, runtime policy.RuntimeReader) error {
-	process, err := isPodContainer(runtime)
+	process, err := isPodInfraContainer(runtime)
 	if err != nil {
 		return fmt.Errorf("Error while processing Kubernetes pod %s", err)
 	}

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -1,0 +1,14 @@
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/aporeto-inc/trireme-lib/common"
+	"github.com/aporeto-inc/trireme-lib/policy"
+)
+
+// HandlePUEvent is called by all monitors when a PU event is generated. The implementer
+// is responsible to update all components by explicitly adding a new PU.
+func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, event common.Event, runtime policy.RuntimeReader) error {
+	return nil
+}

--- a/monitor/internal/kubernetes/handler_test.go
+++ b/monitor/internal/kubernetes/handler_test.go
@@ -1,9 +1,16 @@
 package kubernetesmonitor
 
 import (
+	"context"
 	"testing"
 
+	kubernetesclient "github.com/aporeto-inc/trireme-kubernetes/kubernetes"
+	"github.com/aporeto-inc/trireme-lib/common"
+	"github.com/aporeto-inc/trireme-lib/monitor/config"
+	"github.com/aporeto-inc/trireme-lib/monitor/extractors"
+	dockermonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
 	"github.com/aporeto-inc/trireme-lib/policy"
+	kubecache "k8s.io/client-go/tools/cache"
 )
 
 func Test_getKubernetesInformation(t *testing.T) {
@@ -102,6 +109,69 @@ func Test_getKubernetesInformation(t *testing.T) {
 			}
 			if got1 != tt.want1 {
 				t.Errorf("getKubernetesInformation() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestKubernetesMonitor_HandlePUEvent(t *testing.T) {
+	type fields struct {
+		dockerMonitor       *dockermonitor.DockerMonitor
+		kubernetesClient    *kubernetesclient.Client
+		handlers            *config.ProcessorConfig
+		cache               *cache
+		kubernetesExtractor extractors.KubernetesMetadataExtractorType
+		podStore            kubecache.Store
+		podController       kubecache.Controller
+		podControllerStop   chan struct{}
+		enableHostPods      bool
+	}
+	type args struct {
+		ctx           context.Context
+		puID          string
+		event         common.Event
+		dockerRuntime policy.RuntimeReader
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:   "empty dockerruntime on create",
+			fields: fields{},
+			args: args{
+				event:         common.EventCreate,
+				dockerRuntime: policy.NewPURuntimeWithDefaults(),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "empty dockerruntime on start",
+			fields: fields{},
+			args: args{
+				event:         common.EventCreate,
+				dockerRuntime: policy.NewPURuntimeWithDefaults(),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &KubernetesMonitor{
+				dockerMonitor:       tt.fields.dockerMonitor,
+				kubernetesClient:    tt.fields.kubernetesClient,
+				handlers:            tt.fields.handlers,
+				cache:               tt.fields.cache,
+				kubernetesExtractor: tt.fields.kubernetesExtractor,
+				podStore:            tt.fields.podStore,
+				podController:       tt.fields.podController,
+				podControllerStop:   tt.fields.podControllerStop,
+				enableHostPods:      tt.fields.enableHostPods,
+			}
+			if err := m.HandlePUEvent(tt.args.ctx, tt.args.puID, tt.args.event, tt.args.dockerRuntime); (err != nil) != tt.wantErr {
+				t.Errorf("KubernetesMonitor.HandlePUEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/monitor/internal/kubernetes/handler_test.go
+++ b/monitor/internal/kubernetes/handler_test.go
@@ -1,0 +1,108 @@
+package kubernetesmonitor
+
+import (
+	"testing"
+
+	"github.com/aporeto-inc/trireme-lib/policy"
+)
+
+func Test_getKubernetesInformation(t *testing.T) {
+
+	puRuntimeWithTags := func(tags map[string]string) *policy.PURuntime {
+		puRuntime := policy.NewPURuntimeWithDefaults()
+		puRuntime.SetTags(policy.NewTagStoreFromMap(tags))
+		return puRuntime
+	}
+
+	type args struct {
+		runtime policy.RuntimeReader
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		wantErr bool
+	}{
+		{
+			name:    "no Kubernetes Information",
+			args:    args{runtime: policy.NewPURuntimeWithDefaults()},
+			want:    "",
+			want1:   "",
+			wantErr: true,
+		},
+		{
+			name: "both present",
+			args: args{runtime: puRuntimeWithTags(map[string]string{
+				KubernetesPodNamespaceIdentifier: "a",
+				KubernetesPodNameIdentifier:      "b",
+			},
+			),
+			},
+			want:    "a",
+			want1:   "b",
+			wantErr: false,
+		},
+		{
+			name: "both present. NamespaceIdentifier empty",
+			args: args{runtime: puRuntimeWithTags(map[string]string{
+				KubernetesPodNamespaceIdentifier: "",
+				KubernetesPodNameIdentifier:      "b",
+			},
+			),
+			},
+			want:    "",
+			want1:   "b",
+			wantErr: false,
+		},
+		{
+			name: "both present. Name empty",
+			args: args{runtime: puRuntimeWithTags(map[string]string{
+				KubernetesPodNamespaceIdentifier: "a",
+				KubernetesPodNameIdentifier:      "",
+			},
+			),
+			},
+			want:    "a",
+			want1:   "",
+			wantErr: false,
+		},
+		{
+			name: "Namespace missing",
+			args: args{runtime: puRuntimeWithTags(map[string]string{
+				KubernetesPodNameIdentifier: "b",
+			},
+			),
+			},
+			want:    "",
+			want1:   "",
+			wantErr: true,
+		},
+		{
+			name: "Name missing",
+			args: args{runtime: puRuntimeWithTags(map[string]string{
+				KubernetesPodNamespaceIdentifier: "a",
+			},
+			),
+			},
+			want:    "",
+			want1:   "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := getKubernetesInformation(tt.args.runtime)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getKubernetesInformation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getKubernetesInformation() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("getKubernetesInformation() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/monitor/internal/kubernetes/handler_test.go
+++ b/monitor/internal/kubernetes/handler_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
-	kubernetesclient "github.com/aporeto-inc/trireme-kubernetes/kubernetes"
 	"github.com/aporeto-inc/trireme-lib/common"
 	"github.com/aporeto-inc/trireme-lib/monitor/config"
 	"github.com/aporeto-inc/trireme-lib/monitor/extractors"
 	dockermonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
 	"github.com/aporeto-inc/trireme-lib/policy"
 	api "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	kubecache "k8s.io/client-go/tools/cache"
 )
 
@@ -118,7 +118,8 @@ func Test_getKubernetesInformation(t *testing.T) {
 func TestKubernetesMonitor_HandlePUEvent(t *testing.T) {
 	type fields struct {
 		dockerMonitor       *dockermonitor.DockerMonitor
-		kubernetesClient    *kubernetesclient.Client
+		kubeClient          kubernetes.Interface
+		localNode           string
 		handlers            *config.ProcessorConfig
 		cache               *cache
 		kubernetesExtractor extractors.KubernetesMetadataExtractorType
@@ -162,7 +163,8 @@ func TestKubernetesMonitor_HandlePUEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &KubernetesMonitor{
 				dockerMonitor:       tt.fields.dockerMonitor,
-				kubernetesClient:    tt.fields.kubernetesClient,
+				kubeClient:          tt.fields.kubeClient,
+				localNode:           tt.fields.localNode,
 				handlers:            tt.fields.handlers,
 				cache:               tt.fields.cache,
 				kubernetesExtractor: tt.fields.kubernetesExtractor,
@@ -181,7 +183,8 @@ func TestKubernetesMonitor_HandlePUEvent(t *testing.T) {
 func TestKubernetesMonitor_RefreshPUs(t *testing.T) {
 	type fields struct {
 		dockerMonitor       *dockermonitor.DockerMonitor
-		kubernetesClient    *kubernetesclient.Client
+		kubeClient          kubernetes.Interface
+		localNode           string
 		handlers            *config.ProcessorConfig
 		cache               *cache
 		kubernetesExtractor extractors.KubernetesMetadataExtractorType
@@ -213,7 +216,8 @@ func TestKubernetesMonitor_RefreshPUs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &KubernetesMonitor{
 				dockerMonitor:       tt.fields.dockerMonitor,
-				kubernetesClient:    tt.fields.kubernetesClient,
+				kubeClient:          tt.fields.kubeClient,
+				localNode:           tt.fields.localNode,
 				handlers:            tt.fields.handlers,
 				cache:               tt.fields.cache,
 				kubernetesExtractor: tt.fields.kubernetesExtractor,

--- a/monitor/internal/kubernetes/handler_test.go
+++ b/monitor/internal/kubernetes/handler_test.go
@@ -250,6 +250,22 @@ func TestKubernetesMonitor_HandlePUEvent(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Destroy not in cache",
+			fields: fields{
+				kubeClient:          kubefake.NewSimpleClientset(pod1),
+				kubernetesExtractor: kubernetesExtractorManaged,
+				cache:               newCache(),
+				handlers: &config.ProcessorConfig{
+					Policy: &mockHandler{},
+				},
+			},
+			args: args{
+				event:         common.EventDestroy,
+				dockerRuntime: pod1Runtime,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,0 +1,1 @@
+package kubernetes

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -59,12 +59,12 @@ func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeRead
 	}
 
 	// If Pod is running in the hostNS, no activation (not supported).
-	if pod.Status.PodIP == pod.Status.HostIP {
-		zap.L().Debug("pod running in host mode.")
-		if !m.EnableHostPods {
-			return nil, nil
-		}
-	}
+	// if pod.Status.PodIP == pod.Status.HostIP {
+	// 	zap.L().Debug("pod running in host mode.")
+	// 	if !m.EnableHostPods {
+	// 		return nil, nil
+	// 	}
+	// }
 
 	podLabels := pod.GetLabels()
 	if podLabels == nil {
@@ -99,7 +99,7 @@ func (m *KubernetesMonitor) addPod(addedPod *api.Pod) error {
 	// This event is not needed as the trigger is the  DockerMonitor event
 	// The pod obejct is cached in order to reuse it and avoid an API request possibly laster on
 
-	podEntry := m.cache.getOrCreatePodFromCache(addedPod.GetNamespace(), addedPod.GetName())
+	podEntry := m.cache.getOrCreatePodByKube(addedPod.GetNamespace(), addedPod.GetName())
 	podEntry.Lock()
 	defer podEntry.Unlock()
 
@@ -123,11 +123,12 @@ func (m *KubernetesMonitor) updatePod(oldPod, updatedPod *api.Pod) error {
 	}
 
 	// This event requires sending the Runtime upstream again.
-	podEntry := m.cache.getOrCreatePodFromCache(updatedPod.GetNamespace(), updatedPod.GetName())
+	podEntry := m.cache.getOrCreatePodByKube(updatedPod.GetNamespace(), updatedPod.GetName())
 	podEntry.Lock()
 	defer podEntry.Unlock()
 
 	podEntry.pod = updatedPod
+
 	return m.sendPodEvent(context.TODO(), podEntry, common.EventUpdate)
 }
 

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,1 +1,11 @@
 package kubernetes
+
+import "github.com/aporeto-inc/trireme-lib/policy"
+
+func isPodContainer(runtime policy.RuntimeReader) (bool, error) {
+	return true, nil
+}
+
+func consolidateKubernetesTags(runtime policy.RuntimeReader) (*policy.PURuntime, error) {
+	return nil, nil
+}

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -2,10 +2,12 @@ package kubernetes
 
 import "github.com/aporeto-inc/trireme-lib/policy"
 
-func isPodContainer(runtime policy.RuntimeReader) (bool, error) {
-	return true, nil
+func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeReader) (*policy.PURuntime, error) {
+	return nil, nil
+
+	m.kubernetesClient.PodLabels()
 }
 
-func consolidateKubernetesTags(runtime policy.RuntimeReader) (*policy.PURuntime, error) {
-	return nil, nil
+func isPodContainer(runtime policy.RuntimeReader) (bool, error) {
+	return true, nil
 }

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -61,6 +61,13 @@ func (m *KubernetesMonitor) updatePod(oldPod, updatedPod *api.Pod) error {
 	return nil
 }
 
+func (m *KubernetesMonitor) getPod(podNamespace, podName string) (*api.Pod, error) {
+	zap.L().Debug("no pod cached, querying Kubernetes API")
+
+	// TODO: Use cached Kube Store ?
+	return m.kubernetesClient.Pod(podName, podNamespace)
+}
+
 func isPolicyUpdateNeeded(oldPod, newPod *api.Pod) bool {
 	if !(oldPod.Status.PodIP == newPod.Status.PodIP) {
 		return true

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,11 +1,8 @@
 package kubernetesmonitor
 
 import (
-	"context"
 	"fmt"
 	"time"
-
-	"github.com/aporeto-inc/trireme-lib/common"
 
 	"go.uber.org/zap"
 	api "k8s.io/api/core/v1"
@@ -65,7 +62,8 @@ func (m *KubernetesMonitor) updatePod(oldPod, updatedPod *api.Pod) error {
 		return fmt.Errorf("error updating cache entry %s", err)
 	}
 
-	return m.sendPodEvent(context.TODO(), podEntry, common.EventUpdate)
+	// TODO: Update all dependent Dockers
+	return nil
 }
 
 func isPolicyUpdateNeeded(oldPod, newPod *api.Pod) bool {

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -2,10 +2,8 @@ package kubernetes
 
 import "github.com/aporeto-inc/trireme-lib/policy"
 
-func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeReader) (*policy.PURuntime, error) {
-	return nil, nil
-
-	m.kubernetesClient.PodLabels()
+func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeReader) (policy.RuntimeReader, error) {
+	return runtime, nil
 }
 
 func isPodContainer(runtime policy.RuntimeReader) (bool, error) {

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -72,9 +72,6 @@ func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeRead
 		return nil, nil
 	}
 
-	// TODO: Remove this before merging
-	fmt.Printf("\n\n Tags before: %v \n\n", runtime.Tags())
-
 	tags := policy.NewTagStoreFromMap(podLabels)
 	tags.AppendKeyValue(UpstreamNameIdentifier, pod.GetName())
 	tags.AppendKeyValue(UpstreamNamespaceIdentifier, pod.GetNamespace())
@@ -87,8 +84,7 @@ func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeRead
 	newRuntime := originalRuntime.Clone()
 	newRuntime.SetTags(tags)
 
-	// TODO: Remove this before merging
-	fmt.Printf("\n\n Tags after: %v \n\n", newRuntime.Tags())
+	zap.L().Debug("kubernetes runtime tags", zap.String("name", pod.GetName()), zap.String("namespace", pod.GetNamespace()), zap.Strings("tags", newRuntime.Tags().GetSlice()))
 
 	return newRuntime, nil
 }

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/aporeto-inc/trireme-lib/common"
-
 	"github.com/aporeto-inc/trireme-lib/policy"
+
 	"go.uber.org/zap"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -134,17 +134,6 @@ func isPolicyUpdateNeeded(oldPod, newPod *api.Pod) bool {
 		return true
 	}
 	return false
-}
-
-// isPodInfraContainer returns true if the runtime represents the infra container for the POD
-func isPodInfraContainer(runtime policy.RuntimeReader) (bool, error) {
-	// The Infra container can be found by checking env. variable.
-	tagContent, ok := runtime.Tag(KubernetesContainerNameIdentifier)
-	if !ok || tagContent != KubernetesInfraContainerName {
-		return false, nil
-	}
-
-	return true, nil
 }
 
 // hasSynced sends an event on the Sync chan when the attachedController finished syncing.

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -46,7 +46,9 @@ func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeRead
 	}
 	// If Pod is running in the hostNS, no activation (not supported).
 	if pod.Status.PodIP == pod.Status.HostIP {
-		return nil, nil
+		if !m.EnableHostPods {
+			return nil, nil
+		}
 	}
 
 	podLabels := pod.GetLabels()

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -65,7 +65,7 @@ func (m *KubernetesMonitor) getPod(podNamespace, podName string) (*api.Pod, erro
 	zap.L().Debug("no pod cached, querying Kubernetes API")
 
 	// TODO: Use cached Kube Store ?
-	return m.kubernetesClient.Pod(podName, podNamespace)
+	return m.Pod(podName, podNamespace)
 }
 
 func isPolicyUpdateNeeded(oldPod, newPod *api.Pod) bool {

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,11 +1,32 @@
 package kubernetes
 
-import "github.com/aporeto-inc/trireme-lib/policy"
+import (
+	"github.com/aporeto-inc/trireme-lib/policy"
+)
+
+// KubernetesPodNameIdentifier is the label used by Docker for the K8S pod name.
+const KubernetesPodNameIdentifier = "@usr:io.kubernetes.pod.name"
+
+// KubernetesPodNamespaceIdentifier is the label used by Docker for the K8S namespace.
+const KubernetesPodNamespaceIdentifier = "@usr:io.kubernetes.pod.namespace"
+
+// KubernetesContainerNameIdentifier is the label used by Docker for the K8S container name.
+const KubernetesContainerNameIdentifier = "@usr:io.kubernetes.container.name"
+
+// KubernetesInfraContainerName is the name of the infra POD.
+const KubernetesInfraContainerName = "POD"
 
 func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeReader) (policy.RuntimeReader, error) {
 	return runtime, nil
 }
 
-func isPodContainer(runtime policy.RuntimeReader) (bool, error) {
+// isPodInfraContainer returns true if the runtime represents the infra container for the POD
+func isPodInfraContainer(runtime policy.RuntimeReader) (bool, error) {
+	// The Infra container can be found by checking env. variable.
+	tagContent, ok := runtime.Tag(KubernetesContainerNameIdentifier)
+	if !ok || tagContent != KubernetesInfraContainerName {
+		return false, nil
+	}
+
 	return true, nil
 }

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -34,11 +34,6 @@ func (m *KubernetesMonitor) addPod(addedPod *api.Pod) error {
 	// This event is not needed as the trigger is the  DockerMonitor event
 	// The pod obejct is cached in order to reuse it and avoid an API request possibly laster on
 
-	// _, err := m.cache.updatePodEntry(addedPod.GetNamespace(), addedPod.GetName(), addedPod)
-	// if err != nil {
-	//	return fmt.Errorf("error updating cache entry %s", err)
-	//}
-
 	return nil
 }
 
@@ -64,7 +59,7 @@ func (m *KubernetesMonitor) updatePod(oldPod, updatedPod *api.Pod) error {
 func (m *KubernetesMonitor) getPod(podNamespace, podName string) (*api.Pod, error) {
 	zap.L().Debug("no pod cached, querying Kubernetes API")
 
-	// TODO: Use cached Kube Store ?
+	// TODO: Use cached Kube Store (from a shared informer)
 	return m.Pod(podName, podNamespace)
 }
 

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,6 +1,7 @@
 package kubernetesmonitor
 
 import (
+	"context"
 	"time"
 
 	"go.uber.org/zap"
@@ -56,9 +57,8 @@ func (m *KubernetesMonitor) updatePod(oldPod, updatedPod *api.Pod) error {
 	}
 
 	// This event requires sending the Runtime upstream again.
-
-	// TODO: Update all dependent Dockers
-	return nil
+	// TODO: Use propagated context
+	return m.RefreshPUs(context.TODO(), updatedPod)
 }
 
 func (m *KubernetesMonitor) getPod(podNamespace, podName string) (*api.Pod, error) {

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -80,7 +80,7 @@ func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeRead
 }
 
 func (m *KubernetesMonitor) addPod(addedPod *api.Pod) error {
-	zap.L().Debug("Pod Added", zap.String("name", addedPod.GetName()), zap.String("namespace", addedPod.GetNamespace()))
+	zap.L().Debug("pod added event", zap.String("name", addedPod.GetName()), zap.String("namespace", addedPod.GetNamespace()))
 
 	podEntry := m.cache.getOrCreatePodFromCache(addedPod.GetNamespace(), addedPod.GetName())
 	podEntry.Lock()
@@ -95,16 +95,16 @@ func (m *KubernetesMonitor) addPod(addedPod *api.Pod) error {
 }
 
 func (m *KubernetesMonitor) deletePod(deletedPod *api.Pod) error {
-	zap.L().Debug("Pod Deleted", zap.String("name", deletedPod.GetName()), zap.String("namespace", deletedPod.GetNamespace()))
+	zap.L().Debug("pod deleted event", zap.String("name", deletedPod.GetName()), zap.String("namespace", deletedPod.GetNamespace()))
 
 	return nil
 }
 
 func (m *KubernetesMonitor) updatePod(oldPod, updatedPod *api.Pod) error {
-	zap.L().Debug("Pod Modified detected", zap.String("name", updatedPod.GetName()), zap.String("namespace", updatedPod.GetNamespace()))
+	zap.L().Debug("pod modified event", zap.String("name", updatedPod.GetName()), zap.String("namespace", updatedPod.GetNamespace()))
 
 	if !isPolicyUpdateNeeded(oldPod, updatedPod) {
-		zap.L().Debug("No modified labels for Pod", zap.String("name", updatedPod.GetName()), zap.String("namespace", updatedPod.GetNamespace()))
+		zap.L().Debug("no modified labels for Pod", zap.String("name", updatedPod.GetName()), zap.String("namespace", updatedPod.GetNamespace()))
 		return nil
 	}
 

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,7 +1,6 @@
 package kubernetesmonitor
 
 import (
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -34,10 +33,10 @@ func (m *KubernetesMonitor) addPod(addedPod *api.Pod) error {
 	// This event is not needed as the trigger is the  DockerMonitor event
 	// The pod obejct is cached in order to reuse it and avoid an API request possibly laster on
 
-	_, err := m.cache.updatePodEntry(addedPod.GetNamespace(), addedPod.GetName(), addedPod)
-	if err != nil {
-		return fmt.Errorf("error updating cache entry %s", err)
-	}
+	// _, err := m.cache.updatePodEntry(addedPod.GetNamespace(), addedPod.GetName(), addedPod)
+	// if err != nil {
+	//	return fmt.Errorf("error updating cache entry %s", err)
+	//}
 
 	return nil
 }
@@ -57,10 +56,6 @@ func (m *KubernetesMonitor) updatePod(oldPod, updatedPod *api.Pod) error {
 	}
 
 	// This event requires sending the Runtime upstream again.
-	podEntry, err := m.cache.updatePodEntry(updatedPod.GetNamespace(), updatedPod.GetName(), updatedPod)
-	if err != nil {
-		return fmt.Errorf("error updating cache entry %s", err)
-	}
 
 	// TODO: Update all dependent Dockers
 	return nil

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -82,6 +82,15 @@ func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeRead
 func (m *KubernetesMonitor) addPod(addedPod *api.Pod) error {
 	zap.L().Debug("Pod Added", zap.String("name", addedPod.GetName()), zap.String("namespace", addedPod.GetNamespace()))
 
+	podEntry := m.cache.getOrCreatePodFromCache(addedPod.GetNamespace(), addedPod.GetName())
+	podEntry.Lock()
+	defer podEntry.Unlock()
+
+	podEntry.pod = addedPod
+	if podEntry.runtime != nil {
+		// Both runtime and Pods are here, activate
+	}
+
 	return nil
 }
 

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,4 +1,4 @@
-package kubernetes
+package kubernetesmonitor
 
 import (
 	"github.com/aporeto-inc/trireme-lib/policy"

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -1,6 +1,8 @@
 package kubernetesmonitor
 
 import (
+	"fmt"
+
 	"github.com/aporeto-inc/trireme-lib/policy"
 )
 
@@ -16,8 +18,58 @@ const KubernetesContainerNameIdentifier = "@usr:io.kubernetes.container.name"
 // KubernetesInfraContainerName is the name of the infra POD.
 const KubernetesInfraContainerName = "POD"
 
-func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeReader) (policy.RuntimeReader, error) {
-	return runtime, nil
+// UpstreamNameIdentifier is the identifier used to identify the nane on the resulting PU
+const UpstreamNameIdentifier = "k8s:name"
+
+// UpstreamNamespaceIdentifier is the identifier used to identify the nanespace on the resulting PU
+const UpstreamNamespaceIdentifier = "k8s:namespace"
+
+func (m *KubernetesMonitor) consolidateKubernetesTags(runtime policy.RuntimeReader) (*policy.PURuntime, error) {
+
+	podName, ok := runtime.Tag(KubernetesPodNameIdentifier)
+	if !ok {
+		return nil, fmt.Errorf("Error getting Kubernetes Pod name")
+	}
+	podNamespace, ok := runtime.Tag(KubernetesPodNamespaceIdentifier)
+	if !ok {
+		return nil, fmt.Errorf("Error getting Kubernetes Pod namespace")
+	}
+
+	pod, err := m.kubernetesClient.Pod(podName, podNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get labels for pod %s : %v", podName, err)
+	}
+
+	// If IP is empty, wait for an UpdatePodEvent with the Actual PodIP. Not ready to be activated now.
+	if pod.Status.PodIP == "" {
+		return nil, nil
+	}
+	// If Pod is running in the hostNS, no activation (not supported).
+	if pod.Status.PodIP == pod.Status.HostIP {
+		return nil, nil
+	}
+
+	podLabels := pod.GetLabels()
+	if podLabels == nil {
+		return nil, nil
+	}
+	fmt.Printf("\n\n Tags before: %v \n\n", runtime.Tags())
+
+	tags := policy.NewTagStoreFromMap(podLabels)
+	tags.AppendKeyValue(UpstreamNameIdentifier, podName)
+	tags.AppendKeyValue(UpstreamNamespaceIdentifier, podNamespace)
+
+	originalRuntime, ok := runtime.(*policy.PURuntime)
+	if !ok {
+		return nil, fmt.Errorf("Error casting puruntime")
+	}
+
+	newRuntime := originalRuntime.Clone()
+	newRuntime.SetTags(tags)
+
+	fmt.Printf("\n\n Tags after: %v \n\n", newRuntime.Tags())
+
+	return newRuntime, nil
 }
 
 // isPodInfraContainer returns true if the runtime represents the infra container for the POD

--- a/monitor/internal/kubernetes/kubernetes.go
+++ b/monitor/internal/kubernetes/kubernetes.go
@@ -2,11 +2,13 @@ package kubernetesmonitor
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aporeto-inc/trireme-lib/policy"
 	"go.uber.org/zap"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	kubecache "k8s.io/client-go/tools/cache"
 )
 
 // KubernetesPodNameIdentifier is the label used by Docker for the K8S pod name.
@@ -119,4 +121,15 @@ func isPodInfraContainer(runtime policy.RuntimeReader) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// hasSynced sends an event on the Sync chan when the attachedController finished syncing.
+func hasSynced(sync chan struct{}, controller kubecache.Controller) {
+	for true {
+		if controller.HasSynced() {
+			sync <- struct{}{}
+			return
+		}
+		<-time.After(100 * time.Millisecond)
+	}
 }

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -74,6 +74,10 @@ func (m *KubernetesMonitor) SetupConfig(registerer registerer.Registerer, cfg in
 
 // Run starts the monitor.
 func (m *KubernetesMonitor) Run(ctx context.Context) error {
+	if m.kubernetesClient == nil {
+		return fmt.Errorf("kubernetes client is not initialized correctly")
+	}
+
 	return m.dockerMonitor.Run(ctx)
 }
 
@@ -92,12 +96,11 @@ func (m *KubernetesMonitor) SetupHandlers(c *config.ProcessorConfig) {
 
 // Resync requests to the monitor to do a resync.
 func (m *KubernetesMonitor) Resync(ctx context.Context) error {
-	// TODO: implement this
+	// TODO: Redifine this interface ?
 	return nil
 }
 
 // ReSync ???
 func (m *KubernetesMonitor) ReSync(ctx context.Context) error {
-	// TODO: implement this
-	return nil
+	m.dockerMonitor.ReSync(ctx)
 }

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -1,0 +1,68 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aporeto-inc/trireme-lib/monitor/config"
+	"github.com/aporeto-inc/trireme-lib/monitor/registerer"
+
+	dockermonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
+)
+
+// KubernetesMonitor implements a monitor that sends pod events upstream
+type KubernetesMonitor struct {
+	dockerMonitor *dockermonitor.DockerMonitor
+}
+
+// New returns a new kubernetes monitor.
+func New() *KubernetesMonitor {
+	kubeMonitor := &KubernetesMonitor{}
+
+	return kubeMonitor
+}
+
+// SetupConfig provides a configuration to implmentations. Every implmentation
+// can have its own config type.
+func (m *KubernetesMonitor) SetupConfig(registerer registerer.Registerer, cfg interface{}) error {
+	processorConfig := &config.ProcessorConfig{
+		Policy: m,
+	}
+
+	// As the Kubernetes monitor depends on the DockerMonitor, we setup the Docker monitor first
+	dockerMon := dockermonitor.New()
+	dockerMon.SetupHandlers(processorConfig)
+
+	// we use the defaultconfig for now
+	if err := dockerMon.SetupConfig(nil, nil); err != nil {
+		return fmt.Errorf("DockerMonitor instantiation error: %s", err.Error())
+	}
+
+	m.dockerMonitor = dockerMon
+
+	return nil
+}
+
+// Run starts the monitor.
+func (m *KubernetesMonitor) Run(ctx context.Context) error {
+	return m.dockerMonitor.Run(ctx)
+}
+
+// UpdateConfiguration updates the configuration of the monitor
+func (m *KubernetesMonitor) UpdateConfiguration(ctx context.Context, config *config.MonitorConfig) error {
+	// TODO: implement this
+	return nil
+}
+
+// SetupHandlers sets up handlers for monitors to invoke for various events such as
+// processing unit events and synchronization events. This will be called before Start()
+// by the consumer of the monitor
+func (m *KubernetesMonitor) SetupHandlers(c *config.ProcessorConfig) {
+	// TODO: implement this
+}
+
+// Resync requests to the monitor to do a resync.
+func (m *KubernetesMonitor) Resync(ctx context.Context) error {
+	// TODO: implement this
+	return nil
+}

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -72,3 +72,9 @@ func (m *KubernetesMonitor) Resync(ctx context.Context) error {
 	// TODO: implement this
 	return nil
 }
+
+// ReSync ???
+func (m *KubernetesMonitor) ReSync(ctx context.Context) error {
+	// TODO: implement this
+	return nil
+}

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -8,6 +8,7 @@ import (
 	kubecache "k8s.io/client-go/tools/cache"
 
 	"github.com/aporeto-inc/trireme-lib/collector"
+	"github.com/aporeto-inc/trireme-lib/monitor/extractors"
 
 	"github.com/aporeto-inc/trireme-lib/monitor/config"
 	"github.com/aporeto-inc/trireme-lib/monitor/registerer"
@@ -21,10 +22,11 @@ import (
 // It gets all the PU events from the DockerMonitor and if the container is the POD container from Kubernetes,
 // It connects to the Kubernetes API and adds the tags that are coming from Kuberntes that cannot be found
 type KubernetesMonitor struct {
-	dockerMonitor    *dockermonitor.DockerMonitor
-	kubernetesClient *kubernetesclient.Client
-	handlers         *config.ProcessorConfig
-	cache            *cache
+	dockerMonitor     *dockermonitor.DockerMonitor
+	kubernetesClient  *kubernetesclient.Client
+	handlers          *config.ProcessorConfig
+	cache             *cache
+	metadataExtractor extractors.KubernetesMetadataExtractorType
 
 	podStore          kubecache.Store
 	podController     kubecache.Controller

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -21,6 +21,7 @@ type KubernetesMonitor struct {
 	dockerMonitor    *dockermonitor.DockerMonitor
 	kubernetesClient *kubernetesclient.Client
 	handlers         *config.ProcessorConfig
+	cache            *cache
 
 	EnableHostPods bool
 }
@@ -28,6 +29,9 @@ type KubernetesMonitor struct {
 // New returns a new kubernetes monitor.
 func New() *KubernetesMonitor {
 	kubeMonitor := &KubernetesMonitor{}
+	kubeMonitor.cache = &cache{
+		podCache: map[string]*podCacheEntry{},
+	}
 
 	return kubeMonitor
 }

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aporeto-inc/trireme-lib/collector"
+
 	"github.com/aporeto-inc/trireme-lib/monitor/config"
 	"github.com/aporeto-inc/trireme-lib/monitor/registerer"
 
@@ -46,7 +48,8 @@ func (m *KubernetesMonitor) SetupConfig(registerer registerer.Registerer, cfg in
 	kubernetesconfig = SetupDefaultConfig(kubernetesconfig)
 
 	processorConfig := &config.ProcessorConfig{
-		Policy: m,
+		Policy:    m,
+		Collector: collector.NewDefaultCollector(),
 	}
 
 	// As the Kubernetes monitor depends on the DockerMonitor, we setup the Docker monitor first

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -7,12 +7,18 @@ import (
 	"github.com/aporeto-inc/trireme-lib/monitor/config"
 	"github.com/aporeto-inc/trireme-lib/monitor/registerer"
 
+	kubernetesclient "github.com/aporeto-inc/trireme-kubernetes/kubernetes"
 	dockermonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
 )
 
 // KubernetesMonitor implements a monitor that sends pod events upstream
+// It is implemented as a filter on the standard DockerMonitor.
+// It gets all the PU events from the DockerMonitor and if the container is the POD container from Kubernetes,
+// It connects to the Kubernetes API and adds the tags that are coming from Kuberntes that cannot be found
 type KubernetesMonitor struct {
-	dockerMonitor *dockermonitor.DockerMonitor
+	dockerMonitor    *dockermonitor.DockerMonitor
+	kubernetesClient *kubernetesclient.Client
+	handlers         *config.ProcessorConfig
 }
 
 // New returns a new kubernetes monitor.
@@ -58,7 +64,7 @@ func (m *KubernetesMonitor) UpdateConfiguration(ctx context.Context, config *con
 // processing unit events and synchronization events. This will be called before Start()
 // by the consumer of the monitor
 func (m *KubernetesMonitor) SetupHandlers(c *config.ProcessorConfig) {
-	// TODO: implement this
+	m.handlers = c
 }
 
 // Resync requests to the monitor to do a resync.

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -117,12 +117,6 @@ func (m *KubernetesMonitor) Run(ctx context.Context) error {
 	return m.dockerMonitor.Run(ctx)
 }
 
-// UpdateConfiguration updates the configuration of the monitor
-func (m *KubernetesMonitor) UpdateConfiguration(ctx context.Context, config *config.MonitorConfig) error {
-	// TODO: implement this
-	return nil
-}
-
 // SetupHandlers sets up handlers for monitors to invoke for various events such as
 // processing unit events and synchronization events. This will be called before Start()
 // by the consumer of the monitor
@@ -132,11 +126,5 @@ func (m *KubernetesMonitor) SetupHandlers(c *config.ProcessorConfig) {
 
 // Resync requests to the monitor to do a resync.
 func (m *KubernetesMonitor) Resync(ctx context.Context) error {
-	// TODO: Redefine this interface ?
-	return nil
-}
-
-// ReSync ???
-func (m *KubernetesMonitor) ReSync(ctx context.Context) error {
-	return m.dockerMonitor.ReSync(ctx)
+	return m.dockerMonitor.Resync(ctx)
 }

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -109,7 +109,8 @@ func (m *KubernetesMonitor) Run(ctx context.Context) error {
 		return fmt.Errorf("kubernetes client is not initialized correctly")
 	}
 
-	go m.podController.Run(m.podControllerStop)
+	// TODO. Give directly the channel to the Kubernetes library
+	go m.podController.Run(ctx.Done())
 	initialPodSync := make(chan struct{})
 	go hasSynced(initialPodSync, m.podController)
 	<-initialPodSync

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -132,7 +132,7 @@ func (m *KubernetesMonitor) SetupHandlers(c *config.ProcessorConfig) {
 
 // Resync requests to the monitor to do a resync.
 func (m *KubernetesMonitor) Resync(ctx context.Context) error {
-	// TODO: Redifine this interface ?
+	// TODO: Redefine this interface ?
 	return nil
 }
 

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -21,6 +21,8 @@ type KubernetesMonitor struct {
 	dockerMonitor    *dockermonitor.DockerMonitor
 	kubernetesClient *kubernetesclient.Client
 	handlers         *config.ProcessorConfig
+
+	EnableHostPods bool
 }
 
 // New returns a new kubernetes monitor.
@@ -68,6 +70,7 @@ func (m *KubernetesMonitor) SetupConfig(registerer registerer.Registerer, cfg in
 		return fmt.Errorf("kubernetes client instantiation error: %s", err.Error())
 	}
 	m.kubernetesClient = kubernetesClient
+	m.EnableHostPods = kubernetesconfig.EnableHostPods
 
 	return nil
 }

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -1,4 +1,4 @@
-package kubernetes
+package kubernetesmonitor
 
 import (
 	"context"

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -36,9 +36,7 @@ type KubernetesMonitor struct {
 // New returns a new kubernetes monitor.
 func New() *KubernetesMonitor {
 	kubeMonitor := &KubernetesMonitor{}
-	kubeMonitor.cache = &cache{
-		podCache: map[string]*podCacheEntry{},
-	}
+	kubeMonitor.cache = newCache()
 
 	return kubeMonitor
 }

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -91,7 +91,7 @@ func (m *KubernetesMonitor) SetupConfig(registerer registerer.Registerer, cfg in
 	m.enableHostPods = kubernetesconfig.EnableHostPods
 	m.kubernetesExtractor = kubernetesconfig.KubernetesExtractor
 
-	m.podStore, m.podController = m.kubernetesClient.CreateLocalPodController("",
+	m.podStore, m.podController = m.CreateLocalPodController("",
 		m.addPod,
 		m.deletePod,
 		m.updatePod)

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -102,5 +102,5 @@ func (m *KubernetesMonitor) Resync(ctx context.Context) error {
 
 // ReSync ???
 func (m *KubernetesMonitor) ReSync(ctx context.Context) error {
-	m.dockerMonitor.ReSync(ctx)
+	return m.dockerMonitor.ReSync(ctx)
 }

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -82,6 +82,7 @@ func (m *KubernetesMonitor) SetupConfig(registerer registerer.Registerer, cfg in
 	}
 	m.kubernetesClient = kubernetesClient
 	m.EnableHostPods = kubernetesconfig.EnableHostPods
+	m.metadataExtractor = kubernetesconfig.EventMetadataExtractor
 
 	m.podStore, m.podController = m.kubernetesClient.CreateLocalPodController("",
 		m.addPod,

--- a/monitor/internal/kubernetes/monitor_test.go
+++ b/monitor/internal/kubernetes/monitor_test.go
@@ -1,0 +1,72 @@
+package kubernetesmonitor
+
+import (
+	"testing"
+
+	"github.com/aporeto-inc/trireme-lib/monitor/config"
+	"github.com/aporeto-inc/trireme-lib/monitor/extractors"
+	dockermonitor "github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
+	"github.com/aporeto-inc/trireme-lib/monitor/registerer"
+	"k8s.io/client-go/kubernetes"
+	kubecache "k8s.io/client-go/tools/cache"
+)
+
+func TestKubernetesMonitor_SetupConfig(t *testing.T) {
+	configkube := &Config{ //nolint
+		Kubeconfig:     "123", //nolint
+		Nodename:       "123", //nolint
+		EnableHostPods: true,  //nolint
+	} //nolint
+
+	type fields struct {
+		dockerMonitor       *dockermonitor.DockerMonitor
+		kubeClient          kubernetes.Interface
+		localNode           string
+		handlers            *config.ProcessorConfig
+		cache               *cache
+		kubernetesExtractor extractors.KubernetesMetadataExtractorType
+		podStore            kubecache.Store
+		podController       kubecache.Controller
+		podControllerStop   chan struct{}
+		enableHostPods      bool
+	}
+	type args struct {
+		registerer registerer.Registerer
+		cfg        interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:   "random config",
+			fields: fields{},
+			args: args{
+				registerer: nil,
+				cfg:        "123",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &KubernetesMonitor{
+				dockerMonitor:       tt.fields.dockerMonitor,
+				kubeClient:          tt.fields.kubeClient,
+				localNode:           tt.fields.localNode,
+				handlers:            tt.fields.handlers,
+				cache:               tt.fields.cache,
+				kubernetesExtractor: tt.fields.kubernetesExtractor,
+				podStore:            tt.fields.podStore,
+				podController:       tt.fields.podController,
+				podControllerStop:   tt.fields.podControllerStop,
+				enableHostPods:      tt.fields.enableHostPods,
+			}
+			if err := m.SetupConfig(tt.args.registerer, tt.args.cfg); (err != nil) != tt.wantErr {
+				t.Errorf("KubernetesMonitor.SetupConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/monitor/internal/kubernetes/monitor_test.go
+++ b/monitor/internal/kubernetes/monitor_test.go
@@ -12,11 +12,6 @@ import (
 )
 
 func TestKubernetesMonitor_SetupConfig(t *testing.T) {
-	configkube := &Config{ //nolint
-		Kubeconfig:     "123", //nolint
-		Nodename:       "123", //nolint
-		EnableHostPods: true,  //nolint
-	} //nolint
 
 	type fields struct {
 		dockerMonitor       *dockermonitor.DockerMonitor

--- a/monitor/internal/linux/monitor.go
+++ b/monitor/internal/linux/monitor.go
@@ -85,8 +85,7 @@ func (l *LinuxMonitor) SetupHandlers(m *config.ProcessorConfig) {
 	l.proc.config = m
 }
 
-// ReSync instructs the monitor to do a resync.
-func (l *LinuxMonitor) ReSync(ctx context.Context) error {
-
-	return l.proc.ReSync(ctx, nil)
+// Resync instructs the monitor to do a resync.
+func (l *LinuxMonitor) Resync(ctx context.Context) error {
+	return l.proc.Resync(ctx, nil)
 }

--- a/monitor/internal/linux/monitor.go
+++ b/monitor/internal/linux/monitor.go
@@ -32,7 +32,7 @@ func (l *LinuxMonitor) Run(ctx context.Context) error {
 		return fmt.Errorf("linux %t: %s", l.proc.host, err)
 	}
 
-	if err := l.ReSync(ctx); err != nil {
+	if err := l.Resync(ctx); err != nil {
 		return err
 	}
 

--- a/monitor/internal/linux/processor.go
+++ b/monitor/internal/linux/processor.go
@@ -185,8 +185,8 @@ func (l *linuxProcessor) Pause(ctx context.Context, eventInfo *common.EventInfo)
 	return l.config.Policy.HandlePUEvent(ctx, puID, common.EventPause, nil)
 }
 
-// ReSync resyncs with all the existing services that were there before we start
-func (l *linuxProcessor) ReSync(ctx context.Context, e *common.EventInfo) error {
+// Resync resyncs with all the existing services that were there before we start
+func (l *linuxProcessor) Resync(ctx context.Context, e *common.EventInfo) error {
 	cgroups := l.netcls.ListAllCgroups("")
 	for _, cgroup := range cgroups {
 		if _, ok := ignoreNames[cgroup]; ok {

--- a/monitor/internal/uid/monitor.go
+++ b/monitor/internal/uid/monitor.go
@@ -33,7 +33,7 @@ func (u *UIDMonitor) Run(ctx context.Context) error {
 		return fmt.Errorf("uid: %s", err)
 	}
 
-	if err := u.ReSync(ctx); err != nil {
+	if err := u.Resync(ctx); err != nil {
 		return err
 	}
 
@@ -85,8 +85,7 @@ func (u *UIDMonitor) SetupHandlers(m *config.ProcessorConfig) {
 	u.proc.config = m
 }
 
-// ReSync asks the monitor to do a resync
-func (u *UIDMonitor) ReSync(ctx context.Context) error {
-
-	return u.proc.ReSync(ctx, nil)
+// Resync asks the monitor to do a resync
+func (u *UIDMonitor) Resync(ctx context.Context) error {
+	return u.proc.Resync(ctx, nil)
 }

--- a/monitor/internal/uid/processor.go
+++ b/monitor/internal/uid/processor.go
@@ -149,8 +149,8 @@ func (u *uidProcessor) Pause(ctx context.Context, eventInfo *common.EventInfo) e
 	return u.config.Policy.HandlePUEvent(ctx, eventInfo.PUID, common.EventPause, nil)
 }
 
-// ReSync resyncs with all the existing services that were there before we start
-func (u *uidProcessor) ReSync(ctx context.Context, e *common.EventInfo) error {
+// Resync resyncs with all the existing services that were there before we start
+func (u *uidProcessor) Resync(ctx context.Context, e *common.EventInfo) error {
 
 	uids := u.netcls.ListAllCgroups("")
 	for _, uid := range uids {

--- a/monitor/mock/mockmonitor.go
+++ b/monitor/mock/mockmonitor.go
@@ -149,16 +149,16 @@ func (mr *MockImplementationMockRecorder) SetupHandlers(c interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHandlers", reflect.TypeOf((*MockImplementation)(nil).SetupHandlers), c)
 }
 
-// ReSync mocks base method
+// Resync mocks base method
 // nolint
-func (m *MockImplementation) ReSync(ctx context.Context) error {
-	ret := m.ctrl.Call(m, "ReSync", ctx)
+func (m *MockImplementation) Resync(ctx context.Context) error {
+	ret := m.ctrl.Call(m, "Resync", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ReSync indicates an expected call of ReSync
+// Reync indicates an expected call of Resync
 // nolint
-func (mr *MockImplementationMockRecorder) ReSync(ctx interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReSync", reflect.TypeOf((*MockImplementation)(nil).ReSync), ctx)
+func (mr *MockImplementationMockRecorder) Resync(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resync", reflect.TypeOf((*MockImplementation)(nil).Resync), ctx)
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -144,7 +144,7 @@ func (m *monitors) Resync(ctx context.Context) error {
 	var errs string
 
 	for _, i := range m.monitors {
-		if err := i.ReSync(ctx); err != nil {
+		if err := i.Resync(ctx); err != nil {
 			errs = errs + err.Error()
 			failure = true
 		}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aporeto-inc/trireme-lib/monitor/internal/kubernetes"
+
 	"github.com/aporeto-inc/trireme-lib/common"
 	"github.com/aporeto-inc/trireme-lib/monitor/config"
 	"github.com/aporeto-inc/trireme-lib/monitor/internal/cni"
@@ -70,6 +72,14 @@ func NewMonitors(opts ...Options) (Monitor, error) {
 				return nil, fmt.Errorf("Docker: %s", err.Error())
 			}
 			m.monitors[config.Docker] = mon
+
+		case config.Kubernetes:
+			mon := kubernetesmonitor.New()
+			mon.SetupHandlers(c.Common)
+			if err := mon.SetupConfig(nil, v); err != nil {
+				return nil, fmt.Errorf("kubernetes: %s", err.Error())
+			}
+			m.monitors[config.Kubernetes] = mon
 
 		case config.LinuxProcess:
 			mon := linuxmonitor.New()

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -178,10 +178,17 @@ func SubOptionMonitorKubernetesNodename(nodename string) KubernetesMonitorOption
 	}
 }
 
-// SubOptionMonitorKubernetesNodename provides a way to specify if we want to activate Pods launched in host mode.
+// SubOptionMonitorKubernetesHostPod provides a way to specify if we want to activate Pods launched in host mode.
 func SubOptionMonitorKubernetesHostPod(enableHostPods bool) KubernetesMonitorOption {
 	return func(cfg *kubernetesmonitor.Config) {
 		cfg.EnableHostPods = enableHostPods
+	}
+}
+
+// SubOptionMonitorKubernetesExtractor provides a way to specify metadata extractor for docker.
+func SubOptionMonitorKubernetesExtractor(extractor extractors.KubernetesMetadataExtractorType) KubernetesMonitorOption {
+	return func(cfg *kubernetesmonitor.Config) {
+		cfg.EventMetadataExtractor = extractor
 	}
 }
 

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -149,7 +149,7 @@ func OptionMonitorDocker(opts ...DockerMonitorOption) Options {
 	}
 }
 
-// OptionMonitorDocker provides a way to add a docker monitor and related configuration to be used with New().
+// OptionMonitorKubernetes provides a way to add a docker monitor and related configuration to be used with New().
 func OptionMonitorKubernetes(opts ...KubernetesMonitorOption) Options {
 	kc := kubernetesmonitor.DefaultConfig()
 	// Collect all docker options
@@ -162,11 +162,19 @@ func OptionMonitorKubernetes(opts ...KubernetesMonitorOption) Options {
 	}
 }
 
-// SubOptionMonitorKubernetesKubeconfig provides a way to specify configuration flags info for docker.
+// SubOptionMonitorKubernetesKubeconfig provides a way to specify a kubeconfig to use to connect to Kubernetes.
+// In case of an in-cluter config, leave the kubeconfig field blank
 func SubOptionMonitorKubernetesKubeconfig(kubeconfig string) KubernetesMonitorOption {
 	return func(cfg *kubernetesmonitor.Config) {
-		//TODO: implement this
-		return
+		cfg.Kubeconfig = kubeconfig
+	}
+}
+
+// SubOptionMonitorKubernetesNodename provides a way to specify the kubernetes node name.
+// This is useful for filtering
+func SubOptionMonitorKubernetesNodename(nodename string) KubernetesMonitorOption {
+	return func(cfg *kubernetesmonitor.Config) {
+		cfg.Nodename = nodename
 	}
 }
 

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -192,7 +192,7 @@ func SubOptionMonitorKubernetesExtractor(extractor extractors.KubernetesMetadata
 	}
 }
 
-// SubOptionMonitorKubernetesExtractorForDocker provides a way to specify metadata extractor for docker.
+// SubOptionMonitorKubernetesDockerExtractor provides a way to specify metadata extractor for docker.
 func SubOptionMonitorKubernetesDockerExtractor(extractor extractors.DockerMetadataExtractor) KubernetesMonitorOption {
 	return func(cfg *kubernetesmonitor.Config) {
 		cfg.DockerExtractor = extractor

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aporeto-inc/trireme-lib/monitor/extractors"
 	"github.com/aporeto-inc/trireme-lib/monitor/internal/cni"
 	"github.com/aporeto-inc/trireme-lib/monitor/internal/docker"
+	"github.com/aporeto-inc/trireme-lib/monitor/internal/kubernetes"
 	"github.com/aporeto-inc/trireme-lib/monitor/internal/linux"
 	"github.com/aporeto-inc/trireme-lib/monitor/internal/uid"
 	"github.com/aporeto-inc/trireme-lib/policy"
@@ -22,6 +23,9 @@ type UIDMonitorOption func(*uidmonitor.Config)
 
 // DockerMonitorOption is provided using functional arguments.
 type DockerMonitorOption func(*dockermonitor.Config)
+
+// KubernetesMonitorOption is provided using functional arguments.
+type KubernetesMonitorOption func(*kubernetesmonitor.Config)
 
 // LinuxMonitorOption is provided using functional arguments.
 type LinuxMonitorOption func(*linuxmonitor.Config)
@@ -128,6 +132,14 @@ func SubOptionMonitorDockerFlags(syncAtStart, killContainerOnPolicyError bool) D
 	return func(cfg *dockermonitor.Config) {
 		cfg.KillContainerOnPolicyError = killContainerOnPolicyError
 		cfg.SyncAtStart = syncAtStart
+	}
+}
+
+// SubOptionMonitorKubernetesKubeconfig provides a way to specify configuration flags info for docker.
+func SubOptionMonitorKubernetesKubeconfig(kubeconfig string) KubernetesMonitorOption {
+	return func(cfg *kubernetesmonitor.Config) {
+		//TODO: implement this
+		return
 	}
 }
 

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -178,6 +178,13 @@ func SubOptionMonitorKubernetesNodename(nodename string) KubernetesMonitorOption
 	}
 }
 
+// SubOptionMonitorKubernetesNodename provides a way to specify if we want to activate Pods launched in host mode.
+func SubOptionMonitorKubernetesHostPod(enableHostPods bool) KubernetesMonitorOption {
+	return func(cfg *kubernetesmonitor.Config) {
+		cfg.EnableHostPods = enableHostPods
+	}
+}
+
 // OptionMergeTags provides a way to add merge tags to be used with New().
 func OptionMergeTags(tags []string) Options {
 	return func(cfg *config.MonitorConfig) {

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -193,7 +193,7 @@ func SubOptionMonitorKubernetesExtractor(extractor extractors.KubernetesMetadata
 }
 
 // SubOptionMonitorKubernetesExtractorForDocker provides a way to specify metadata extractor for docker.
-func SubOptionMonitorKubernetesExtractorForDocker(extractor extractors.DockerMetadataExtractor) KubernetesMonitorOption {
+func SubOptionMonitorKubernetesDockerExtractor(extractor extractors.DockerMetadataExtractor) KubernetesMonitorOption {
 	return func(cfg *kubernetesmonitor.Config) {
 		cfg.DockerExtractor = extractor
 	}

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -135,14 +135,6 @@ func SubOptionMonitorDockerFlags(syncAtStart, killContainerOnPolicyError bool) D
 	}
 }
 
-// SubOptionMonitorKubernetesKubeconfig provides a way to specify configuration flags info for docker.
-func SubOptionMonitorKubernetesKubeconfig(kubeconfig string) KubernetesMonitorOption {
-	return func(cfg *kubernetesmonitor.Config) {
-		//TODO: implement this
-		return
-	}
-}
-
 // OptionMonitorDocker provides a way to add a docker monitor and related configuration to be used with New().
 func OptionMonitorDocker(opts ...DockerMonitorOption) Options {
 
@@ -154,6 +146,27 @@ func OptionMonitorDocker(opts ...DockerMonitorOption) Options {
 
 	return func(cfg *config.MonitorConfig) {
 		cfg.Monitors[config.Docker] = dc
+	}
+}
+
+// OptionMonitorDocker provides a way to add a docker monitor and related configuration to be used with New().
+func OptionMonitorKubernetes(opts ...KubernetesMonitorOption) Options {
+	kc := kubernetesmonitor.DefaultConfig()
+	// Collect all docker options
+	for _, opt := range opts {
+		opt(kc)
+	}
+
+	return func(cfg *config.MonitorConfig) {
+		cfg.Monitors[config.Kubernetes] = kc
+	}
+}
+
+// SubOptionMonitorKubernetesKubeconfig provides a way to specify configuration flags info for docker.
+func SubOptionMonitorKubernetesKubeconfig(kubeconfig string) KubernetesMonitorOption {
+	return func(cfg *kubernetesmonitor.Config) {
+		//TODO: implement this
+		return
 	}
 }
 

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -185,10 +185,17 @@ func SubOptionMonitorKubernetesHostPod(enableHostPods bool) KubernetesMonitorOpt
 	}
 }
 
-// SubOptionMonitorKubernetesExtractor provides a way to specify metadata extractor for docker.
+// SubOptionMonitorKubernetesExtractor provides a way to specify metadata extractor for Kubernetes
 func SubOptionMonitorKubernetesExtractor(extractor extractors.KubernetesMetadataExtractorType) KubernetesMonitorOption {
 	return func(cfg *kubernetesmonitor.Config) {
-		cfg.EventMetadataExtractor = extractor
+		cfg.KubernetesExtractor = extractor
+	}
+}
+
+// SubOptionMonitorKubernetesExtractorForDocker provides a way to specify metadata extractor for docker.
+func SubOptionMonitorKubernetesExtractorForDocker(extractor extractors.DockerMetadataExtractor) KubernetesMonitorOption {
+	return func(cfg *kubernetesmonitor.Config) {
+		cfg.DockerExtractor = extractor
 	}
 }
 

--- a/monitor/processor/interfaces.go
+++ b/monitor/processor/interfaces.go
@@ -25,6 +25,6 @@ type Processor interface {
 	// Event processes a pause event
 	Pause(ctx context.Context, eventInfo *common.EventInfo) error
 
-	// ReSync resyncs all PUs handled by this processor
-	ReSync(ctx context.Context, EventInfo *common.EventInfo) error
+	// Resync resyncs all PUs handled by this processor
+	Resync(ctx context.Context, EventInfo *common.EventInfo) error
 }

--- a/monitor/processor/mock/mockprocessor.go
+++ b/monitor/processor/mock/mockprocessor.go
@@ -109,16 +109,16 @@ func (mr *MockProcessorMockRecorder) Pause(ctx, eventInfo interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pause", reflect.TypeOf((*MockProcessor)(nil).Pause), ctx, eventInfo)
 }
 
-// ReSync mocks base method
+// Resync mocks base method
 // nolint
-func (m *MockProcessor) ReSync(ctx context.Context, EventInfo *common.EventInfo) error {
-	ret := m.ctrl.Call(m, "ReSync", ctx, EventInfo)
+func (m *MockProcessor) Resync(ctx context.Context, EventInfo *common.EventInfo) error {
+	ret := m.ctrl.Call(m, "Resync", ctx, EventInfo)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ReSync indicates an expected call of ReSync
+// Resync indicates an expected call of Resync
 // nolint
-func (mr *MockProcessorMockRecorder) ReSync(ctx, EventInfo interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReSync", reflect.TypeOf((*MockProcessor)(nil).ReSync), ctx, EventInfo)
+func (mr *MockProcessorMockRecorder) Resync(ctx, EventInfo interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resync", reflect.TypeOf((*MockProcessor)(nil).Resync), ctx, EventInfo)
 }

--- a/monitor/registerer/registerer.go
+++ b/monitor/registerer/registerer.go
@@ -35,7 +35,7 @@ func (r *registerer) RegisterProcessor(puType common.PUType, ep processor.Proces
 	r.addHandler(puType, common.EventCreate, ep.Create)
 	r.addHandler(puType, common.EventDestroy, ep.Destroy)
 	r.addHandler(puType, common.EventPause, ep.Pause)
-	r.addHandler(puType, common.EventResync, ep.ReSync)
+	r.addHandler(puType, common.EventResync, ep.Resync)
 
 	return nil
 }

--- a/policy/interfaces.go
+++ b/policy/interfaces.go
@@ -24,7 +24,7 @@ type RuntimeReader interface {
 	// Name returns the process name of the Runtime.
 	Name() string
 
-	// NSPath returns the process name of the Runtime.
+	// NSPath returns the path to the namespace of the PU, if applicable
 	NSPath() string
 
 	// Tag returns  the value of the given tag.

--- a/policy/interfaces.go
+++ b/policy/interfaces.go
@@ -24,6 +24,9 @@ type RuntimeReader interface {
 	// Name returns the process name of the Runtime.
 	Name() string
 
+	// NSPath returns the process name of the Runtime.
+	NSPath() string
+
 	// Tag returns  the value of the given tag.
 	Tag(string) (string, bool)
 


### PR DESCRIPTION
This PR introduces a Monitor for Kubernetes that will only send POD events upstream.

It also connects to Kubernetes API in order to complete and merge the tags.

It reuses the Docker Monitor as intermediate and filter its events.