### PR TITLE
Report stats for failing to reach upstream 

### DIFF
--- a/collector/interfaces.go
+++ b/collector/interfaces.go
@@ -30,6 +30,8 @@ const (
 	PolicyDrop = "policy"
 	// APIPolicyDrop indicates that the request was dropped because of failed API validation.
 	APIPolicyDrop = "api"
+	// UnableToDial indicates that the proxy cannot dial out the connection
+	UnableToDial = "dial"
 )
 
 // Container event description

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -121,7 +121,6 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 				r.Action = policy.Reject
 				r.DropReason = collector.UnableToDial
 				r.PolicyID = "default"
-				fmt.Printf("Dispatching stats report %+v\n", r)
 				p.collector.CollectFlowEvent(r)
 			}
 		}

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -27,8 +27,11 @@ import (
 	"go.uber.org/zap"
 )
 
+type statsContextKeyType string
+
 const (
 	defaultValidity = 60 * time.Second
+	statsContextKey = statsContextKeyType("statsContext")
 )
 
 // JWTClaims is the structure of the claims we are sending on the wire.
@@ -112,6 +115,18 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		l = tls.NewListener(l, config)
 	}
 
+	reportStats := func(ctx context.Context) {
+		if statsRecord := ctx.Value(statsContextKey); statsRecord != nil {
+			if r, ok := statsRecord.(*collector.FlowRecord); ok {
+				r.Action = policy.Reject
+				r.DropReason = collector.UnableToDial
+				r.PolicyID = "default"
+				fmt.Printf("Dispatching stats report %+v\n", r)
+				p.collector.CollectFlowEvent(r)
+			}
+		}
+	}
+
 	// Create an encrypted downstream transport. We will mark the downstream connection
 	// to let the iptables rule capture it.
 	encryptedTransport := &http.Transport{
@@ -121,10 +136,12 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			raddr, err := net.ResolveTCPAddr(network, ctx.Value(http.LocalAddrContextKey).(*net.TCPAddr).String())
 			if err != nil {
+				reportStats(ctx)
 				return nil, err
 			}
 			conn, err := markedconn.DialMarkedTCP("tcp", nil, raddr, p.mark)
 			if err != nil {
+				reportStats(ctx)
 				return nil, err
 			}
 			return conn, nil
@@ -136,10 +153,12 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			raddr, err := net.ResolveTCPAddr(network, ctx.Value(http.LocalAddrContextKey).(*net.TCPAddr).String())
 			if err != nil {
+				reportStats(ctx)
 				return nil, err
 			}
 			conn, err := markedconn.DialMarkedTCP("tcp", nil, raddr, p.mark)
 			if err != nil {
+				reportStats(ctx)
 				return nil, fmt.Errorf("Failed to dial remote: %s", err)
 			}
 			return conn, nil
@@ -277,7 +296,6 @@ func (p *Config) retrieveApplicationContext(w http.ResponseWriter, r *http.Reque
 }
 
 func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
-
 	zap.L().Debug("Processing Application Request", zap.String("URI", r.RequestURI), zap.String("Host", r.Host))
 
 	puContext, apiCache, err := p.retrieveApplicationContext(w, r)
@@ -300,6 +318,7 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 		Source: &collector.EndPoint{
 			Type: collector.EnpointTypePU,
 			ID:   puContext.ManagementID(),
+			IP:   "0.0.0.0/0",
 		},
 		Action:      policy.Reject,
 		L4Protocol:  packet.IPProtocolTCP,
@@ -375,12 +394,12 @@ func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 	r.Header.Add("X-APORETO-KEY", string(p.secrets.TransmittedKey()))
 	r.Header.Add("X-APORETO-AUTH", token)
 
+	contextWithStats := context.WithValue(r.Context(), statsContextKey, record)
 	// Forward the request.
-	p.fwdTLS.ServeHTTP(w, r)
+	p.fwdTLS.ServeHTTP(w, r.WithContext(contextWithStats))
 }
 
 func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
-
 	zap.L().Debug("Processing Network Request", zap.String("URI", r.RequestURI), zap.String("Host", r.Host))
 	originalDestination := r.Context().Value(http.LocalAddrContextKey).(*net.TCPAddr)
 
@@ -527,7 +546,9 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 	record.Action = policy.Accept | policy.Encrypt
 	record.Destination.IP = originalDestination.IP.String()
 	record.Destination.Port = uint16(originalDestination.Port)
-	p.fwd.ServeHTTP(w, r)
+
+	contextWithStats := context.WithValue(r.Context(), statsContextKey, record)
+	p.fwd.ServeHTTP(w, r.WithContext(contextWithStats))
 	zap.L().Debug("Forwarding Request", zap.String("URI", r.RequestURI), zap.String("Host", r.Host))
 }
 

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -146,14 +146,16 @@ func (p *Proxy) handle(ctx context.Context, upConn net.Conn) {
 			DestType:   collector.EndPointTypeExternalIP,
 			SourceType: collector.EnpointTypePU,
 		}
