### PR TITLE
Enforcerd as sidecar container.

### DIFF
--- a/controller/constants/constants.go
+++ b/controller/constants/constants.go
@@ -70,4 +70,6 @@ const (
 	RemoteContainer ModeType = iota
 	// LocalServer indicates that the Supervisor applies to Linux processes
 	LocalServer
+	// Sidecar indicates the controller to be in sidecar mode
+	Sidecar
 )

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -35,12 +35,12 @@ type trireme struct {
 }
 
 // New returns a trireme interface implementation based on configuration provided.
-func New(serverID string, opts ...Option) TriremeController {
+func New(serverID string, mode constants.ModeType, opts ...Option) TriremeController {
 
 	c := &config{
 		serverID:               serverID,
 		collector:              collector.NewDefaultCollector(),
-		mode:                   constants.RemoteContainer,
+		mode:                   mode,
 		fq:                     fqconfig.NewFilterQueueWithDefaults(),
 		mutualAuth:             true,
 		validity:               time.Hour * 8760,
@@ -232,7 +232,10 @@ func (t *trireme) doUpdatePolicy(contextID string, newPolicy *policy.PUPolicy, r
 	if err := t.enforcers[t.puTypeToEnforcerType[containerInfo.Runtime.PUType()]].Enforce(contextID, containerInfo); err != nil {
 		//We lost communication with the remote and killed it lets restart it here by feeding a create event in the request channel
 		zap.L().Warn("Re-initializing enforcers - connection lost", zap.Error(err))
-		if containerInfo.Runtime.PUType() == common.ContainerPU {
+
+		// Varks: below statement is not required. Remove it later on.
+		isSidecar := t.puTypeToEnforcerType[containerInfo.Runtime.PUType()] == constants.Sidecar
+		if containerInfo.Runtime.PUType() == common.ContainerPU && !isSidecar {
 			//The unsupervise and unenforce functions just make changes to the proxy structures
 			//and do not depend on the remote instance running and can be called here
 			switch t.enforcers[t.puTypeToEnforcerType[containerInfo.Runtime.PUType()]].(type) {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -233,7 +233,6 @@ func (t *trireme) doUpdatePolicy(contextID string, newPolicy *policy.PUPolicy, r
 		//We lost communication with the remote and killed it lets restart it here by feeding a create event in the request channel
 		zap.L().Warn("Re-initializing enforcers - connection lost", zap.Error(err))
 
-		// Varks: below statement is not required. Remove it later on.
 		isSidecar := t.puTypeToEnforcerType[containerInfo.Runtime.PUType()] == constants.Sidecar
 		if containerInfo.Runtime.PUType() == common.ContainerPU && !isSidecar {
 			//The unsupervise and unenforce functions just make changes to the proxy structures

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -241,6 +241,17 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 
 	rules := [][]string{}
 
+	// If enforcer is in sidecar mode. we need to add an exclusive dns rule
+	// to accept the dns traffic. This is required for the enforcer to talk to
+	// to the backend services.
+	if i.mode == constants.Sidecar {
+		rules = append(rules, []string{
+			i.appPacketIPTableContext, appChain,
+			"-p", "udp", "-dport", "53",
+			"-j", "ACCEPT",
+		})
+	}
+
 	// Application Packets - SYN
 	rules = append(rules, []string{
 		i.appPacketIPTableContext, appChain,
@@ -270,6 +281,17 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 		"-p", "udp",
 		"-j", "NFQUEUE", "--queue-balance", i.fqc.GetApplicationQueueAckStr(),
 	})
+
+	// If enforcer is in sidecar mode. we need to add an exclusive dns rule
+	// to accept the dns traffic. This is required for the enforcer to talk to
+	// to the backend services.
+	if i.mode == constants.Sidecar {
+		rules = append(rules, []string{
+			i.netPacketIPTableContext, netChain,
+			"-p", "udp", "-sport", "53",
+			"-j", "ACCEPT",
+		})
+	}
 
 	// Network Packets - SYN
 	rules = append(rules, []string{

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -247,7 +247,7 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 	if i.mode == constants.Sidecar {
 		rules = append(rules, []string{
 			i.appPacketIPTableContext, appChain,
-			"-p", "udp", "-dport", "53",
+			"-p", "udp", "--dport", "53",
 			"-j", "ACCEPT",
 		})
 	}
@@ -288,7 +288,7 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 	if i.mode == constants.Sidecar {
 		rules = append(rules, []string{
 			i.netPacketIPTableContext, netChain,
-			"-p", "udp", "-sport", "53",
+			"-p", "udp", "--sport", "53",
 			"-j", "ACCEPT",
 		})
 	}

--- a/controller/internal/supervisor/iptablesctrl/acls_test.go
+++ b/controller/internal/supervisor/iptablesctrl/acls_test.go
@@ -260,6 +260,49 @@ func TestAddPacketTrap(t *testing.T) {
 		})
 
 	})
+
+	Convey("Given an iptables controller, when I test addPacketTrap for sidecar container", t, func() {
+		i, _ := NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.Sidecar, portset.New(nil))
+		iptables := provider.NewTestIptablesProvider()
+		i.ipt = iptables
+
+		Convey("When I add the packet trap rules and they succeed", func() {
+			iptables.MockAppend(t, func(table string, chain string, rulespec ...string) error {
+				return nil
+			})
+			err := i.addPacketTrap("appchain", "netchain", []string{"172.17.0.0/24"})
+			Convey("I should get no error", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When I add the packet trap rules and the appPacketIPTableContext fails ", func() {
+			iptables.MockAppend(t, func(table string, chain string, rulespec ...string) error {
+				if table == i.appPacketIPTableContext {
+					return errors.New("error")
+				}
+				return nil
+			})
+			err := i.addPacketTrap("appchain", "netchain", []string{"172.17.0.0/24"})
+			Convey("I should get  error", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When I add the packet trap rules and the netPacketIPtableContext fails ", func() {
+			iptables.MockAppend(t, func(table string, chain string, rulespec ...string) error {
+				if table == i.netPacketIPTableContext {
+					return errors.New("error")
+				}
+				return nil
+			})
+			err := i.addPacketTrap("appchain", "netchain", []string{"172.17.0.0/24"})
+			Convey("I should get  error", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+	})
 }
 
 func TestAddAppACLs(t *testing.T) {

--- a/controller/internal/supervisor/iptablesctrl/iptables.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables.go
@@ -418,7 +418,7 @@ func (i *Instance) installRules(contextID, appChain, netChain, proxySetName stri
 	}
 
 	// If its a remote and thus container, configure container rules.
-	if i.mode == constants.RemoteContainer {
+	if i.mode == constants.RemoteContainer || i.mode == constants.Sidecar {
 		if err := i.configureContainerRules(contextID, appChain, netChain, proxySetName, containerInfo); err != nil {
 			return err
 		}


### PR DESCRIPTION
This is an initial PR to run enforcerd as a sidecar container. This introduces a new mode called Sidecar which creates a single PU for all the containers that share a network namespace as in a Kubernetes pod.