### PR TITLE
API access control - extsvc client showing as Somewhere vs defined extsvc

### DIFF
--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -125,7 +125,7 @@ func (p *AppProxy) Enforce(ctx context.Context, puID string, puInfo *policy.PUIn
 	// Create the network listener and cache it so that we can terminate it later.
 	l, err := p.createNetworkListener(":" + puInfo.Runtime.Options().ProxyPort)
 	if err != nil {
-		return fmt.Errorf("Cannot create listener: port:%d %s", puInfo.Runtime.Options().ProxyPort, err)
+		return fmt.Errorf("Cannot create listener: port:%s %s", puInfo.Runtime.Options().ProxyPort, err)
 	}
 
 	// Create a new client entry and start the servers.

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -286,6 +286,7 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 		if !found {
 			zap.L().Error("Uknown  or unauthorized service - no policy found", zap.Error(err))
 			http.Error(w, fmt.Sprintf("Unknown or unauthorized service - no policy found"), http.StatusForbidden)
+			// @dimitri : do we need to report here?
 			return
 		}
 
@@ -302,6 +303,7 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 			if err = p.verifyPolicy(rule.Scopes, puContext.Identity().Tags, puContext.Scopes(), []string{}); err != nil {
 				zap.L().Error("Uknown  or unauthorized service", zap.Error(err))
 				http.Error(w, fmt.Sprintf("Unknown or unauthorized service - rejected by policy"), http.StatusForbidden)
+				// @dimitri : do we need to report here?
 				return
 			}
 

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -268,10 +268,13 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, netaction, noNetAccesPolicy := puContext.ApplicationACLPolicyFromAddr(originalDestination.IP.To4(), uint16(originalDestination.Port))
-	if noNetAccesPolicy == nil && netaction.Action.Rejected() {
-		http.Error(w, fmt.Sprintf("Unauthorized Service - Rejected Outgoing Request by Network Policies"), http.StatusNetworkAuthenticationRequired)
+	if netaction != nil {
 		record.Destination.ID = netaction.ServiceID
 		record.PolicyID = netaction.PolicyID
+	}
+
+	if noNetAccesPolicy == nil && netaction.Action.Rejected() {
+		http.Error(w, fmt.Sprintf("Unauthorized Service - Rejected Outgoing Request by Network Policies"), http.StatusNetworkAuthenticationRequired)
 		p.collector.CollectFlowEvent(record)
 		return
 	}
@@ -387,11 +390,15 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 	record.Destination.ID = puContext.ManagementID()
 
 	_, networkPolicy, noNetAccessPolicy := puContext.NetworkACLPolicyFromAddr(sourceAddress.IP.To4(), uint16(sourceAddress.Port))
-	if noNetAccessPolicy == nil && networkPolicy.Action.Rejected() {
-		http.Error(w, fmt.Sprintf("Access denied by network policy"), http.StatusNetworkAuthenticationRequired)
+
+	if networkPolicy != nil {
 		record.Source.Type = collector.EndPointTypeExteranlIPAddress
 		record.Source.ID = networkPolicy.ServiceID
 		record.PolicyID = networkPolicy.PolicyID
+	}
+	if noNetAccessPolicy == nil && networkPolicy.Action.Rejected() {
+		http.Error(w, fmt.Sprintf("Access denied by network policy"), http.StatusNetworkAuthenticationRequired)
+
 		return
 	}
 


### PR DESCRIPTION
Fix for the issue: https://github.com/aporeto-inc/aporeto/issues/252