### PR TITLE
Fix local context calculation for proxy connections:

### DIFF
--- a/controller/pkg/connection/connection.go
+++ b/controller/pkg/connection/connection.go
@@ -199,9 +199,16 @@ type ProxyConnection struct {
 
 // NewProxyConnection returns a new Proxy Connection
 func NewProxyConnection() *ProxyConnection {
+	nonce, err := crypto.GenerateRandomBytes(16)
+	if err != nil {
+		return nil
+	}
 
 	return &ProxyConnection{
 		state: ClientTokenSend,
+		Auth: AuthInfo{
+			LocalContext: nonce,
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes the local context setting for new TCP connections. It was broken when the method changed to avoid RTT issues. 