### PR TITLE
Revert "move target networks for TCP from ACLs to enforcer"

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -132,7 +132,6 @@ func (t *trireme) newEnforcers() error {
 			t.config.procMountPoint,
 			t.config.externalIPcacheTimeout,
 			t.config.packetLogs,
-			t.config.targetNetworks,
 		)
 		if err != nil {
 			return fmt.Errorf("Failed to initialize enforcer: %s ", err)
@@ -154,7 +153,6 @@ func (t *trireme) newEnforcers() error {
 			t.config.procMountPoint,
 			t.config.externalIPcacheTimeout,
 			t.config.packetLogs,
-			t.config.targetNetworks,
 		)
 	}
 
@@ -172,7 +170,6 @@ func (t *trireme) newEnforcers() error {
 			t.config.procMountPoint,
 			t.config.externalIPcacheTimeout,
 			t.config.packetLogs,
-			t.config.targetNetworks,
 		)
 		if err != nil {
 			return fmt.Errorf("Failed to initialize sidecar enforcer: %s ", err)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -143,14 +143,6 @@ func (t *trireme) UpdateConfiguration(networks []string) error {
 		}
 	}
 
-	for _, e := range t.enforcers {
-		err := e.SetTargetNetworks(networks)
-		if err != nil {
-			zap.L().Error("Failed to update target networks in supervisor")
-			failure = true
-		}
-	}
-
 	if failure {
 		return fmt.Errorf("Configuration update failed")
 	}

--- a/controller/internal/enforcer/enforcer.go
+++ b/controller/internal/enforcer/enforcer.go
@@ -40,8 +40,6 @@ type Enforcer interface {
 
 	// UpdateSecrets -- updates the secrets of running enforcers managed by trireme. Remote enforcers will get the secret updates with the next policy push
 	UpdateSecrets(secrets secrets.Secrets) error
-
-	SetTargetNetworks(networks []string) error
 }
 
 // enforcer holds all the active implementations of the enforcer
@@ -115,10 +113,6 @@ func (e *enforcer) Unenforce(contextID string) error {
 	return nil
 }
 
