### PR TITLE
Send FinAck to pre-existing UIDPAM ssh connections.

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -968,7 +968,8 @@ func (d *Datapath) netRetrieveState(p *packet.Packet) (*connection.TCPConnection
 				// Let's try if its an existing connection
 				context, cerr := d.contextFromIP(false, p.DestinationAddress.String(), p.Mark, p.DestinationPort, packet.IPProtocolTCP)
 				if cerr != nil {
-					return nil, errors.New("No context in app processing")
+					err := p.ConvertAcktoFinAck()
+					return nil, fmt.Errorf("No context in app processing:%s", err)
 				}
 				conn = connection.NewTCPConnection(context)
 				conn.(*connection.TCPConnection).SetState(connection.UnknownState)

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -968,7 +968,7 @@ func (d *Datapath) netRetrieveState(p *packet.Packet) (*connection.TCPConnection
 				// Let's try if its an existing connection
 				context, cerr := d.contextFromIP(false, p.DestinationAddress.String(), p.Mark, p.DestinationPort, packet.IPProtocolTCP)
 				if cerr != nil {
-					err := p.ConvertAcktoFinAck()
+					err = p.ConvertAcktoFinAck()
 					return nil, fmt.Errorf("No context in app processing:%s", err)
 				}
 				conn = connection.NewTCPConnection(context)


### PR DESCRIPTION
For UIDPAM ssh PUs, an existing connection from ssh user (before the enforcer was introduced), need to be closed rather than relying on the client to send a Reset after numerous packet drops.
