### PR TITLE
Enable user JWT mappings to copy JWT claims to downstream http headers

### DIFF
--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -376,7 +376,7 @@ func buildExposedServices(p *auth.Processor, exposedServices policy.ApplicationS
 			continue
 		}
 		ruleCache := urisearch.NewAPICache(service.HTTPRules, service.ID, false)
-		p.AddOrUpdateService(service.ID, ruleCache, service.JWTTokenHandler)
+		p.AddOrUpdateService(service.ID, ruleCache, service.JWTTokenHandler, service.JWTClaimMappings)
 		for _, fqdn := range service.NetworkInfo.FQDNs {
 			rhost := fqdn + ":" + service.NetworkInfo.Ports.String()
 			serviceMap[rhost] = service.ID

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -510,6 +510,9 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Update the request headers with the user attributes as defined by the mappings
+	authorizer.UpdateRequestHeaders(serviceID, r, userAttributes)
+
 	// Update the statistics and forward the request. We always encrypt downstream
 	record.Action = policy.Accept | policy.Encrypt
 	record.Destination.IP = originalDestination.IP.String()

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -44,10 +44,14 @@ type ApplicationService struct {
 	// Tags are the tags of the service.
 	Tags *TagStore
 
-	// JWTCertificate is a certificate for validating JWT bearer tokens in http requests.
-	// It is only useful for HTTP services where the Bearer Authentication header provides
-	// a JWT token. It is used to validate the JWT tokens.
+	// JWTTokenHandler is the token handler for validating user JWT tokens.
 	JWTTokenHandler usertokens.Verifier
+
+	// JWTClaimMappings is a map of mappings between JWT claims arriving in
+	// a user request and outgoing HTTP headers towards an application. It
+	// is used to allow operators to map claims to HTTP headers that downstream
+	// applications can understand.
+	JWTClaimMappings map[string]string
 
 	// External indicates if this is an external service. For external services
 	// access control is implemented at the ingress.


### PR DESCRIPTION
#### Description
Enables a new feature where user JWT claims can be mapped based on policy to downstream HTTP headers that an application can consume. 