### PR TITLE
Do not fatal if ip_early_demux is not found

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -167,7 +167,7 @@ func New(
 		if mode == constants.LocalServer {
 			cmd = exec.Command(sysctlCmd, "-w", "net.ipv4.ip_early_demux=0")
 			if err := cmd.Run(); err != nil {
-				zap.L().Fatal("Failed to set early demux options", zap.Error(err))
+				zap.L().Error("Failed to set early demux options", zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
Certain AMIs do not have ip_early_demux option. Currently we fatal if we are unable to set ip_early_demux option. we should throw an error and continue.