-func (e *enforcer) SetTargetNetworks(networks []string) error {
-	return e.transport.SetTargetNetworks(networks)
-}
-
 // Updatesecrets updates the secrets of the enforcers
 func (e *enforcer) UpdateSecrets(secrets secrets.Secrets) error {
 	if e.proxy != nil {
@@ -159,7 +153,6 @@ func New(
 	procMountPoint string,
 	externalIPCacheTimeout time.Duration,
 	packetLogs bool,
-	targetNetworks []string,
 ) (Enforcer, error) {
 
 	tokenAccessor, err := tokenaccessor.New(serverID, validity, secrets)
@@ -183,7 +176,6 @@ func New(
 		packetLogs,
 		tokenAccessor,
 		puFromContextID,
-		targetNetworks,
 	)
 
 	tcpProxy, err := applicationproxy.NewAppProxy(tokenAccessor, collector, puFromContextID, nil, secrets)
@@ -205,7 +197,6 @@ func NewWithDefaults(
 	secrets secrets.Secrets,
 	mode constants.ModeType,
 	procMountPoint string,
-	targetNetworks []string,
 ) Enforcer {
 	return nfqdatapath.NewWithDefaults(
 		serverID,
@@ -214,6 +205,5 @@ func NewWithDefaults(
 		secrets,
 		mode,
 		procMountPoint,
-		targetNetworks,
 	)
 }

--- a/controller/internal/enforcer/mockenforcer/mockenforcer.go
+++ b/controller/internal/enforcer/mockenforcer/mockenforcer.go
@@ -120,14 +120,6 @@ func (m *MockEnforcer) UpdateSecrets(secrets secrets.Secrets) error {
 	return ret0
 }
 
-// SetTargetNetworks mocks SetTargetNetworks
-// nolint
-func (m *MockEnforcer) SetTargetNetworks(networks []string) error {
-	ret := m.ctrl.Call(m, "SetTargetNetworks", networks)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
 // UpdateSecrets indicates an expected call of UpdateSecrets
 // nolint
 func (mr *MockEnforcerMockRecorder) UpdateSecrets(secrets interface{}) *gomock.Call {

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -273,22 +273,8 @@ func (d *Datapath) processApplicationTCPPacket(tcpPacket *packet.Packet, context
 // processApplicationSynPacket processes a single Syn Packet
 func (d *Datapath) processApplicationSynPacket(tcpPacket *packet.Packet, context *pucontext.PUContext, conn *connection.TCPConnection) (interface{}, error) {
 
-	// If the packet is not in target networks then look into the external services application cache to
-	// make a decision whether the packet should be forwarded. For target networks with external services
-	// network syn/ack accepts the packet if it belongs to external services.
-	_, pkt, perr := d.targetNetworks.GetMatchingAction(tcpPacket.DestinationAddress.To4(), tcpPacket.DestinationPort)
-
-	if perr != nil {
-		report, policy, perr := context.ApplicationACLPolicyFromAddr(tcpPacket.DestinationAddress.To4(), tcpPacket.DestinationPort)
-
-		if perr == nil && policy.Action.Accepted() {
-			return nil, nil
-		}
-
-		d.reportExternalServiceFlow(context, report, pkt, true, tcpPacket)
-		return nil, fmt.Errorf("No acls found for external services. Dropping application syn packet %v", perr.Error())
-	}
-
+	// First check if the destination is in the external servicess approved cache
+	// and if yes, allow the packet to go.
 	if policy, err := context.RetrieveCachedExternalFlowPolicy(tcpPacket.DestinationAddress.String() + ":" + strconv.Itoa(int(tcpPacket.DestinationPort))); err == nil {
 		d.appOrigConnectionTracker.AddOrUpdate(tcpPacket.L4FlowHash(), conn)
 		d.sourcePortConnectionCache.AddOrUpdate(tcpPacket.SourcePortHash(packet.PacketTypeApplication), conn)
@@ -429,7 +415,7 @@ func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context
 	if conn.GetState() == connection.UnknownState {
 		// Check if the destination is in the external servicess approved cache
 		// and if yes, allow the packet to go and release the flow.
-		_, policy, perr := context.ApplicationACLPolicyFromAddr(tcpPacket.DestinationAddress.To4(), tcpPacket.DestinationPort)
+		_, policy, perr := context.ApplicationACLPolicy(tcpPacket)
 
 		if perr != nil {
 			err := tcpPacket.ConvertAcktoFinAck()
@@ -593,7 +579,7 @@ func (d *Datapath) processNetworkSynAckPacket(context *pucontext.PUContext, conn
 		}
 
 		// Never seen this IP before, let's parse them.
-		report, pkt, perr := context.ApplicationACLPolicyFromAddr(tcpPacket.SourceAddress.To4(), tcpPacket.SourcePort)
+		report, pkt, perr := context.ApplicationACLPolicy(tcpPacket)
 		if perr != nil || pkt.Action.Rejected() {
 			d.reportReverseExternalServiceFlow(context, report, pkt, true, tcpPacket)
 			return nil, nil, fmt.Errorf("no auth or acls: drop synack packet and connection: %s: action=%d", perr, pkt.Action)

--- a/controller/internal/enforcer/proxy/enforcerproxy_test.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy_test.go
@@ -141,7 +141,7 @@ func setupProxyEnforcer(rpchdl rpcwrapper.RPCClient, prochdl processmon.ProcessM
 		defaultExternalIPCacheTimeout,
 		nil,
 		false,
-		[]string{"0.0.0.0/0"})
+	)
 	return policyEnf
 }
 
@@ -151,7 +151,7 @@ func TestNewDefaultProxyEnforcer(t *testing.T) {
 
 	Convey("When I try to start a proxy enforcer with defaults", t, func() {
 		rpchdl := mockrpcwrapper.NewMockRPCClient(ctrl)
-		policyEnf := NewDefaultProxyEnforcer("testServerID", eventCollector(), secretGen(nil, nil, nil), rpchdl, procMountPoint, []string{"0.0.0.0/0"})
+		policyEnf := NewDefaultProxyEnforcer("testServerID", eventCollector(), secretGen(nil, nil, nil), rpchdl, procMountPoint)
 
 		Convey("Then policyEnf should not be nil", func() {
 			So(policyEnf, ShouldNotBeNil)
@@ -174,7 +174,7 @@ func TestInitRemoteEnforcer(t *testing.T) {
 
 	Convey("When I try to start a proxy enforcer with defaults", t, func() {
 		rpchdl := mockrpcwrapper.NewMockRPCClient(ctrl)
-		policyEnf := NewDefaultProxyEnforcer("testServerID", eventCollector(), secretGen(nil, nil, nil), rpchdl, procMountPoint, []string{"0.0.0.0/0"})
+		policyEnf := NewDefaultProxyEnforcer("testServerID", eventCollector(), secretGen(nil, nil, nil), rpchdl, procMountPoint)
 
 		Convey("Then policyEnf should not be nil", func() {
 			So(policyEnf, ShouldNotBeNil)
@@ -193,7 +193,7 @@ func TestInitRemoteEnforcer(t *testing.T) {
 	Convey("When I try to start a proxy enforcer with defaults and PKICompactType", t, func() {
 		rpchdl := mockrpcwrapper.NewMockRPCClient(ctrl)
 		cpki, _ := secrets.NewCompactPKI([]byte(keypem), []byte(certPEM), []byte(caPool), token, constants.CompressionTypeNone)
-		policyEnf := NewDefaultProxyEnforcer("testServerID", eventCollector(), cpki, rpchdl, procMountPoint, []string{"0.0.0.0/0"})
+		policyEnf := NewDefaultProxyEnforcer("testServerID", eventCollector(), cpki, rpchdl, procMountPoint)
 
 		Convey("Then policyEnf should not be nil", func() {
 			So(policyEnf, ShouldNotBeNil)
@@ -259,61 +259,6 @@ func TestEnforce(t *testing.T) {
 			rpchdl.EXPECT().RemoteCall("testServerID", remoteenforcer.InitEnforcer, gomock.Any(), gomock.Any()).Times(1).Return(nil)
 			rpchdl.EXPECT().RemoteCall("testServerID", remoteenforcer.Enforce, gomock.Any(), gomock.Any()).Times(1).Return(nil)
 			err := policyEnf.(*ProxyInfo).Enforce("testServerID", createPUInfo())
-
-			Convey("Then I should not get any error", func() {
-				So(err, ShouldBeNil)
-			})
-		})
-
-	})
-}
-
-func TestSetTargetNetworks(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	Convey("When I try to start a proxy enforcer with defaults", t, func() {
-		rpchdl := mockrpcwrapper.NewMockRPCClient(ctrl)
-		prochdl := mockprocessmon.NewMockProcessManager(ctrl)
-		policyEnf := setupProxyEnforcer(rpchdl, prochdl)
-
-		Convey("Then policyEnf should not be nil", func() {
-			So(policyEnf, ShouldNotBeNil)
-		})
-
-		Convey("When I try to initiate a remote enforcer", func() {
-			rpchdl.EXPECT().RemoteCall("testServerID", remoteenforcer.InitEnforcer, gomock.Any(), gomock.Any()).Times(1).Return(nil)
-			err := policyEnf.(*ProxyInfo).InitRemoteEnforcer("testServerID")
-
-			Convey("Then I should not get any error", func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey("When I try to call enforce method", func() {
-				prochdl.EXPECT().LaunchProcess("testServerID", gomock.Any(), gomock.Any(), rpchdl, gomock.Any(), gomock.Any(), gomock.Any())
-				rpchdl.EXPECT().RemoteCall("testServerID", remoteenforcer.Enforce, gomock.Any(), gomock.Any()).Times(1).Return(nil)
-
-				err := policyEnf.(*ProxyInfo).Enforce("testServerID", createPUInfo())
-
-				Convey("Then I should not get any error", func() {
-					So(err, ShouldBeNil)
-				})
-			})
-		})
-	})
-
-	Convey("When I try to start a proxy enforcer with defaults", t, func() {
-		rpchdl := mockrpcwrapper.NewMockRPCClient(ctrl)
-		prochdl := mockprocessmon.NewMockProcessManager(ctrl)
-		policyEnf := setupProxyEnforcer(rpchdl, prochdl)
-
-		Convey("Then policyEnf should not be nil", func() {
-			So(policyEnf, ShouldNotBeNil)
-		})
-
-		Convey("When I try to call SetTargetNetworks method without enforcer running", func() {
-			rpchdl.EXPECT().ContextList()
-			err := policyEnf.(*ProxyInfo).SetTargetNetworks([]string{"0.0.0.0/0"})
 
 			Convey("Then I should not get any error", func() {
 				So(err, ShouldBeNil)

--- a/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -268,5 +268,4 @@ func RegisterTypes() {
 	gob.RegisterName("go.aporeto.io/enforcer/utils/rpcwrapper.UnSupervise_Payload", *(&UnSupervisePayload{}))
 	gob.RegisterName("go.aporeto.io/enforcer/utils/rpcwrapper.Stats_Payload", *(&StatsPayload{}))
 	gob.RegisterName("go.aporeto.io/enforcer/utils/rpcwrapper.UpdateSecrets_Payload", *(&UpdateSecretsPayload{}))
-	gob.RegisterName("go.aporeto.io/enforcer/utils/rpcwrapper.SetTarget_Networks", *(&SetTargetNetworks{}))
 }

--- a/controller/internal/enforcer/utils/rpcwrapper/types.go
+++ b/controller/internal/enforcer/utils/rpcwrapper/types.go
@@ -46,7 +46,6 @@ type InitRequestPayload struct {
 	ServerID               string                `json:",omitempty"`
 	ExternalIPCacheTimeout time.Duration         `json:",omitempty"`
 	Secrets                secrets.PublicSecrets `json:",omitempty"`
-	TargetNetworks         []string              `json:",omitempty"`
 }
 
 // UpdateSecretsPayload payload for the update secrets to remote enforcers
@@ -112,9 +111,4 @@ type StatsPayload struct {
 //ExcludeIPRequestPayload carries the list of excluded ips
 type ExcludeIPRequestPayload struct {
 	IPs []string `json:",omitempty"`
-}
-
-//SetTargetNetworks carries the payload for target networks
-type SetTargetNetworks struct {
-	TargetNetworks []string `json:",omitempty"`
 }

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -269,6 +269,7 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 	// Application Packets - SYN
 	rules = append(rules, []string{
 		i.appPacketIPTableContext, appChain,
+		"-m", "set", "--match-set", targetNetworkSet, "dst",
 		"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN",
 		"-j", "NFQUEUE", "--queue-balance", i.fqc.GetApplicationQueueSynStr(),
 	})
@@ -276,12 +277,14 @@ func (i *Instance) trapRules(appChain string, netChain string) [][]string {
 	// Application Packets - Evertyhing but SYN and SYN,ACK (first 4 packets). SYN,ACK is captured by global rule
 	rules = append(rules, []string{
 		i.appPacketIPTableContext, appChain,
+		"-m", "set", "--match-set", targetNetworkSet, "dst",
 		"-p", "tcp", "--tcp-flags", "SYN,ACK", "ACK",
 		"-j", "NFQUEUE", "--queue-balance", i.fqc.GetApplicationQueueAckStr(),
 	})
 
 	rules = append(rules, []string{
 		i.appPacketIPTableContext, appChain,
+		"-m", "set", "--match-set", targetNetworkSet, "dst",
 		"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN,ACK",
 		"-j", "NFQUEUE", "--queue-balance", i.fqc.GetApplicationQueueAckStr(),
 	})
@@ -1381,6 +1384,7 @@ func (i *Instance) setGlobalRules(appChain, netChain string) error {
 	err = i.ipt.Insert(
 		i.netPacketIPTableContext,
 		netChain, 1,
+		"-m", "set", "--match-set", targetNetworkSet, "src",
 		"-p", "tcp", "--tcp-flags", "SYN,ACK", "SYN,ACK",
 		"-j", "NFQUEUE", "--queue-bypass", "--queue-balance", i.fqc.GetNetworkQueueSynAckStr())
 

--- a/controller/internal/supervisor/supervisor_test.go
+++ b/controller/internal/supervisor/supervisor_test.go
@@ -78,7 +78,7 @@ func TestNewSupervisor(t *testing.T) {
 			return nil, nil
 		}
 
-		e := enforcer.NewWithDefaults("serverID", c, nil, secrets, constants.LocalServer, "/proc", []string{"0.0.0.0/0"})
+		e := enforcer.NewWithDefaults("serverID", c, nil, secrets, constants.LocalServer, "/proc")
 		mode := constants.LocalServer
 
 		Convey("When I provide correct parameters", func() {
@@ -124,7 +124,7 @@ func TestSupervise(t *testing.T) {
 		nfqdatapath.GetUDPRawSocket = func(mark int, device string) (afinetrawsocket.SocketWriter, error) {
 			return nil, nil
 		}
-		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"})
+		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc")
 
 		s, _ := NewSupervisor(c, e, constants.RemoteContainer, []string{})
 		So(s, ShouldNotBeNil)
@@ -201,7 +201,7 @@ func TestUnsupervise(t *testing.T) {
 			return nil, nil
 		}
 
-		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"})
+		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc")
 
 		s, _ := NewSupervisor(c, e, constants.RemoteContainer, []string{"172.17.0.0/16"})
 		So(s, ShouldNotBeNil)
@@ -247,7 +247,7 @@ func TestStart(t *testing.T) {
 			return nil, nil
 		}
 
-		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"})
+		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc")
 
 		s, _ := NewSupervisor(c, e, constants.RemoteContainer, []string{"172.17.0.0/16"})
 		So(s, ShouldNotBeNil)
@@ -290,7 +290,7 @@ func TestStop(t *testing.T) {
 			return nil, nil
 		}
 
-		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"})
+		e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc")
 
 		s, _ := NewSupervisor(c, e, constants.RemoteContainer, []string{"172.17.0.0/16"})
 		So(s, ShouldNotBeNil)

--- a/controller/pkg/pucontext/pucontext.go
+++ b/controller/pkg/pucontext/pucontext.go
@@ -142,6 +142,11 @@ func (p *PUContext) NetworkACLPolicyFromAddr(addr net.IP, port uint16) (report *
 	return p.networkACLs.GetMatchingAction(addr, port)
 }
 
+// ApplicationACLPolicy retrieves the policy based on ACLs
+func (p *PUContext) ApplicationACLPolicy(packet *packet.Packet) (report *policy.FlowPolicy, action *policy.FlowPolicy, err error) {
+	return p.applicationACLs.GetMatchingAction(packet.SourceAddress.To4(), packet.SourcePort)
+}
+
 // ApplicationACLPolicyFromAddr retrieve the policy given an address and port.
 func (p *PUContext) ApplicationACLPolicyFromAddr(addr net.IP, port uint16) (report *policy.FlowPolicy, action *policy.FlowPolicy, err error) {
 	return p.applicationACLs.GetMatchingAction(addr, port)

--- a/controller/pkg/remoteenforcer/interfaces.go
+++ b/controller/pkg/remoteenforcer/interfaces.go
@@ -21,8 +21,6 @@ const (
 	EnforcerExit = "RemoteEnforcer.EnforcerExit"
 	// UpdateSecrets is string for invoking updatesecrets RPC
 	UpdateSecrets = "RemoteEnforcer.UpdateSecrets"
-	// SetTargetNetworks is string for invoking SetTargetNetworks RPC
-	SetTargetNetworks = "RemoteEnforcer.SetTargetNetworks"
 )
 
 // RemoteIntf is the interface implemented by the remote enforcer

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -114,7 +114,6 @@ func (s *RemoteEnforcer) setupEnforcer(req rpcwrapper.Request) error {
 		s.procMountPoint,
 		payload.ExternalIPCacheTimeout,
 		payload.PacketLogs,
-		payload.TargetNetworks,
 	); err != nil || s.enforcer == nil {
 		return fmt.Errorf("Error while initializing remote enforcer, %s", err)
 	}
@@ -310,29 +309,6 @@ func (s *RemoteEnforcer) Unsupervise(req rpcwrapper.Request, resp *rpcwrapper.Re
 
 	payload := req.Payload.(rpcwrapper.UnSupervisePayload)
 	return s.supervisor.Unsupervise(payload.ContextID)
-}
-
-// SetTargetNetworks calls the same method on the actual enforcer
-func (s *RemoteEnforcer) SetTargetNetworks(req rpcwrapper.Request, resp *rpcwrapper.Response) error {
-	var err error
-	if !s.rpcHandle.CheckValidity(&req, s.rpcSecret) {
-		resp.Status = "SetTargetNetworks message auth failed" //nolint
-		return fmt.Errorf(resp.Status)
-	}
-
-	cmdLock.Lock()
-	defer cmdLock.Unlock()
-	if s.enforcer == nil {
-		return fmt.Errorf(resp.Status)
-	}
-
-	payload := req.Payload.(rpcwrapper.SetTargetNetworks)
-	err = s.enforcer.SetTargetNetworks(payload.TargetNetworks)
-	if err != nil {
-		return err
-	}
-	return nil
-
 }
 
 // Enforce this method calls the enforce method on the enforcer created during initenforcer

--- a/controller/pkg/remoteenforcer/remoteenforcer_test.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_test.go
@@ -236,12 +236,6 @@ func initTestEnfPayload() rpcwrapper.EnforcePayload {
 	return initPayload
 }
 
-func initTestSetTargetPayload() rpcwrapper.SetTargetNetworks {
-	var payload rpcwrapper.SetTargetNetworks
-	payload.TargetNetworks = []string{"128.0.0.0/1"}
-	return payload
-}
-
 func initTestUnEnfPayload() rpcwrapper.UnEnforcePayload {
 
 	var initPayload rpcwrapper.UnEnforcePayload
@@ -471,7 +465,7 @@ func TestInitSupervisor(t *testing.T) {
 					return nil, nil
 				}
 
-				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"}).(enforcer.Enforcer)
+				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc").(enforcer.Enforcer)
 
 				err := server.InitSupervisor(rpcwrperreq, &rpcwrperres)
 
@@ -526,7 +520,7 @@ func TestInitSupervisor(t *testing.T) {
 					return nil, nil
 				}
 
-				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"}).(enforcer.Enforcer)
+				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc").(enforcer.Enforcer)
 
 				err := server.InitSupervisor(rpcwrperreq, &rpcwrperres)
 
@@ -560,7 +554,7 @@ func TestInitSupervisor(t *testing.T) {
 					return nil, nil
 				}
 
-				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"}).(enforcer.Enforcer)
+				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc").(enforcer.Enforcer)
 				server.supervisor, _ = supervisor.NewSupervisor(collector, server.enforcer, constants.RemoteContainer, []string{})
 
 				err := server.InitSupervisor(rpcwrperreq, &rpcwrperres)
@@ -657,7 +651,7 @@ func TestLaunchRemoteEnforcer(t *testing.T) {
 					return nil, nil
 				}
 
-				e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"})
+				e := enforcer.NewWithDefaults("serverID", c, nil, scrts, constants.RemoteContainer, "/proc")
 				server.supervisor, _ = supervisor.NewSupervisor(c, e, constants.RemoteContainer, []string{})
 				server.enforcer = nil
 				err := server.EnforcerExit(rpcwrapper.Request{}, &rpcwrapper.Response{})
@@ -863,7 +857,7 @@ func TestEnforce(t *testing.T) {
 					return nil, nil
 				}
 
-				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"}).(enforcer.Enforcer)
+				server.enforcer = enforcer.NewWithDefaults("someServerID", collector, nil, secret, constants.RemoteContainer, "/proc").(enforcer.Enforcer)
 
 				err := server.Enforce(rpcwrperreq, &rpcwrperres)
 
@@ -971,7 +965,7 @@ func TestUnEnforce(t *testing.T) {
 					return nil, nil
 				}
 
-				server.enforcer = enforcer.NewWithDefaults("b06f47830f64", collector, nil, secret, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"}).(enforcer.Enforcer)
+				server.enforcer = enforcer.NewWithDefaults("b06f47830f64", collector, nil, secret, constants.RemoteContainer, "/proc").(enforcer.Enforcer)
 
 				err := server.Unenforce(rpcwrperreq, &rpcwrperres)
 
@@ -1078,7 +1072,7 @@ func TestUnSupervise(t *testing.T) {
 					return nil, nil
 				}
 
-				e := enforcer.NewWithDefaults("ac0d3577e808", c, nil, scrts, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"})
+				e := enforcer.NewWithDefaults("ac0d3577e808", c, nil, scrts, constants.RemoteContainer, "/proc")
 
 				server.supervisor, _ = supervisor.NewSupervisor(c, e, constants.RemoteContainer, []string{})
 


### PR DESCRIPTION
Reverts aporeto-inc/trireme-lib#587