### PR TITLE
Allow * to mean all paths and ? to mean one level of the hierarchy

### DIFF
--- a/controller/pkg/urisearch/urisearch.go
+++ b/controller/pkg/urisearch/urisearch.go
@@ -107,7 +107,11 @@ func search(n *node, api string) (found bool, data interface{}) {
 	next, foundPrefix := n.children[prefix]
 	if !foundPrefix {
 		// If not found, try the star
-		next, foundPrefix = n.children["/*"]
+		next, foundPrefix = n.children["/?"]
+		if !foundPrefix {
+			next, foundPrefix = n.children["/*"]
+			suffix = "/"
+		}
 	}
 
 	// We found either an exact match or a * match


### PR DESCRIPTION
#### Description
Changes the API specification to allow for * to mean any length of path. 

Current behavior is that matching is happening for /a/b/* would drop requests for /a/b/c/d

New behavior:
/a/b/? would match any of /a/b/c /a/b/d 

/a/b/* would match any of /a/b/c /a/b/c/d /a/b/x/y/z
