### PR TITLE
Update connmark with flow  based on direction (app/network)

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -327,11 +327,11 @@ func (d *Datapath) processApplicationSynAckPacket(tcpPacket *packet.Packet, cont
 	// packets from this connection.
 	if conn.GetState() == connection.TCPData && !conn.ServiceConnection {
 		if err := d.conntrackHdl.ConntrackTableUpdateMark(
-			tcpPacket.DestinationAddress.String(),
 			tcpPacket.SourceAddress.String(),
+			tcpPacket.DestinationAddress.String(),
 			tcpPacket.IPProto,
-			tcpPacket.DestinationPort,
 			tcpPacket.SourcePort,
+			tcpPacket.DestinationPort,
 			constants.DefaultConnMark,
 		); err != nil {
 			zap.L().Error("Failed to update conntrack entry for flow",
@@ -624,11 +624,11 @@ func (d *Datapath) processNetworkSynAckPacket(context *pucontext.PUContext, conn
 
 		// Revert the connmarks - dealing with retransmissions
 		if cerr := d.conntrackHdl.ConntrackTableUpdateMark(
-			tcpPacket.SourceAddress.String(),
 			tcpPacket.DestinationAddress.String(),
+			tcpPacket.SourceAddress.String(),
 			tcpPacket.IPProto,
-			tcpPacket.SourcePort,
 			tcpPacket.DestinationPort,
+			tcpPacket.SourcePort,
 			0,
 		); cerr != nil {
 			zap.L().Error("Failed to update conntrack table for flow",
@@ -774,11 +774,11 @@ func (d *Datapath) processNetworkAckPacket(context *pucontext.PUContext, conn *c
 
 		if !conn.ServiceConnection {
 			if err := d.conntrackHdl.ConntrackTableUpdateMark(
-				tcpPacket.SourceAddress.String(),
 				tcpPacket.DestinationAddress.String(),
+				tcpPacket.SourceAddress.String(),
 				tcpPacket.IPProto,
-				tcpPacket.SourcePort,
 				tcpPacket.DestinationPort,
+				tcpPacket.SourcePort,
 				constants.DefaultConnMark,
 			); err != nil {
 				zap.L().Error("Failed to update conntrack table after ack packet")


### PR DESCRIPTION
Enforcer traps packets at mangle input and mangle output. The kernel adds an entry to conntrack prior to nat prerouting and prior to mangle output. In presence of nats/proxies on the same host, enforcer sees packets post nat on the network side and pre nat on the output side. We can be sure of the flow being present in the conntrack if we follow the below convention, as these entries will be sure to be recorded in conntrack table.

It is always safe to update the connection mark for a particular flow as below: 

1) when updating connmark for a flow from a network, use the L4reverseflowHash
2) when updating connmark for a flow from application, use the L4flowHash.

This can prevent any connmark update failures when nats/proxies are present.