### PR TITLE
Generic OIDC support for API authorization

### DIFF
--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -412,7 +412,6 @@ func buildExposedServices(p *auth.Processor, exposedServices policy.ApplicationS
 		}
 		ruleCache := urisearch.NewAPICache(service.HTTPRules, service.ID, false)
 		p.AddOrUpdateService(service.ID, ruleCache, service.JWTTokenHandler)
-		fmt.Println("Added serviceID and auth ", service.ID, ruleCache)
 		for _, fqdn := range service.NetworkInfo.FQDNs {
 			rhost := fqdn + ":" + service.NetworkInfo.Ports.String()
 			serviceMap[rhost] = service.ID

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -481,15 +481,18 @@ func serviceFromProxySet(pair string) (*common.Service, error) {
 func (p *AppProxy) expandCAPool(externalCAs [][]byte) *x509.CertPool {
 	systemPool, err := x509.SystemCertPool()
 	if err != nil {
+		fmt.Println("Failed to find the root CA pool")
 		return p.systemCAPool
 	}
 	// We append the CA only if we are not in PSK mode as it doesn't provide a CA.
 	if p.secrets.PublicSecrets().SecretsType() != secrets.PSKType {
 		if ok := systemPool.AppendCertsFromPEM(p.secrets.PublicSecrets().CertAuthority()); !ok {
+			fmt.Println("Failed to add the ca  pool for the standard service")
 			return p.systemCAPool
 		}
 	}
 	for _, ca := range externalCAs {
+		fmt.Println("Adding ca", string(ca))
 		systemPool.AppendCertsFromPEM(ca)
 	}
 	return systemPool

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -114,7 +114,7 @@ func (p *AppProxy) Enforce(ctx context.Context, puID string, puInfo *policy.PUIn
 	dependentCache, caPool := buildDependentCaches(puInfo.Policy.DependentServices())
 	p.authProcessorCache.AddOrUpdate(puID, authProcessor)
 	p.dependentAPICache.AddOrUpdate(puID, dependentCache)
-	p.serviceMap.Add(puID, serviceMap)
+	p.serviceMap.AddOrUpdate(puID, serviceMap)
 
 	// For updates we need to update the certificates if we have new ones. Otherwise
 	// we return. There is nothing else to do in case of policy update.

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -481,18 +481,15 @@ func serviceFromProxySet(pair string) (*common.Service, error) {
 func (p *AppProxy) expandCAPool(externalCAs [][]byte) *x509.CertPool {
 	systemPool, err := x509.SystemCertPool()
 	if err != nil {
-		fmt.Println("Failed to find the root CA pool")
 		return p.systemCAPool
 	}
 	// We append the CA only if we are not in PSK mode as it doesn't provide a CA.
 	if p.secrets.PublicSecrets().SecretsType() != secrets.PSKType {
 		if ok := systemPool.AppendCertsFromPEM(p.secrets.PublicSecrets().CertAuthority()); !ok {
-			fmt.Println("Failed to add the ca  pool for the standard service")
 			return p.systemCAPool
 		}
 	}
 	for _, ca := range externalCAs {
-		fmt.Println("Adding ca", string(ca))
 		systemPool.AppendCertsFromPEM(ca)
 	}
 	return systemPool

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -132,9 +132,6 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 				RootCAs:            p.ca,
 				InsecureSkipVerify: false,
 			})
-			for _, s := range p.ca.Subjects() {
-				fmt.Println("At connectiong added subject", string(s))
-			}
 			return tlsConn, nil
 		},
 	}

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -3,18 +3,17 @@ package httpproxy
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/aporeto-inc/bireme/pkg/auth"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/vulcand/oxy/forward"
 	"go.aporeto.io/trireme-lib/collector"
@@ -39,23 +38,24 @@ type JWTClaims struct {
 
 // Config maintains state for proxies connections from listen to backend.
 type Config struct {
-	cert              *tls.Certificate
-	ca                *x509.CertPool
-	keyPEM            string
-	certPEM           string
-	secrets           secrets.Secrets
-	tokenaccessor     tokenaccessor.TokenAccessor
-	collector         collector.EventCollector
-	puContext         string
-	puFromIDCache     cache.DataStore
-	exposedAPICache   cache.DataStore
-	dependentAPICache cache.DataStore
-	jwtCache          cache.DataStore
-	applicationProxy  bool
-	mark              int
-	server            *http.Server
-	fwd               *forward.Forwarder
-	fwdTLS            *forward.Forwarder
+	cert               *tls.Certificate
+	ca                 *x509.CertPool
+	keyPEM             string
+	certPEM            string
+	secrets            secrets.Secrets
+	tokenaccessor      tokenaccessor.TokenAccessor
+	collector          collector.EventCollector
+	puContext          string
+	puFromIDCache      cache.DataStore
+	authProcessorCache cache.DataStore
+	serviceMapCache    cache.DataStore
+	dependentAPICache  cache.DataStore
+	jwtCache           cache.DataStore
+	applicationProxy   bool
+	mark               int
+	server             *http.Server
+	fwd                *forward.Forwarder
+	fwdTLS             *forward.Forwarder
 	sync.RWMutex
 }
 
@@ -66,26 +66,26 @@ func NewHTTPProxy(
 	puContext string,
 	puFromIDCache cache.DataStore,
 	caPool *x509.CertPool,
-	exposedAPICache cache.DataStore,
+	serviceMap cache.DataStore,
+	authProcessorCache cache.DataStore,
 	dependentAPICache cache.DataStore,
-	jwtCache cache.DataStore,
 	applicationProxy bool,
 	mark int,
 	secrets secrets.Secrets,
 ) *Config {
 
 	return &Config{
-		collector:         c,
-		tokenaccessor:     tp,
-		puFromIDCache:     puFromIDCache,
-		puContext:         puContext,
-		ca:                caPool,
-		exposedAPICache:   exposedAPICache,
-		dependentAPICache: dependentAPICache,
-		applicationProxy:  applicationProxy,
-		jwtCache:          jwtCache,
-		mark:              mark,
-		secrets:           secrets,
+		collector:          c,
+		tokenaccessor:      tp,
+		puFromIDCache:      puFromIDCache,
+		puContext:          puContext,
+		ca:                 caPool,
+		authProcessorCache: authProcessorCache,
+		serviceMapCache:    serviceMap,
+		dependentAPICache:  dependentAPICache,
+		applicationProxy:   applicationProxy,
+		mark:               mark,
+		secrets:            secrets,
 	}
 }
 
@@ -100,7 +100,8 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		return fmt.Errorf("Server already running")
 	}
 
-	// If its an encrypted, wrap it in a TLS context.
+	// If its an encrypted, wrap the listener in a TLS context. This is activated
+	// for the listener from the network, but not for the listener from a PU.
 	if encrypted {
 		config := &tls.Config{
 			GetCertificate: p.GetCertificateFunc(),
@@ -109,7 +110,8 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		l = tls.NewListener(l, config)
 	}
 
-	// Create an encrypted downstream transport
+	// Create an encrypted downstream transport. We will mark the downstream connection
+	// to let the iptables rule capture it.
 	encryptedTransport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs: p.ca,
@@ -147,6 +149,7 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		},
 	}
 
+	// Create the proxies dowards the network and the application.
 	var err error
 	p.fwdTLS, err = forward.New(forward.RoundTripper(encryptedTransport))
 	if err != nil {
@@ -208,7 +211,37 @@ func (p *Config) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certifica
 	}
 }
 
