### PR TITLE
Fix updates of target networks

### DIFF
--- a/controller/internal/supervisor/supervisor.go
+++ b/controller/internal/supervisor/supervisor.go
@@ -159,9 +159,14 @@ func (s *Config) SetTargetNetworks(networks []string) error {
 	if len(networks) == 0 {
 		networks = []string{"0.0.0.0/1", "128.0.0.0/1"}
 	}
+
+	if err := s.impl.SetTargetNetworks(s.triremeNetworks, networks); err != nil {
+		return err
+	}
+
 	s.triremeNetworks = networks
 
-	return s.impl.SetTargetNetworks(s.triremeNetworks, networks)
+	return nil
 }
 
 func (s *Config) doCreatePU(contextID string, pu *policy.PUInfo) error {


### PR DESCRIPTION
#### Description
Fixes the updates of target networks. The variable was assigned to the new target 
networks and then used. Order was reverted.
