### PR TITLE
Enable API control for external services

### DIFF
--- a/common/service.go
+++ b/common/service.go
@@ -17,7 +17,7 @@ type Service struct {
 	// Protocol is the protocol number
 	Protocol uint8 `json:"protocol,omitempty"`
 
-	// Addresses are the IP addresses. An empty list means 0.0.0.0
+	// Addresses are the IP addresses. An empty list means 0.0.0.0/0
 	Addresses []*net.IPNet `json:"addresses,omitempty"`
 
 	// FQDNs is the list of FQDNs for the service.

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -399,10 +399,11 @@ func buildCaches(services, dependentServices policy.ApplicationServicesList) (ma
 	for _, service := range dependentServices {
 		uricache := urisearch.NewAPICache(service.HTTPRules)
 		for _, fqdn := range service.NetworkInfo.FQDNs {
-			if _, ok := dependentCache[fqdn]; ok {
+			address := fqdn + ":" + service.NetworkInfo.Ports.String()
+			if _, ok := dependentCache[address]; ok {
 				continue
 			}
-			dependentCache[fqdn] = uricache
+			dependentCache[address] = uricache
 		}
 	}
 

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -386,7 +386,7 @@ func buildCaches(services, dependentServices policy.ApplicationServicesList) (ma
 		if service.Type != policy.ServiceHTTP {
 			continue
 		}
-		apicache[service.NetworkInfo.Ports.String()] = urisearch.NewAPICache(service.HTTPRules)
+		apicache[service.NetworkInfo.Ports.String()] = urisearch.NewAPICache(service.HTTPRules, false)
 		cert, err := cryptoutils.LoadCertificate(service.JWTCertificate)
 		if err != nil {
 			// We just ignore bad certificates and move on.
@@ -397,7 +397,7 @@ func buildCaches(services, dependentServices policy.ApplicationServicesList) (ma
 	}
 
 	for _, service := range dependentServices {
-		uricache := urisearch.NewAPICache(service.HTTPRules)
+		uricache := urisearch.NewAPICache(service.HTTPRules, service.External)
 		for _, fqdn := range service.NetworkInfo.FQDNs {
 			address := fqdn + ":" + service.NetworkInfo.Ports.String()
 			if _, ok := dependentCache[address]; ok {

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -246,8 +246,8 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 	// certificate distribution service is considered as external and must
 	// be defined as external.
 	if apiCache.External {
-		_, _port, err := servicePort(w, r)
-		if err != nil {
+		_, _port, perr := servicePort(w, r)
+		if perr != nil {
 			return
 		}
 		record := &collector.FlowRecord{

--- a/controller/internal/supervisor/iptablesctrl/ipsets.go
+++ b/controller/internal/supervisor/iptablesctrl/ipsets.go
@@ -156,7 +156,7 @@ func (i *Instance) updateProxySet(policy *policy.PUPolicy, portSetName string) e
 	}
 
 	for _, exposedService := range policy.ExposedServices() {
-		min, max := exposedService.NetworkInfo.Ports.Range()
+		min, max := exposedService.PrivateNetworkInfo.Ports.Range()
 		for i := int(min); i <= int(max); i++ {
 			if err := srvTargetSet.Add(strconv.Itoa(i), 0); err != nil {
 				zap.L().Error("Failed to add vip", zap.Error(err))

--- a/controller/pkg/urisearch/urisearch.go
+++ b/controller/pkg/urisearch/urisearch.go
@@ -13,13 +13,15 @@ type node struct {
 
 // APICache represents an API cache.
 type APICache struct {
-	root *node
+	External bool
+	root     *node
 }
 
 // NewAPICache creates a new API cache
-func NewAPICache(rules []*policy.HTTPRule) *APICache {
+func NewAPICache(rules []*policy.HTTPRule, external bool) *APICache {
 	a := &APICache{
-		root: &node{},
+		root:     &node{},
+		External: external,
 	}
 
 	empty := struct{}{}

--- a/controller/pkg/urisearch/urisearch_test.go
+++ b/controller/pkg/urisearch/urisearch_test.go
@@ -44,7 +44,7 @@ func TestNewAPICache(t *testing.T) {
 		rules := initTrieRules()
 
 		Convey("When I insert them in the cache, I should get a valid cache", func() {
-			c := NewAPICache(rules)
+			c := NewAPICache(rules, false)
 			So(c, ShouldNotBeNil)
 			So(c.root.leaf, ShouldBeTrue)
 			So(c.root.data.([]string), ShouldNotBeNil)
@@ -161,7 +161,7 @@ func TestParse(t *testing.T) {
 
 func TestAPICacheFind(t *testing.T) {
 	Convey("Given valid API cache", t, func() {
-		c := NewAPICache(initTrieRules())
+		c := NewAPICache(initTrieRules(), false)
 		Convey("When I search for correct URIs, I should get the right data", func() {
 			found, data := c.Find("GET", "/users/123/name")
 			So(found, ShouldBeTrue)

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -31,6 +31,8 @@ type ApplicationService struct {
 	JWTCertificate []byte
 	// External indicates if this is an external service
 	External bool
+	// CACert is the certificate of the CA of external services
+	CACert []byte
 }
 
 // HTTPRule holds a rule for a particular HTTPService. The rule

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -19,19 +19,38 @@ type ApplicationServicesList []*ApplicationService
 
 // ApplicationService is the type of service that this PU exposes.
 type ApplicationService struct {
-	// NetworkInfo provides the network information (addresses/ports) of the service
+	// NetworkInfo provides the network information (addresses/ports) of the service.
+	// This is the public facing network information, or how the service can be
+	// accessed. In the case of Load Balancers for example, this would be the
+	// IP/port of the load balancer.
 	NetworkInfo *common.Service
+
+	// PrivateNetworkInfo captures the network service definition of an application
+	// as seen by the application. For example the port that the application is
+	// listening to. This is needed in the case of port mappings.
+	PrivateNetworkInfo *common.Service
+
 	// Type is the type of the service.
 	Type ServiceType
-	// ApplicationRules are only valid for non TCP or L3 services
+
+	// HTTPRules are only valid for HTTP Services and capture the list of APIs
+	// exposed by the service.
 	HTTPRules []*HTTPRule
+
 	// Tags are the tags of the service.
 	Tags *TagStore
+
 	// JWTCertificate is a certificate for validating JWT bearer tokens in http requests.
+	// It is only useful for HTTP services where the Bearer Authentication header provides
+	// a JWT token. It is used to validate the JWT tokens.
 	JWTCertificate []byte
-	// External indicates if this is an external service
+
+	// External indicates if this is an external service. For external services
+	// access control is implemented at the ingress.
 	External bool
-	// CACert is the certificate of the CA of external services
+
+	// CACert is the certificate of the CA of external services. This allows TLS to
+	// work with external services that use private CAs.
 	CACert []byte
 }
 
@@ -39,12 +58,16 @@ type ApplicationService struct {
 // relates a set of URIs defined as regular expressions with associated
 // verbs. The * VERB indicates all actions.
 type HTTPRule struct {
-	// URIs is a list of regular expressions  that describe the URIs
+	// URIs is a list of regular expressions that describe the URIs that
+	// a service is exposing.
 	URIs []string
-	// Verbs is a list of the allowed verbs
+
+	// Verbs is a list of the allowed verbs for the given list of URIs.
 	Verbs []string
+
 	// Scopes is a list of scopes associated with this rule. Clients
 	// must present one of these scopes in order to get access to this
-	// API.
+	// API. The scopes are presented either in the Trireme identity or the
+	// JWT of HTTP Authorization header.
 	Scopes []string
 }

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -29,6 +29,8 @@ type ApplicationService struct {
 	Tags *TagStore
 	// JWTCertificate is a certificate for validating JWT bearer tokens in http requests.
 	JWTCertificate []byte
+	// External indicates if this is an external service
+	External bool
 }
 
 // HTTPRule holds a rule for a particular HTTPService. The rule


### PR DESCRIPTION
#### Description
Enable API level access control even for external services. Validations and checks are based on the identity of the PU and follow the same patterns. 

#### Test plan
Need new tests for API access to external services. 

> Fixes #.