-func (p *Config) retrieveContextAndPolicy(c cache.DataStore, w http.ResponseWriter, r *http.Request) (*pucontext.PUContext, *urisearch.APICache, error) {
+func (p *Config) retrieveNetworkContext(w http.ResponseWriter, r *http.Request) (*pucontext.PUContext, *auth.Processor, string, error) {
+	pu, err := p.puFromIDCache.Get(p.puContext)
+	if err != nil {
+		zap.L().Error("Cannot find policy, dropping request")
+		http.Error(w, fmt.Sprintf("Cannot handle request: %s", err), http.StatusInternalServerError)
+		return nil, nil, "", err
+	}
+	puContext := pu.(*pucontext.PUContext)
+
+	data, err := p.serviceMapCache.Get(p.puContext)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Cannot handle request - unknown context: %s", p.puContext), http.StatusForbidden)
+		return nil, nil, "", err
+	}
+
+	serviceID, ok := data.(map[string]string)[appendDefaultPort(r.Host)]
+	if !ok {
+		http.Error(w, fmt.Sprintf("Cannot handle request - unknown destination %s", r.Host), http.StatusForbidden)
+		return nil, nil, "", fmt.Errorf("Cannot handle request - unknown destination")
+	}
+
+	authorizer, err := p.authProcessorCache.Get(p.puContext)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Cannot handle request - unknown authorization %s %s", p.puContext, r.Host), http.StatusForbidden)
+		return nil, nil, "", fmt.Errorf("Cannot handle request - unknown authorization: %s %s", p.puContext, r.Host)
+	}
+
+	return puContext, authorizer.(*auth.Processor), serviceID, nil
+}
+
+func (p *Config) retrieveApplicationContext(w http.ResponseWriter, r *http.Request) (*pucontext.PUContext, *urisearch.APICache, error) {
 	pu, err := p.puFromIDCache.Get(p.puContext)
 	if err != nil {
 		zap.L().Error("Cannot find policy, dropping request")
@@ -220,7 +253,7 @@ func (p *Config) retrieveContextAndPolicy(c cache.DataStore, w http.ResponseWrit
 	// Find the right API cache for this context and service. This is done in two steps.
 	// First lookup is to find the PU context. Second lookup is to find the cache based on
 	// the service.
-	data, err := c.Get(p.puContext)
+	data, err := p.dependentAPICache.Get(p.puContext)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Cannot handle request - unknown context: %s", p.puContext), http.StatusForbidden)
 		return nil, nil, err
@@ -239,7 +272,7 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 
 	zap.L().Debug("Processing Application Request", zap.String("URI", r.RequestURI), zap.String("Host", r.Host))
 
-	puContext, apiCache, err := p.retrieveContextAndPolicy(p.dependentAPICache, w, r)
+	puContext, apiCache, err := p.retrieveApplicationContext(w, r)
 	if err != nil {
 		return
 	}
@@ -276,11 +309,10 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For external services we validate policy at the ingress. Note that the
+	// For external services we validate policy at the ingress. Note, that the
 	// certificate distribution service is considered as external and must
 	// be defined as external.
 	if apiCache.External {
-
 		// Get the corresponding scopes
 		found, rule := apiCache.FindRule(r.Method, r.URL.Path)
 		if !found {
@@ -288,14 +320,12 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("Unknown or unauthorized service - no policy found"), http.StatusForbidden)
 			return
 		}
-
 		// If it is a secrets request we process it and move on. No need to
 		// validate policy.
 		if p.isSecretsRequest(w, r) {
 			zap.L().Debug("Processing certificate request", zap.String("URI", r.RequestURI))
 			return
 		}
-
 		if !rule.Public {
 			// Validate the policy based on the scopes of the PU.
 			// TODO: Add user scopes
@@ -304,7 +334,6 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, fmt.Sprintf("Unknown or unauthorized service - rejected by policy"), http.StatusForbidden)
 				return
 			}
-
 			// All checks have passed. We can accept the request, log it, and create the
 			// right tokens. If it is not an external service, we do not log at the transmit side.
 			record.Action = policy.Encrypt
@@ -369,23 +398,15 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 	defer p.collector.CollectFlowEvent(record)
 
 	// Retrieve the context and policy
-	puContext, apiCache, err := p.retrieveContextAndPolicy(p.exposedAPICache, w, r)
+	puContext, authorizer, serviceID, err := p.retrieveNetworkContext(w, r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Uknown service"), http.StatusInternalServerError)
 		record.DropReason = collector.PolicyDrop
 		return
 	}
-	record.ServiceID = apiCache.ID
+	record.ServiceID = serviceID
 	record.Tags = puContext.Annotations()
 	record.Destination.ID = puContext.ManagementID()
-
-	// Find the original port from the URL
-	port, _, err := originalServicePort(w, r)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Unable to detect destination"), http.StatusInternalServerError)
-		record.DropReason = collector.InvalidConnection
-		return
-	}
 
 	// Check for network access rules that might require a drop.
 	_, aclPolicy, noNetAccessPolicy := puContext.NetworkACLPolicyFromAddr(sourceAddress.IP.To4(), uint16(sourceAddress.Port))
@@ -401,29 +422,15 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 	if token != "" {
 		r.Header.Del("X-APORETO-AUTH")
 	}
-
 	key := r.Header.Get("X-APORETO-KEY")
 	if key != "" {
 		r.Header.Del("X-APORETO-LEN")
 	}
 
-	// Process the Auth header for any JWT context.
-	jwtcache, err := p.jwtCache.Get(p.puContext)
-	if err != nil {
-		zap.L().Debug("No JWT cache found for this pu", zap.Error(err))
-	}
-
-	var jwtCert *x509.Certificate
-	if jwtcache != nil {
-		var ok bool
-		jwtCert, ok = jwtcache.(map[string]*x509.Certificate)[port]
-		if !ok {
-			zap.L().Debug("No JWT found for this port", zap.String("port", port))
-		}
-	}
-
-	// Calculate the user attributes and claims.
-	userAttributes := parseUserAttributes(r, jwtCert)
+	// Calculate the user attributes. User attributes can be derived either from a
+	// token or from a certificate. The authorizer library will parse them.
+	userToken, userCerts := userCredentials(r)
+	userAttributes := authorizer.DecodeUserClaims(serviceID, userToken, userCerts)
 	if len(userAttributes) > 0 {
 		userRecord := &collector.UserRecord{Claims: userAttributes}
 		p.collector.CollectUserEvent(userRecord)
@@ -432,18 +439,20 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 		record.Source.Type = collector.EndpointTypeClaims
 	}
 
-	var claims *JWTClaims
-	claims, err = p.parseClientToken(key, token)
-	if err != nil {
-		claims = nil
-	} else {
-		record.Source.ID = claims.SourceID
+	// Calculate the Aporeto PU claims by parsing the token if it exists.
+	sourceID, aporetoClaims := authorizer.DecodeAporetoClaims(serviceID, token, key)
+	if len(aporetoClaims) > 0 {
+		record.Source.ID = sourceID
 		record.Source.Type = collector.EnpointTypePU
 	}
 
+	// We need to verify network policy, before validating the API policy. If a network
+	// policy has given us an accept because of IP address based ACLs we proceed anyway.
+	// This is rather convoluted, but a user might choose to implement network
+	// policies with ACLs only, and we have to cover this case.
 	if noNetAccessPolicy != nil {
-		if claims != nil {
-			_, netPolicyAction := puContext.SearchRcvRules(policy.NewTagStoreFromSlice(claims.Profile))
+		if len(aporetoClaims) > 0 {
+			_, netPolicyAction := puContext.SearchRcvRules(policy.NewTagStoreFromSlice(aporetoClaims))
 			record.PolicyID = netPolicyAction.PolicyID
 			if netPolicyAction.Action.Rejected() {
 				http.Error(w, fmt.Sprintf("Access not authorized by network policy"), http.StatusNetworkAuthenticationRequired)
@@ -456,33 +465,17 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Look in the cache for the method and request URI for the associated scopes
-	// and policies.
-	found, rule := apiCache.FindRule(r.Method, r.URL.Path)
-	if !found {
-		http.Error(w, fmt.Sprintf("Unknown or unauthorized service"), http.StatusForbidden)
+	// We can now validate the API authorization. This is the final step
+	// before forwarding.
+	allClaims := append(aporetoClaims, userAttributes...)
+	if !authorizer.Check(serviceID, r.Method, r.URL.Path, allClaims) {
+		http.Error(w, fmt.Sprintf("Unauthorized Access to %s", r.URL), http.StatusUnauthorized)
+		record.DropReason = collector.PolicyDrop
+		zap.L().Warn("No match found in API token",
+			zap.Strings("User Attributes", userAttributes),
+			zap.Strings("Aporeto Claims", aporetoClaims),
+		)
 		return
-	}
-
-	if !rule.Public {
-		if claims == nil {
-			if len(userAttributes) == 0 {
-				// We have no PU claims or user claims and this is not a public API.
-				// We drop at this point.
-				http.Error(w, err.Error(), http.StatusUnauthorized)
-				record.DropReason = collector.PolicyDrop
-				return
-			}
-			// We have no PU claims. We will rely only on user information for authorization.
-			claims = &JWTClaims{}
-		}
-
-		// Validate the policy and drop the request if there is no authorization.
-		if err = p.verifyPolicy(rule.Scopes, claims.Profile, claims.Scopes, userAttributes); err != nil {
-			record.DropReason = collector.APIPolicyDrop
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
 	}
 
 	// Create the target URI and forward the request.
@@ -493,13 +486,13 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Update the statistics and forward the request. We always encrypt downstream
 	record.Action = policy.Accept | policy.Encrypt
 	record.Destination.IP = originalDestination.IP.String()
 	record.Destination.Port = uint16(originalDestination.Port)
 
-	zap.L().Debug("Forwarding Request", zap.String("URI", r.RequestURI), zap.String("Host", r.Host))
-
 	p.fwd.ServeHTTP(w, r)
+	zap.L().Debug("Forwarding Request", zap.String("URI", r.RequestURI), zap.String("Host", r.Host))
 }
 
 func (p *Config) createClientToken(puContext *pucontext.PUContext) (string, error) {
@@ -514,6 +507,26 @@ func (p *Config) createClientToken(puContext *pucontext.PUContext) (string, erro
 		SourceID: puContext.ManagementID(),
 	}
 	return jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(p.secrets.EncodingKey())
+}
+
+func (p *Config) parseClientToken(txtKey string, token string) (*JWTClaims, error) {
+	key, err := p.secrets.VerifyPublicKey([]byte(txtKey))
+	if err != nil {
+		return &JWTClaims{}, fmt.Errorf("Invalid Service Token")
+	}
+
+	claims := &JWTClaims{}
+	_, err = jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
+		ekey, ok := key.(*ecdsa.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("Invalid key")
+		}
+		return ekey, nil
+	})
+	if err != nil {
+		return claims, fmt.Errorf("Error parsing token: %s", err)
+	}
+	return claims, nil
 }
 
 func (p *Config) verifyPolicy(apitags []string, profile, scopes []string, userAttributes []string) error {
@@ -544,26 +557,6 @@ func (p *Config) verifyPolicy(apitags []string, profile, scopes []string, userAt
 		zap.Strings("PU Scopes", scopes),
 	)
 	return fmt.Errorf("No matching authorization policy")
-}
-
-func (p *Config) parseClientToken(txtKey string, token string) (*JWTClaims, error) {
-	key, err := p.secrets.VerifyPublicKey([]byte(txtKey))
-	if err != nil {
-		return &JWTClaims{}, fmt.Errorf("Invalid Service Token")
-	}
-
-	claims := &JWTClaims{}
-	_, err = jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
-		ekey, ok := key.(*ecdsa.PublicKey)
-		if !ok {
-			return nil, fmt.Errorf("Invalid key")
-		}
-		return ekey, nil
-	})
-	if err != nil {
-		return claims, fmt.Errorf("Error parsing token: %s", err)
-	}
-	return claims, nil
 }
 
 func (p *Config) isSecretsRequest(w http.ResponseWriter, r *http.Request) bool {
@@ -603,89 +596,22 @@ func getServerName(addr string) string {
 	return addr
 }
 
-func parseUserAttributes(r *http.Request, cert *x509.Certificate) []string {
-	attributes := []string{}
-	for _, cert := range r.TLS.PeerCertificates {
-		attributes = append(attributes, "user="+cert.Subject.CommonName)
-		for _, email := range cert.EmailAddresses {
-			attributes = append(attributes, "email="+email)
-		}
-	}
+// userCredentials will find all the user credentials in the http request.
+// TODO: In addition to looking at the headers, we need to look at the parameters
+// in case authorization is provided there.
+func userCredentials(r *http.Request) (string, []*x509.Certificate) {
+
+	certs := r.TLS.PeerCertificates
 
 	authorization := r.Header.Get("Authorization")
 	if len(authorization) < 7 {
-		return attributes
+		return "", certs
 	}
 
 	authorization = strings.TrimPrefix(authorization, "Bearer ")
 	if len(authorization) == 0 {
-		return attributes
+		return "", certs
 	}
 
-	// Use a generic claims map. This allows us to customize the user attributes
-	// by providing the right scopes in the API policy.
-	claims := &jwt.MapClaims{}
-	token, err := jwt.ParseWithClaims(authorization, claims, func(token *jwt.Token) (interface{}, error) {
-		if cert == nil {
-			return nil, fmt.Errorf("Nil certificate - ignore")
-		}
-		switch token.Method {
-		case token.Method.(*jwt.SigningMethodECDSA):
-			if rcert, ok := cert.PublicKey.(*ecdsa.PublicKey); ok {
-				return rcert, nil
-			}
-		case token.Method.(*jwt.SigningMethodRSA):
-			if rcert, ok := cert.PublicKey.(*rsa.PublicKey); ok {
-				return rcert, nil
-			}
-		default:
-			return nil, fmt.Errorf("Unknown signing method")
-		}
-		return nil, fmt.Errorf("Signing method does not match certificate")
-	})
-
-	// We can't decode it. Just ignore the user attributes at this point.
-	if err != nil || token == nil {
-		zap.L().Warn("Identified token, but it is invalid", zap.Error(err))
-		return attributes
-	}
-
-	if !token.Valid {
-		return attributes
-	}
-
-	for k, v := range *claims {
-		if slice, ok := v.([]string); ok {
-			for _, data := range slice {
-				attributes = append(attributes, k+"="+data)
-			}
-		}
-		if attr, ok := v.(string); ok {
-			attributes = append(attributes, k+"="+attr)
-		}
-		if kv, ok := v.(map[string]interface{}); ok {
-			for key, value := range kv {
-				if attr, ok := value.(string); ok {
-					attributes = append(attributes, k+":"+key+"="+attr)
-				}
-			}
-		}
-	}
-
-	return attributes
-}
-
-func originalServicePort(w http.ResponseWriter, r *http.Request) (string, uint16, error) {
-	var err error
-	port := "80"
-	if strings.Contains(r.Host, ":") {
-		_, port, err = net.SplitHostPort(r.Host)
-		if err != nil {
-			zap.L().Error("Invalid HTTP port parameter", zap.Error(err))
-			http.Error(w, fmt.Sprintf("Invalid HTTP port parameter: %s", err), http.StatusUnprocessableEntity)
-			return "", 0, err
-		}
-	}
-	_port, _ := strconv.Atoi(port)
-	return port, uint16(_port), nil
+	return authorization, certs
 }

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -132,6 +132,9 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 				RootCAs:            p.ca,
 				InsecureSkipVerify: false,
 			})
+			for _, s := range p.ca.Subjects() {
+				fmt.Println("At connectiong added subject", string(s))
+			}
 			return tlsConn, nil
 		},
 	}

--- a/controller/internal/enforcer/applicationproxy/markedconn/markedconn.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/markedconn.go
@@ -165,7 +165,6 @@ type ProxiedListener struct {
 func (l ProxiedListener) Accept() (c net.Conn, err error) {
 	nc, err := l.netListener.Accept()
 	if err != nil {
-		fmt.Println("I got an error", err)
 		return nil, err
 	}
 

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -322,8 +322,6 @@ func (p *Proxy) StartClientAuthStateMachine(downIP net.IP, downPort int, downCon
 	// First validate that L3 policies do not require a reject.
 	networkReport, networkPolicy, noNetAccessPolicy := puContext.ApplicationACLPolicyFromAddr(downIP.To4(), uint16(downPort))
 	if noNetAccessPolicy == nil && networkPolicy.Action.Rejected() {
-		fmt.Println("I am dropping at the entry", downIP.To4().String(), networkPolicy.Action.ActionString(), networkPolicy.PolicyID, "report", networkReport.PolicyID)
-		fmt.Printf("Flowproperties %+v\n ", flowproperties)
 		p.reportRejectedFlow(flowproperties, conn, collector.DefaultEndPoint, puContext.ManagementID(), puContext, collector.PolicyDrop, networkReport, networkPolicy)
 		return false, fmt.Errorf("Unauthorized")
 	}

--- a/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -8,6 +8,9 @@ import (
 	"encoding/gob"
 	"fmt"
 
+	"github.com/aporeto-inc/bireme/pkg/generictokens/okta"
+	"github.com/aporeto-inc/bireme/pkg/generictokens/pkitokens"
+
 	"go.uber.org/zap"
 
 	"net"
@@ -252,6 +255,8 @@ func RegisterTypes() {
 	gob.Register(&secrets.CompactPKIPublicSecrets{})
 	gob.Register(&secrets.PKIPublicSecrets{})
 	gob.Register(&secrets.PSKPublicSecrets{})
+	gob.Register(&pkitokens.PKIJWTVerifier{})
+	gob.Register(&okta.Verifier{})
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Request_Payload", *(&InitRequestPayload{}))
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Response_Payload", *(&InitResponsePayload{}))
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Supervisor_Payload", *(&InitSupervisorPayload{}))

--- a/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -8,9 +8,8 @@ import (
 	"encoding/gob"
 	"fmt"
 
-	"github.com/aporeto-inc/bireme/pkg/generictokens/oidc"
-	"github.com/aporeto-inc/bireme/pkg/generictokens/okta"
-	"github.com/aporeto-inc/bireme/pkg/generictokens/pkitokens"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/oidc"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/pkitokens"
 
 	"go.uber.org/zap"
 
@@ -257,7 +256,6 @@ func RegisterTypes() {
 	gob.Register(&secrets.PKIPublicSecrets{})
 	gob.Register(&secrets.PSKPublicSecrets{})
 	gob.Register(&pkitokens.PKIJWTVerifier{})
-	gob.Register(&okta.Verifier{})
 	gob.Register(&oidc.TokenVerifier{})
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Request_Payload", *(&InitRequestPayload{}))
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Response_Payload", *(&InitResponsePayload{}))

--- a/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -8,6 +8,7 @@ import (
 	"encoding/gob"
 	"fmt"
 
+	"github.com/aporeto-inc/bireme/pkg/generictokens/oidc"
 	"github.com/aporeto-inc/bireme/pkg/generictokens/okta"
 	"github.com/aporeto-inc/bireme/pkg/generictokens/pkitokens"
 
@@ -257,6 +258,7 @@ func RegisterTypes() {
 	gob.Register(&secrets.PSKPublicSecrets{})
 	gob.Register(&pkitokens.PKIJWTVerifier{})
 	gob.Register(&okta.Verifier{})
+	gob.Register(&oidc.TokenVerifier{})
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Request_Payload", *(&InitRequestPayload{}))
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Response_Payload", *(&InitResponsePayload{}))
 	gob.RegisterName("go.aporeto.io/internal/enforcer/utils/rpcwrapper.Init_Supervisor_Payload", *(&InitSupervisorPayload{}))

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -104,6 +104,9 @@ func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certi
 	}
 
 	// Now we can parse the user claims.
+	if srv.userJWThandler == nil {
+		return attributes, false, nil
+	}
 	claims, redirect, err := srv.userJWThandler.Validate(r.Context(), userToken)
 	if err != nil {
 		if len(attributes) == 0 {

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -1,0 +1,203 @@
+package auth
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
+	"go.aporeto.io/trireme-lib/controller/pkg/servicetokens"
+	"go.aporeto.io/trireme-lib/controller/pkg/urisearch"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens"
+)
+
+type service struct {
+	apis             *urisearch.APICache
+	userJWThandler   usertokens.Verifier
+	redirect         bool
+	redirectTemplate string
+}
+
+// Processor holds all the local data of the authorization engine. A processor
+// can handle authorization for multiple services. The goal is to authenticate
+// a request based on both service and user credentials.
+type Processor struct {
+	serviceMap map[string]*service
+	aporetoJWT *servicetokens.Verifier
+	sync.RWMutex
+}
+
+// NewProcessor creates an auth processor with PKI user tokens. The caller
+// must provide a valid secrets structure and an optional list of trustedCertificates
+// that can be used to validate tokens. If the list is empty, the CA from the secrets
+// will be used for token validation.
+func NewProcessor(s secrets.Secrets, trustedCertificate *x509.Certificate) *Processor {
+	return &Processor{
+		serviceMap: map[string]*service{},
+		aporetoJWT: servicetokens.NewVerifier(s, trustedCertificate),
+	}
+}
+
+// UpdateSecrets will update the Aporeto secrets for the validation of the
+// Aporeto tokens.
+func (p *Processor) UpdateSecrets(s secrets.Secrets, trustedCertificate *x509.Certificate) {
+	p.aporetoJWT.UpdateSecrets(s, trustedCertificate)
+}
+
+// AddOrUpdateService adds or replaces a service in the authorization db.
+func (p *Processor) AddOrUpdateService(name string, apis *urisearch.APICache, handler usertokens.Verifier) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.serviceMap[name] = &service{
+		apis:           apis,
+		userJWThandler: handler,
+	}
+}
+
+// RemoveService removes a service from the authorization db
+func (p *Processor) RemoveService(name string) {
+	p.Lock()
+	defer p.Unlock()
+
+	delete(p.serviceMap, name)
+}
+
+// UpdateServiceAPIs updates an existing service with a new API definition.
+func (p *Processor) UpdateServiceAPIs(name string, apis *urisearch.APICache) error {
+	p.Lock()
+	defer p.Unlock()
+
+	if srv, ok := p.serviceMap[name]; ok {
+		srv.apis = apis
+		return nil
+	}
+
+	return fmt.Errorf("Service not found")
+}
+
+// DecodeUserClaims decodes the user claims with the user authorization method.
+func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certificate, r *http.Request) ([]string, bool, error) {
+	attributes := []string{}
+
+	srv, ok := p.serviceMap[name]
+	if !ok {
+		return attributes, false, nil
+	}
+
+	// First parse any incoming certificates and retrieve attributes from them.
+	// This is used in case of client authorization with certificates.
+	for _, cert := range certs {
+		attributes = append(attributes, "user="+cert.Subject.CommonName)
+		for _, email := range cert.EmailAddresses {
+			attributes = append(attributes, "email="+email)
+		}
+		for _, org := range cert.Subject.Organization {
+			attributes = append(attributes, "organization=", org)
+		}
+		for _, org := range cert.Subject.OrganizationalUnit {
+			attributes = append(attributes, "ou=", org)
+		}
+	}
+
+	// Now we can parse the user claims.
+	claims, redirect, err := srv.userJWThandler.Validate(r.Context(), userToken)
+	if err != nil {
+		if len(attributes) == 0 {
+			return attributes, redirect, err
+		}
+		return attributes, false, nil
+	}
+
+	return append(attributes, claims...), false, nil
+}
+
+// DecodeAporetoClaims decodes the Aporeto claims
+func (p *Processor) DecodeAporetoClaims(name, aporetoToken string, publicKey string) (string, []string) {
+	if len(aporetoToken) == 0 {
+		return "", []string{}
+	}
+
+	// Finally we can parse the Aporeto token.
+	id, scopes, profile, err := p.aporetoJWT.ParseToken(aporetoToken, publicKey)
+	if err != nil {
+		return "", []string{}
+	}
+	return id, append(profile, scopes...)
+}
+
+// Callback is function called by and IDP auth provider will exchange the provided
+// authorization code with a JWT token. This closes the Oauth loop.
+func (p *Processor) Callback(name string, w http.ResponseWriter, r *http.Request) (int, error) {
+	p.RLock()
+	defer p.RUnlock()
+
+	// We first detect the service that is being called, in order to get the
+	// right OAUTH context.
+	srv, ok := p.serviceMap[name]
+	if !ok {
+		return http.StatusInternalServerError, fmt.Errorf("Unknown service")
+	}
+
+	// Validate the JWT token through the handler.
+	token, originURL, status, err := srv.userJWThandler.Callback(r)
+	if err != nil {
+		return status, err
+	}
+
+	cookie := &http.Cookie{
+		Name:     "X-APORETO-AUTH",
+		Value:    token,
+		HttpOnly: true,
+		Path:     "/",
+		Expires:  time.Now().Add(1 * time.Minute),
+	}
+
+	http.SetCookie(w, cookie)
+
+	// We transmit the information in the return payload for applications
+	// that choose to use it directly without a cookie.
+	data, err := json.MarshalIndent(cookie, " ", " ")
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	// We redirect here to the original URL that the application attempted
+	// to access.
+	w.Header().Add("Location", originURL)
+	http.Error(w, string(data), status)
+
+	return http.StatusFound, err
+}
+
+// Check is the main method that will search API cache and validate whether the call should
+// be allowed. It returns two values. If the access is allowed, and whether the access
+// public or not. This allows callers to decide what to do when there is a failure, and
+// potentially issue a redirect.
+func (p *Processor) Check(name, method, uri string, claims []string) (bool, bool) {
+	p.RLock()
+	defer p.RUnlock()
+
+	srv, ok := p.serviceMap[name]
+	if !ok {
+		return false, false
+	}
+
+	return srv.apis.FindAndMatchScope(method, uri, claims)
+}
+
+// RedirectURI returns the redirect URI in order to start the authentication dance.
+func (p *Processor) RedirectURI(name string, originURL string) string {
+	p.RLock()
+	defer p.RUnlock()
+
+	srv, ok := p.serviceMap[name]
+	if !ok {
+		return ""
+	}
+	//TODO: erropr hanmdlign
+	return srv.userJWThandler.IssueRedirect(originURL)
+}

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -117,7 +117,7 @@ func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certi
 
 // DecodeAporetoClaims decodes the Aporeto claims
 func (p *Processor) DecodeAporetoClaims(name, aporetoToken string, publicKey string) (string, []string) {
-	if len(aporetoToken) == 0 {
+	if len(aporetoToken) == 0 || p.aporetoJWT == nil {
 		return "", []string{}
 	}
 

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -261,7 +261,7 @@ func (s *RemoteEnforcer) Supervise(req rpcwrapper.Request, resp *rpcwrapper.Resp
 
 	puInfo := &policy.PUInfo{
 		ContextID: payload.ContextID,
-		Policy:    payload.Policy.ToPrivatePolicy(),
+		Policy:    payload.Policy.ToPrivatePolicy(false),
 		Runtime:   policy.NewPURuntimeWithDefaults(),
 	}
 
@@ -326,7 +326,7 @@ func (s *RemoteEnforcer) Enforce(req rpcwrapper.Request, resp *rpcwrapper.Respon
 
 	puInfo := &policy.PUInfo{
 		ContextID: payload.ContextID,
-		Policy:    payload.Policy.ToPrivatePolicy(),
+		Policy:    payload.Policy.ToPrivatePolicy(true),
 		Runtime:   policy.NewPURuntimeWithDefaults(),
 	}
 

--- a/controller/pkg/servicetokens/servicetokens.go
+++ b/controller/pkg/servicetokens/servicetokens.go
@@ -1,0 +1,116 @@
+package servicetokens
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/dgrijalva/jwt-go"
+
+	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
+)
+
+// JWTClaims is the structure of the claims we are sending on the wire.
+type JWTClaims struct {
+	jwt.StandardClaims
+	SourceID string
+	Scopes   []string
+	Profile  []string
+}
+
+// Verifier keeps all the structures for processing tokens.
+type Verifier struct {
+	secrets    secrets.Secrets
+	globalCert *x509.Certificate
+	tokenCache gcache.Cache
+	sync.RWMutex
+}
+
+// NewVerifier creates a new Aporeto JWT Verifier. The globalCertificate is optional
+// and is needed for configurations that do not transmit the token over the wire.
+func NewVerifier(s secrets.Secrets, globalCertificate *x509.Certificate) *Verifier {
+	return &Verifier{
+		secrets:    s,
+		globalCert: globalCertificate,
+		// tokenCache will cache the token results to accelerate performance
+		tokenCache: gcache.New(2048).LRU().Expiration(20 * time.Second).Build(),
+	}
+}
+
+// ParseToken parses and validates the JWT token, give the publicKey. It returns the scopes
+// the identity and the sourceID of the provided token. These tokens are strictly
+// signed with EC.
+// TODO: We can be more flexible with the algorithm selection here.
+func (p *Verifier) ParseToken(token string, publicKey string) (string, []string, []string, error) {
+	p.RLock()
+	defer p.RUnlock()
+
+	if data, _ := p.tokenCache.Get(token); data != nil {
+		claims := data.(*JWTClaims)
+		return claims.SourceID, claims.Scopes, claims.Profile, nil
+	}
+
+	// if a public key is transmitted in the wire, we need to verify its validity and use it.
+	// Otherwise we use the public key of the stored secrets.
+	var key *ecdsa.PublicKey
+	var ok bool
+	if len(publicKey) > 0 {
+		// Public keys are cached and verified and they are the compact keys
+		// that we transmit in all other requests signed by the CA. These keys
+		// are not full certificates.
+		gKey, err := p.secrets.VerifyPublicKey([]byte(publicKey))
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("Cannot validate public key: %s", err)
+		}
+		key, ok = gKey.(*ecdsa.PublicKey)
+		if !ok {
+			return "", nil, nil, fmt.Errorf("Provided public key not supported")
+		}
+	} else {
+		if p.globalCert == nil {
+			return "", nil, nil, fmt.Errorf("Cannot validate global public key")
+		}
+		key, ok = p.globalCert.PublicKey.(*ecdsa.PublicKey)
+		if !ok {
+			return "", nil, nil, fmt.Errorf("Global public key is not supported")
+		}
+	}
+
+	claims := &JWTClaims{}
+	if _, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
+		return key, nil
+	}); err != nil {
+		return "", nil, nil, err
+	}
+	return claims.SourceID, claims.Scopes, claims.Profile, nil
+}
+
+// UpdateSecrets updates the secrets of the token Verifier.
+func (p *Verifier) UpdateSecrets(s secrets.Secrets, globalCert *x509.Certificate) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.secrets = s
+	p.globalCert = globalCert
+}
+
+// CreateAndSign creates a new JWT token based on the Aporeto identities.
+func CreateAndSign(server string, profile, scopes []string, id string, validity time.Duration, gkey interface{}) (string, error) {
+	key, ok := gkey.(*ecdsa.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("Not a valid private key format")
+	}
+	claims := &JWTClaims{
+		StandardClaims: jwt.StandardClaims{
+			Issuer:    server,
+			ExpiresAt: time.Now().Add(validity).Unix(),
+		},
+		Profile:  profile,
+		Scopes:   scopes,
+		SourceID: id,
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(key)
+}

--- a/controller/pkg/urisearch/urisearch.go
+++ b/controller/pkg/urisearch/urisearch.go
@@ -66,25 +66,27 @@ func (c *APICache) FindRule(verb, uri string) (bool, *policy.HTTPRule) {
 }
 
 // FindAndMatchScope finds the rule and returns true only if the scope matches
-// as well.
-func (c *APICache) FindAndMatchScope(verb, uri string, attributes []string) bool {
+// as well. It also returns true of this was a public rule, allowing the callers
+// to decide how to present the data or potentially what to do if authorization
+// fails.
+func (c *APICache) FindAndMatchScope(verb, uri string, attributes []string) (bool, bool) {
 	found, rule := c.Find(verb, uri)
 	if !found || rule == nil {
-		return false
+		return false, false
 	}
 	policyRule, ok := rule.(*scopeRule)
 	if !ok {
-		return false
+		return false, false
 	}
 	if policyRule.rule.Public {
-		return true
+		return true, true
 	}
 	for _, attr := range attributes {
 		if _, ok := policyRule.scopes[attr]; ok {
-			return true
+			return true, false
 		}
 	}
-	return false
+	return false, false
 }
 
 // Find finds a URI in the cache and returns true and the data if found.

--- a/controller/pkg/urisearch/urisearch.go
+++ b/controller/pkg/urisearch/urisearch.go
@@ -1,8 +1,6 @@
 package urisearch
 
 import (
-	"fmt"
-
 	"go.aporeto.io/trireme-lib/policy"
 )
 
@@ -176,13 +174,11 @@ func search(n *node, api string) (found bool, data interface{}) {
 	next, foundPrefix = n.children["/*"]
 	if foundPrefix {
 		for len(suffix) > 0 {
-			fmt.Println("Testing with suffix ", suffix)
 			matchedChildren, data := search(next, suffix)
 			if matchedChildren {
 				return true, data
 			}
 			prefix, suffix = parse(suffix)
-			fmt.Println("New suffix ", suffix)
 		}
 		matchedChildren, data := search(next, "/")
 		if matchedChildren {

--- a/controller/pkg/urisearch/urisearch_test.go
+++ b/controller/pkg/urisearch/urisearch_test.go
@@ -329,27 +329,27 @@ func TestFindAndMachScope(t *testing.T) {
 		c := NewAPICache(initTrieRules(), "id", false)
 
 		Convey("When I search for rules matching scopes, it should return true", func() {
-			found := c.FindAndMatchScope("GET", "/users/bob/name", []string{"policy1"})
+			found, _ := c.FindAndMatchScope("GET", "/users/bob/name", []string{"policy1"})
 			So(found, ShouldBeTrue)
 		})
 
 		Convey("When I search for an invalid URI, it should return false", func() {
-			found := c.FindAndMatchScope("GET", "/this/doesnot/exist", []string{"policy1"})
+			found, _ := c.FindAndMatchScope("GET", "/this/doesnot/exist", []string{"policy1"})
 			So(found, ShouldBeFalse)
 		})
 
 		Convey("When I search for a valid URI and not matching scopes, it should return false", func() {
-			found := c.FindAndMatchScope("GET", "/users/bob/name", []string{"policy10"})
+			found, _ := c.FindAndMatchScope("GET", "/users/bob/name", []string{"policy10"})
 			So(found, ShouldBeFalse)
 		})
 
 		Convey("When I search for public rule and bad scopes it should always return true", func() {
-			found := c.FindAndMatchScope("POST", "/v1/things/something", []string{"policy10"})
+			found, _ := c.FindAndMatchScope("POST", "/v1/things/something", []string{"policy10"})
 			So(found, ShouldBeTrue)
 		})
 
 		Convey("When I search for public rule and good scopes it should always return true", func() {
-			found := c.FindAndMatchScope("POST", "/v1/things/something", []string{"policy3"})
+			found, _ := c.FindAndMatchScope("POST", "/v1/things/something", []string{"policy3"})
 			So(found, ShouldBeTrue)
 		})
 	})

--- a/controller/pkg/usertokens/common/common.go
+++ b/controller/pkg/usertokens/common/common.go
@@ -1,0 +1,31 @@
+package common
+
+// JWTType is the type of user JWTs that must be implemented.
+type JWTType int
+
+// Values of JWTType
+const (
+	PKI JWTType = iota
+	OIDC
+)
+
+// FlattenClaim flattes all the generic claims in a flat array for strings.
+func FlattenClaim(key string, claim interface{}) []string {
+	attributes := []string{}
+	if slice, ok := claim.([]string); ok {
+		for _, data := range slice {
+			attributes = append(attributes, key+"="+data)
+		}
+	}
+	if attr, ok := claim.(string); ok {
+		attributes = append(attributes, key+"="+attr)
+	}
+	if kv, ok := claim.(map[string]interface{}); ok {
+		for ikey, ivalue := range kv {
+			if attr, ok := ivalue.(string); ok {
+				attributes = append(attributes, key+":"+ikey+"="+attr)
+			}
+		}
+	}
+	return attributes
+}

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -1,0 +1,177 @@
+package oidc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/rs/xid"
+	"golang.org/x/oauth2"
+
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
+
+	oidc "github.com/coreos/go-oidc"
+)
+
+// TokenVerifier is an OIDC validator.
+type TokenVerifier struct {
+	ProviderURL       string
+	ClientID          string
+	ClientSecret      string
+	RedirectURL       string
+	RedirectOnFail    bool
+	RedirectOnNoToken bool
+	NonceSize         int
+	CookieDuration    time.Duration
+	Scopes            []string
+	provider          *oidc.Provider
+	clientConfig      *oauth2.Config
+	oauthVerifier     *oidc.IDTokenVerifier
+	cache             gcache.Cache
+	state             gcache.Cache
+}
+
+// NewClient creates a new validator client
+func NewClient(ctx context.Context, v *TokenVerifier) (*TokenVerifier, error) {
+
+	// Create a new generic OIDC provider based on the provider URL.
+	// The library will auto-discover the configuration of the provider.
+	// If it is not a compliant provider we should report and error here.
+	provider, err := oidc.NewProvider(ctx, v.ProviderURL)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to initialize provider: %s", err)
+	}
+	oidConfig := &oidc.Config{
+		ClientID: v.ClientID,
+	}
+	v.oauthVerifier = provider.Verifier(oidConfig)
+
+	v.clientConfig = &oauth2.Config{
+		ClientID:     v.ClientID,
+		ClientSecret: v.ClientSecret,
+		Endpoint:     provider.Endpoint(),
+		RedirectURL:  v.RedirectURL,
+		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+	}
+
+	// We maintain two caches. The first maintains the set of states that
+	// we issue the redirect requests with. This helps us validate the
+	// callbacks and verify the state to avoid any cross-origin violations.
+	// Currently providing 60 seconds for the user to authenticate.
+	v.state = gcache.New(2048).LRU().Expiration(60 * time.Second).Build()
+
+	// The second cache will maintain the validations of the tokens so that
+	// we don't go to the authorizer for every request.
+	v.cache = gcache.New(2048).LRU().Expiration(120 * time.Second).Build()
+
+	return v, nil
+}
+
+// IssueRedirect creates the redirect URL. The URI is created by the provider
+// and it includes a state that is random. The state will be remembered
+// for the return. There is an assumption here that the LBs in front of
+// applications are sticky or the TCP session is re-used. Otherwise, we will
+// need a global state that could introduce additional calls to a central
+// system.
+// TODO: add support for a global state.
+func (v *TokenVerifier) IssueRedirect(originURL string) string {
+	state, err := randomSha1(v.NonceSize)
+	if err != nil {
+		state = xid.New().String()
+	}
+	v.state.Set(state, originURL)
+
+	return v.clientConfig.AuthCodeURL(state)
+}
+
+// Callback is the function that is called back by the IDP to catch the token
+// and perform all other validations. It will return the resulting token,
+// the original URL that was called to initiate the protocol, and the
+// http status response.
+func (v *TokenVerifier) Callback(r *http.Request) (string, string, int, error) {
+
+	// We first validate that the callback state matches the original redirect
+	// state. We clean up the cache once it is validated. During this process
+	// we recover the original URL that initiated the protocol. This allows
+	// us to redirect the client to their original request.
+	receivedState := r.URL.Query().Get("state")
+	originURL, err := v.state.Get(receivedState)
+	if err != nil {
+		return "", "", http.StatusBadRequest, fmt.Errorf("Bad state")
+	}
+	v.state.Remove(receivedState)
+
+	// We exchange the authorization code with an OAUTH token. This is the main
+	// step where the OAUTH provider will match the code to the token.
+	oauth2Token, err := v.clientConfig.Exchange(r.Context(), r.URL.Query().Get("code"))
+	if err != nil {
+		return "", "", http.StatusInternalServerError, fmt.Errorf("Bad code: %s", err)
+	}
+
+	// We extract the rawID token.
+	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+	if !ok {
+		return "", "", http.StatusInternalServerError, fmt.Errorf("Bad ID")
+	}
+
+	return rawIDToken, originURL.(string), http.StatusTemporaryRedirect, nil
+}
+
+// Validate checks if the token is valid and returns the claims. The validator
+// maintains an internal cache with tokens to accelerate performance. If the
+// token is not in the cache, it will validate it with the central authorizer.
+func (v *TokenVerifier) Validate(ctx context.Context, token string) ([]string, bool, error) {
+
+	if len(token) == 0 && v.RedirectOnNoToken {
+		return []string{}, v.RedirectOnNoToken, fmt.Errorf("Invalid token presented")
+	}
+
+	if data, err := v.cache.Get(token); err == nil {
+		return data.([]string), false, nil
+	}
+
+	idToken, err := v.oauthVerifier.Verify(ctx, token)
+	if err != nil {
+		return []string{}, v.RedirectOnFail, fmt.Errorf("Token validation failed: %s", err)
+	}
+
+	// Get the claims out of the token. Use the standard data structure for
+	// this and ignore the other fields. We are only interested on the ID.
+	resp := struct {
+		IDTokenClaims map[string]interface{} // ID Token payload is just JSON.
+	}{map[string]interface{}{}}
+	if err := idToken.Claims(&resp.IDTokenClaims); err != nil {
+		return []string{}, v.RedirectOnFail, fmt.Errorf("Unable to process claims: %s", err)
+	}
+
+	// Flatten the claims in a generic format.
+	attributes := []string{}
+	for k, v := range resp.IDTokenClaims {
+		attributes = append(attributes, common.FlattenClaim(k, v)...)
+	}
+
+	// Cache the token and attributes to avoid multiple validations.
+	v.cache.Set(token, attributes)
+
+	return attributes, false, nil
+}
+
+// VerifierType returns the type of the TokenVerifier.
+func (v *TokenVerifier) VerifierType() common.JWTType {
+	return common.OIDC
+}
+
+func randomSha1(nonceSourceSize int) (string, error) {
+	nonceSource := make([]byte, nonceSourceSize)
+	_, err := rand.Read(nonceSource)
+	if err != nil {
+		return "", err
+	}
+	sha := sha1.Sum(nonceSource)
+	return base64.StdEncoding.EncodeToString(sha[:]), nil
+}

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -84,7 +84,9 @@ func (v *TokenVerifier) IssueRedirect(originURL string) string {
 	if err != nil {
 		state = xid.New().String()
 	}
-	v.state.Set(state, originURL)
+	if err := v.state.Set(state, originURL); err != nil {
+		return ""
+	}
 
 	return v.clientConfig.AuthCodeURL(state)
 }
@@ -156,7 +158,9 @@ func (v *TokenVerifier) Validate(ctx context.Context, token string) ([]string, b
 	}
 
 	// Cache the token and attributes to avoid multiple validations.
-	v.cache.Set(token, attributes)
+	if err := v.cache.Set(token, attributes); err != nil {
+		return []string{}, false, fmt.Errorf("Cannot cache token")
+	}
 
 	return attributes, false, nil
 }

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -1,0 +1,111 @@
+package pkitokens
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+
+	"go.aporeto.io/tg/tglib"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
+)
+
+// PKIJWTVerifier is a generic JWT PKI verifier. It assumes that the tokens have
+// been signed by a private key, and it validates them with the provide public key.
+// This is a simple and stateless verifier that doesn't depend on central server
+// for validating the tokens. The public key is provided out-of-band.
+type PKIJWTVerifier struct {
+	JWTCertPEM        []byte
+	jwtCert           *x509.Certificate
+	RedirectOnFail    bool
+	RedirectOnNoToken bool
+	RedirectURL       string
+}
+
+// NewVerifierFromFile assumes that the input is provided as file path.
+func NewVerifierFromFile(jwtcertPath string, redirectURI string, redirectOnFail, redirectOnNoToken bool) (*PKIJWTVerifier, error) {
+	jwtCertPEM, err := ioutil.ReadFile(jwtcertPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read jwt signing certificate from file: %s", err)
+	}
+	return NewVerifierFromPEM(jwtCertPEM, redirectURI, redirectOnFail, redirectOnNoToken)
+}
+
+// NewVerifierFromPEM assumes that the input is a PEM byte array.
+func NewVerifierFromPEM(jwtCertPEM []byte, redirectURI string, redirectOnFail, redirectOnNoToken bool) (*PKIJWTVerifier, error) {
+	jwtCertificate, err := tglib.ParseCertificate(jwtCertPEM)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read jwt signing certificate from PEM: %s", err)
+	}
+	return &PKIJWTVerifier{
+		JWTCertPEM:  jwtCertPEM,
+		jwtCert:     jwtCertificate,
+		RedirectURL: redirectURI,
+	}, nil
+}
+
+// NewVerifier creates a new verifier from the provided configuration.
+func NewVerifier(v *PKIJWTVerifier) (*PKIJWTVerifier, error) {
+	jwtCertificate, err := tglib.ParseCertificate(v.JWTCertPEM)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse certificate: %s", err)
+	}
+	v.jwtCert = jwtCertificate
+	return v, nil
+}
+
+// Validate parses a generic JWT token and flattens the claims in a normalized form. It
+// assumes that the JWT signing certificate will validate the token.
+func (j *PKIJWTVerifier) Validate(ctx context.Context, tokenString string) ([]string, bool, error) {
+	if len(tokenString) == 0 {
+		return []string{}, j.RedirectOnNoToken, fmt.Errorf("Empty token")
+	}
+	claims := &jwt.MapClaims{}
+	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		if j.jwtCert == nil {
+			return nil, fmt.Errorf("Nil certificate - ignore")
+		}
+		switch token.Method {
+		case token.Method.(*jwt.SigningMethodECDSA):
+			if rcert, ok := j.jwtCert.PublicKey.(*ecdsa.PublicKey); ok {
+				return rcert, nil
+			}
+		case token.Method.(*jwt.SigningMethodRSA):
+			if rcert, ok := j.jwtCert.PublicKey.(*rsa.PublicKey); ok {
+				return rcert, nil
+			}
+		default:
+			return nil, fmt.Errorf("Unknown signing method")
+		}
+		return nil, fmt.Errorf("Signing method does not match certificate")
+	})
+	if err != nil || token == nil || !token.Valid {
+		return []string{}, j.RedirectOnFail, fmt.Errorf("Invalid token")
+	}
+
+	attributes := []string{}
+	for k, v := range *claims {
+		attributes = append(attributes, common.FlattenClaim(k, v)...)
+	}
+	return attributes, false, nil
+}
+
+// VerifierType returns the type of the verifier.
+func (j *PKIJWTVerifier) VerifierType() common.JWTType {
+	return common.PKI
+}
+
+// Callback is called by an IDP. Not implemented here. No central authorizer for the tokens.
+func (j *PKIJWTVerifier) Callback(r *http.Request) (string, string, int, error) {
+	return "", "", 0, nil
+}
+
+// IssueRedirect issues a redirect. Not implemented. There is no need for a redirect.
+func (j *PKIJWTVerifier) IssueRedirect(originURL string) string {
+	return ""
+}

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -51,6 +51,9 @@ func NewVerifierFromPEM(jwtCertPEM []byte, redirectURI string, redirectOnFail, r
 
 // NewVerifier creates a new verifier from the provided configuration.
 func NewVerifier(v *PKIJWTVerifier) (*PKIJWTVerifier, error) {
+	if len(v.JWTCertPEM) == 0 {
+		return v, nil
+	}
 	jwtCertificate, err := tglib.ParseCertificate(v.JWTCertPEM)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse certificate: %s", err)

--- a/controller/pkg/usertokens/usetokens.go
+++ b/controller/pkg/usertokens/usetokens.go
@@ -23,6 +23,9 @@ type Verifier interface {
 // NewVerifier initializes data structures based on the interface that
 // is transmitted over the RPC between main and remote enforcers.
 func NewVerifier(v Verifier) Verifier {
+	if v == nil {
+		return nil
+	}
 	switch v.VerifierType() {
 	case common.PKI:
 		p := v.(*pkitokens.PKIJWTVerifier)

--- a/controller/pkg/usertokens/usetokens.go
+++ b/controller/pkg/usertokens/usetokens.go
@@ -1,0 +1,44 @@
+package usertokens
+
+import (
+	"context"
+	"net/http"
+
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/oidc"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/pkitokens"
+)
+
+// Verifier is a generic JWT verifier interface. Different implementations
+// will use different client libraries to verify the tokens. Currently
+// requires only one method. Given a token, return the claims and whether
+// there is a verification error.
+type Verifier interface {
+	VerifierType() common.JWTType
+	Validate(ctx context.Context, token string) ([]string, bool, error)
+	Callback(r *http.Request) (string, string, int, error)
+	IssueRedirect(string) string
+}
+
+// NewVerifier initializes data structures based on the interface that
+// is transmitted over the RPC between main and remote enforcers.
+func NewVerifier(v Verifier) Verifier {
+	switch v.VerifierType() {
+	case common.PKI:
+		p := v.(*pkitokens.PKIJWTVerifier)
+		v, err := pkitokens.NewVerifier(p)
+		if err != nil {
+			return nil
+		}
+		return v
+	case common.OIDC:
+		p := v.(*oidc.TokenVerifier)
+		verifier, err := oidc.NewClient(context.Background(), p)
+		// TODO figure out error handling
+		if err != nil {
+			return nil
+		}
+		return verifier
+	}
+	return nil
+}

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"github.com/aporeto-inc/bireme/pkg/generictokens"
 	"go.aporeto.io/trireme-lib/common"
 )
 
@@ -46,7 +47,7 @@ type ApplicationService struct {
 	// JWTCertificate is a certificate for validating JWT bearer tokens in http requests.
 	// It is only useful for HTTP services where the Bearer Authentication header provides
 	// a JWT token. It is used to validate the JWT tokens.
-	JWTCertificate []byte
+	JWTTokenHandler generictokens.Verifier
 
 	// External indicates if this is an external service. For external services
 	// access control is implemented at the ingress.

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -1,8 +1,8 @@
 package policy
 
 import (
-	"github.com/aporeto-inc/bireme/pkg/generictokens"
 	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens"
 )
 
 // ServiceType are the types of services that can are suported.
@@ -47,7 +47,7 @@ type ApplicationService struct {
 	// JWTCertificate is a certificate for validating JWT bearer tokens in http requests.
 	// It is only useful for HTTP services where the Bearer Authentication header provides
 	// a JWT token. It is used to validate the JWT tokens.
-	JWTTokenHandler generictokens.Verifier
+	JWTTokenHandler usertokens.Verifier
 
 	// External indicates if this is an external service. For external services
 	// access control is implemented at the ingress.

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -3,7 +3,7 @@ package policy
 import (
 	"sync"
 
-	"github.com/aporeto-inc/bireme/pkg/generictokens"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens"
 )
 
 // PUPolicy captures all policy information related ot the container
@@ -424,7 +424,7 @@ func (p *PUPolicyPublic) ToPrivatePolicy(convert bool) *PUPolicy {
 	exposedServices := ApplicationServicesList{}
 	for _, e := range p.ExposedServices {
 		if convert {
-			e.JWTTokenHandler = generictokens.NewVerifier(e.JWTTokenHandler)
+			e.JWTTokenHandler = usertokens.NewVerifier(e.JWTTokenHandler)
 		}
 		exposedServices = append(exposedServices, e)
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -2,6 +2,8 @@ package policy
 
 import (
 	"sync"
+
+	"github.com/aporeto-inc/bireme/pkg/generictokens"
 )
 
 // PUPolicy captures all policy information related ot the container
@@ -418,6 +420,13 @@ type PUPolicyPublic struct {
 
 // ToPrivatePolicy converts the object to a private object.
 func (p *PUPolicyPublic) ToPrivatePolicy() *PUPolicy {
+
+	exposedServices := ApplicationServicesList{}
+	for _, e := range p.ExposedServices {
+		e.JWTTokenHandler = generictokens.NewVerifier(e.JWTTokenHandler)
+		exposedServices = append(exposedServices, e)
+	}
+
 	return &PUPolicy{
 		managementID:        p.ManagementID,
 		triremeAction:       p.TriremeAction,
@@ -431,7 +440,7 @@ func (p *PUPolicyPublic) ToPrivatePolicy() *PUPolicy {
 		triremeNetworks:     p.TriremeNetworks,
 		excludedNetworks:    p.ExcludedNetworks,
 		proxiedServices:     p.ProxiedServices,
-		exposedServices:     p.ExposedServices,
+		exposedServices:     exposedServices,
 		dependentServices:   p.DependentServices,
 		scopes:              p.Scopes,
 		servicesCA:          p.ServicesCA,

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -419,11 +419,13 @@ type PUPolicyPublic struct {
 }
 
 // ToPrivatePolicy converts the object to a private object.
-func (p *PUPolicyPublic) ToPrivatePolicy() *PUPolicy {
+func (p *PUPolicyPublic) ToPrivatePolicy(convert bool) *PUPolicy {
 
 	exposedServices := ApplicationServicesList{}
 	for _, e := range p.ExposedServices {
-		e.JWTTokenHandler = generictokens.NewVerifier(e.JWTTokenHandler)
+		if convert {
+			e.JWTTokenHandler = generictokens.NewVerifier(e.JWTTokenHandler)
+		}
 		exposedServices = append(exposedServices, e)
 	}
 


### PR DESCRIPTION
#### Description
This PR introduces generic support in Trireme for third party OIDC providers. Identities from these providers can be used for user authorization. The integration enables the definition of the OAUTH parameters and introduces the option for Trireme to redirect callers to an OIDC provider for authorization. This allows Trireme to support user authorization with Okta, Google, and other OIDC compliant identity providers.