-		puContext, err := p.puContextFromContextID(p.puContext)
-		var managementID string
-		if err != nil {
-			puContext = nil
-		} else {
-			managementID = puContext.ManagementID()
+
+		puContext, perr := p.puContextFromContextID(p.puContext)
+		if perr != nil {
+			zap.L().Error("Unable to find policy context for tcp connection",
+				zap.String("Context", p.puContext),
+				zap.Error(perr))
+			return
 		}
-		p.reportRejectedFlow(flowproperties, managementID, "default", puContext, collector.UnableToDial, nil, nil)
+
+		p.reportRejectedFlow(flowproperties, puContext.ManagementID(), "default", puContext, collector.UnableToDial, nil, nil)
 		return
 	}
 	defer downConn.Close() // nolint

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -139,6 +139,21 @@ func (p *Proxy) handle(ctx context.Context, upConn net.Conn) {
 
 	downConn, err := p.downConnection(ip, port)
 	if err != nil {
+		flowproperties := &proxyFlowProperties{
+			DestIP:     ip.String(),
+			DestPort:   uint16(port),
+			SourceIP:   upConn.RemoteAddr().(*net.TCPAddr).IP.String(),
+			DestType:   collector.EndPointTypeExternalIP,
+			SourceType: collector.EnpointTypePU,
+		}
+		puContext, err := p.puContextFromContextID(p.puContext)
+		var managementID string
+		if err != nil {
+			puContext = nil
+		} else {
+			managementID = puContext.ManagementID()
+		}
+		p.reportRejectedFlow(flowproperties, managementID, "default", puContext, collector.UnableToDial, nil, nil)
 		return
 	}
 	defer downConn.Close() // nolint
@@ -314,7 +329,7 @@ func (p *Proxy) StartClientAuthStateMachine(downIP net.IP, downPort int, downCon
 	// First validate that L3 policies do not require a reject.
 	networkReport, networkPolicy, noNetAccessPolicy := puContext.ApplicationACLPolicyFromAddr(downIP.To4(), uint16(downPort))
 	if noNetAccessPolicy == nil && networkPolicy.Action.Rejected() {
-		p.reportRejectedFlow(flowproperties, conn, puContext.ManagementID(), networkPolicy.ServiceID, puContext, collector.PolicyDrop, networkReport, networkPolicy)
+		p.reportRejectedFlow(flowproperties, puContext.ManagementID(), networkPolicy.ServiceID, puContext, collector.PolicyDrop, networkReport, networkPolicy)
 		return false, fmt.Errorf("Unauthorized by Application ACLs")
 	}
 
@@ -343,12 +358,12 @@ func (p *Proxy) StartClientAuthStateMachine(downIP net.IP, downPort int, downCon
 			}
 			claims, err := p.tokenaccessor.ParsePacketToken(&conn.Auth, msg)
 			if err != nil || claims == nil {
-				p.reportRejectedFlow(flowproperties, conn, puContext.ManagementID(), collector.DefaultEndPoint, puContext, collector.InvalidToken, nil, nil)
+				p.reportRejectedFlow(flowproperties, puContext.ManagementID(), collector.DefaultEndPoint, puContext, collector.InvalidToken, nil, nil)
 				return false, fmt.Errorf("peer token reject because of bad claims: error: %s, claims: %v %v", err, claims, string(msg))
 			}
 			report, packet := puContext.SearchTxtRules(claims.T, false)
 			if packet.Action.Rejected() {
-				p.reportRejectedFlow(flowproperties, conn, puContext.ManagementID(), conn.Auth.RemoteContextID, puContext, collector.PolicyDrop, report, packet)
+				p.reportRejectedFlow(flowproperties, puContext.ManagementID(), conn.Auth.RemoteContextID, puContext, collector.PolicyDrop, report, packet)
 				return isEncrypted, errors.New("dropping because of reject rule on transmitter")
 			}
 			if packet.Action.Encrypted() {
@@ -396,7 +411,7 @@ func (p *Proxy) StartServerAuthStateMachine(ip fmt.Stringer, backendport int, up
 	networkReport, networkPolicy, noNetAccessPolicy := puContext.NetworkACLPolicyFromAddr(upConn.RemoteAddr().(*net.TCPAddr).IP.To4(), uint16(backendport))
 	if noNetAccessPolicy == nil && networkPolicy.Action.Rejected() {
 		flowProperties.SourceType = collector.EndPointTypeExternalIP
-		p.reportRejectedFlow(flowProperties, conn, networkPolicy.ServiceID, puContext.ManagementID(), puContext, collector.PolicyDrop, networkReport, networkPolicy)
+		p.reportRejectedFlow(flowProperties, networkPolicy.ServiceID, puContext.ManagementID(), puContext, collector.PolicyDrop, networkReport, networkPolicy)
 		return false, fmt.Errorf("Unauthorized by Network ACLs")
 	}
 
@@ -418,14 +433,14 @@ func (p *Proxy) StartServerAuthStateMachine(ip fmt.Stringer, backendport int, up
 			}
 			claims, err := p.tokenaccessor.ParsePacketToken(&conn.Auth, msg)
 			if err != nil || claims == nil {
-				p.reportRejectedFlow(flowProperties, conn, collector.DefaultEndPoint, puContext.ManagementID(), puContext, collector.InvalidToken, nil, nil)
+				p.reportRejectedFlow(flowProperties, collector.DefaultEndPoint, puContext.ManagementID(), puContext, collector.InvalidToken, nil, nil)
 				return isEncrypted, fmt.Errorf("reported rejected flow due to invalid token: %s", err)
 			}
 			tags := claims.T.Copy()
 			tags.AppendKeyValue(enforcerconstants.PortNumberLabelString, strconv.Itoa(int(backendport)))
 			report, packet := puContext.SearchRcvRules(tags)
 			if packet.Action.Rejected() {
-				p.reportRejectedFlow(flowProperties, conn, conn.Auth.RemoteContextID, puContext.ManagementID(), puContext, collector.PolicyDrop, report, packet)
+				p.reportRejectedFlow(flowProperties, conn.Auth.RemoteContextID, puContext.ManagementID(), puContext, collector.PolicyDrop, report, packet)
 				return isEncrypted, fmt.Errorf("connection dropped by policy %s: ", packet.PolicyID)
 			}
 
@@ -460,16 +475,16 @@ func (p *Proxy) StartServerAuthStateMachine(ip fmt.Stringer, backendport int, up
 				return false, fmt.Errorf("unable to receive ack token: %s", err)
 			}
 			if _, err := p.tokenaccessor.ParseAckToken(&conn.Auth, msg); err != nil {
-				p.reportRejectedFlow(flowProperties, conn, collector.DefaultEndPoint, puContext.ManagementID(), puContext, collector.InvalidFormat, nil, nil)
+				p.reportRejectedFlow(flowProperties, collector.DefaultEndPoint, puContext.ManagementID(), puContext, collector.InvalidFormat, nil, nil)
 				return isEncrypted, fmt.Errorf("ack packet dropped because signature validation failed %s", err)
 			}
-			p.reportAcceptedFlow(flowProperties, conn, conn.Auth.RemoteContextID, puContext.ManagementID(), puContext, conn.ReportFlowPolicy, conn.PacketFlowPolicy)
+			p.reportAcceptedFlow(flowProperties, conn.Auth.RemoteContextID, puContext.ManagementID(), puContext, conn.ReportFlowPolicy, conn.PacketFlowPolicy)
 			return isEncrypted, nil
 		}
 	}
 }
 
-func (p *Proxy) reportFlow(flowproperties *proxyFlowProperties, conn *connection.ProxyConnection, sourceID string, destID string, context *pucontext.PUContext, mode string, reportAction *policy.FlowPolicy, packetAction *policy.FlowPolicy) {
+func (p *Proxy) reportFlow(flowproperties *proxyFlowProperties, sourceID string, destID string, context *pucontext.PUContext, mode string, reportAction *policy.FlowPolicy, packetAction *policy.FlowPolicy) {
 	c := &collector.FlowRecord{
 		ContextID: context.ID(),
 		Source: &collector.EndPoint{
@@ -501,12 +516,12 @@ func (p *Proxy) reportFlow(flowproperties *proxyFlowProperties, conn *connection
 	p.collector.CollectFlowEvent(c)
 }
 
-func (p *Proxy) reportAcceptedFlow(flowproperties *proxyFlowProperties, conn *connection.ProxyConnection, sourceID string, destID string, context *pucontext.PUContext, report *policy.FlowPolicy, packet *policy.FlowPolicy) {
+func (p *Proxy) reportAcceptedFlow(flowproperties *proxyFlowProperties, sourceID string, destID string, context *pucontext.PUContext, report *policy.FlowPolicy, packet *policy.FlowPolicy) {
 
-	p.reportFlow(flowproperties, conn, sourceID, destID, context, "N/A", report, packet)
+	p.reportFlow(flowproperties, sourceID, destID, context, "N/A", report, packet)
 }
 
-func (p *Proxy) reportRejectedFlow(flowproperties *proxyFlowProperties, conn *connection.ProxyConnection, sourceID string, destID string, context *pucontext.PUContext, mode string, report *policy.FlowPolicy, packet *policy.FlowPolicy) {
+func (p *Proxy) reportRejectedFlow(flowproperties *proxyFlowProperties, sourceID string, destID string, context *pucontext.PUContext, mode string, report *policy.FlowPolicy, packet *policy.FlowPolicy) {
 
 	if report == nil {
 		report = &policy.FlowPolicy{
@@ -517,7 +532,7 @@ func (p *Proxy) reportRejectedFlow(flowproperties *proxyFlowProperties, conn *co
 	if packet == nil {
 		packet = report
 	}
-	p.reportFlow(flowproperties, conn, sourceID, destID, context, mode, report, packet)
+	p.reportFlow(flowproperties, sourceID, destID, context, mode, report, packet)
 }
 
 func readMsg(reader io.Reader) ([]byte, error) {


### PR DESCRIPTION
#### Description
This PR will help a lot with troubleshooting since it will report stats when failing to dial to the upstream server. When configurations are wrong, users will be able to see the failed connections and understand the reason. 
