### PR TITLE
New: Generate a runtime for All events. Including Pause, Unpause, Stop, Destroy

### DIFF
--- a/monitor/internal/docker/cache.go
+++ b/monitor/internal/docker/cache.go
@@ -1,0 +1,47 @@
+package dockermonitor
+
+import (
+	"sync"
+
+	"github.com/aporeto-inc/trireme-lib/policy"
+)
+
+type cache struct {
+	// runtimeCache keeps a mapping between a PUID and the corresponding runtime.
+	runtimeCache map[string]*policy.PURuntime
+
+	// Lock for the whole cache
+	sync.RWMutex
+}
+
+func newCache() *cache {
+	return &cache{
+		runtimeCache: map[string]*policy.PURuntime{},
+	}
+}
+
+func (c *cache) addOrUpdateRuntime(puid string, runtime *policy.PURuntime) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.runtimeCache[puid] = runtime
+}
+
+func (c *cache) getRuntime(puid string) *policy.PURuntime {
+	c.Lock()
+	defer c.Unlock()
+
+	runtime, ok := c.runtimeCache[puid]
+	if !ok {
+		return nil
+	}
+
+	return runtime
+}
+
+func (c *cache) deleteRuntime(puid string) {
+	c.Lock()
+	defer c.Unlock()
+
+	delete(c.runtimeCache, puid)
+}

--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -469,23 +469,33 @@ func (d *DockerMonitor) handleStartEvent(ctx context.Context, event *events.Mess
 //handleDie event is called when a container dies. It generates a "Stop" event.
 func (d *DockerMonitor) handleDieEvent(ctx context.Context, event *events.Message) error {
 
+	_, runtime, err := d.containerAndRuntimeFromEvent(ctx, event)
+	if err != nil {
+		return err
+	}
+
 	puID, err := puIDFromDockerID(event.ID)
 	if err != nil {
 		return err
 	}
 
-	return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventStop, policy.NewPURuntimeWithDefaults())
+	return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventStop, runtime)
 }
 
 // handleDestroyEvent handles destroy events from Docker. It generated a "Destroy event"
 func (d *DockerMonitor) handleDestroyEvent(ctx context.Context, event *events.Message) error {
 
+	_, runtime, err := d.containerAndRuntimeFromEvent(ctx, event)
+	if err != nil {
+		return err
+	}
+
 	puID, err := puIDFromDockerID(event.ID)
 	if err != nil {
 		return err
 	}
 
-	err = d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventDestroy, policy.NewPURuntimeWithDefaults())
+	err = d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventDestroy, runtime)
 	if err != nil {
 		zap.L().Error("Failed to handle delete event",
 			zap.Error(err),
@@ -504,25 +514,35 @@ func (d *DockerMonitor) handleDestroyEvent(ctx context.Context, event *events.Me
 
 // handlePauseEvent generates a create event type.
 func (d *DockerMonitor) handlePauseEvent(ctx context.Context, event *events.Message) error {
-	zap.L().Info("UnPause Event for nativeID", zap.String("ID", event.ID))
+	zap.L().Info("Pause Event for nativeID", zap.String("ID", event.ID))
+
+	_, runtime, err := d.containerAndRuntimeFromEvent(ctx, event)
+	if err != nil {
+		return err
+	}
 
 	puID, err := puIDFromDockerID(event.ID)
 	if err != nil {
 		return err
 	}
 
-	return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventPause, policy.NewPURuntimeWithDefaults())
+	return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventPause, runtime)
 }
 
 // handleCreateEvent generates a create event type.
 func (d *DockerMonitor) handleUnpauseEvent(ctx context.Context, event *events.Message) error {
 
+	_, runtime, err := d.containerAndRuntimeFromEvent(ctx, event)
+	if err != nil {
+		return err
+	}
+
 	puID, err := puIDFromDockerID(event.ID)
 	if err != nil {
 		return err
 	}
 
-	return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventUnpause, policy.NewPURuntimeWithDefaults())
+	return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventUnpause, runtime)
 }
 
 func puIDFromDockerID(dockerID string) (string, error) {


### PR DESCRIPTION
This PR adds uniformity to all the events types for the Docker Monitor.

Upto now, only the Start and Create events were generating metadata.
For all the other events, we were sending a PURuntime with Defaults. That doesn't really make sense and disallow any type of Processing to the upper level Resolvers if they don't keep a local cache.

This PR adds processing of the Runtime for all the event types.