### PR TITLE
Add claims to external services

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -478,6 +478,10 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("Access denied by network policy"), http.StatusNetworkAuthenticationRequired)
 			return
 		}
+	} else {
+		if aclPolicy.Action.Accepted() {
+			aporetoClaims = append(aporetoClaims, aclPolicy.Labels...)
+		}
 	}
 
 	// We can now validate the API authorization. This is the final step

--- a/policy/types.go
+++ b/policy/types.go
@@ -158,6 +158,7 @@ type FlowPolicy struct {
 	Action        ActionType
 	ServiceID     string
 	PolicyID      string
+	Labels        []string
 }
 
 // LogPrefix is the prefix used in nf-log action. It must be less than


### PR DESCRIPTION
#### Description
When a request matches a non-trireme network we augment the request with the corresponding
labels of the external network and these labels can be used in the API authorization function
to selectively allow access to specific IP to a give API. 
