### PR TITLE
Disable early demux to avoid the kernel bug

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -125,6 +125,12 @@ func New(
 			zap.L().Fatal("Failed to set conntrack options", zap.Error(err))
 		}
 
+		if mode == constants.LocalServer {
+			cmd = exec.Command(sysctlCmd, "-w", "net.ipv4.ip_early_demux=0")
+			if err := cmd.Run(); err != nil {
+				zap.L().Fatal("Failed to set early demux options", zap.Error(err))
+			}
+		}
 	}
 
 	// This cache is shared with portSetInstance. The portSetInstance


### PR DESCRIPTION
#### Description
Kernel issue was dropping packets without this setting.
