### PR TITLE
NAT support in HTTP proxies

### DIFF
--- a/controller/internal/enforcer/applicationproxy/protomux/protomux.go
+++ b/controller/internal/enforcer/applicationproxy/protomux/protomux.go
@@ -205,7 +205,6 @@ func (m *MultiplexedListener) serve(conn net.Conn) {
 
 	defer m.wg.Done()
 	ip, port := c.GetOriginalDestination()
-
 	local := false
 	if _, ok = m.localIPs[networkOfAddress(c.RemoteAddr().String())]; ok {
 		local = true
@@ -225,6 +224,7 @@ func (m *MultiplexedListener) serve(conn net.Conn) {
 			c.Close() // nolint
 			return
 		}
+		fmt.Println(entry)
 	}
 
 	ltype := entry.(ListenerType)

--- a/controller/internal/supervisor/iptablesctrl/ipsets.go
+++ b/controller/internal/supervisor/iptablesctrl/ipsets.go
@@ -140,6 +140,15 @@ func (i *Instance) updateProxySet(policy *policy.PUPolicy, portSetName string) e
 				return fmt.Errorf("unable to add ip %d to target ports ipset: %s", i, err)
 			}
 		}
+		if exposedService.PublicNetworkInfo != nil {
+			min, max := exposedService.PublicNetworkInfo.Ports.Range()
+			for i := int(min); i <= int(max); i++ {
+				if err := srvTargetSet.Add(strconv.Itoa(i), 0); err != nil {
+					zap.L().Error("Failed to VIP for public network", zap.Error(err))
+					return fmt.Errorf("Failed to program VIP: %s", err)
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -34,6 +34,17 @@ type ApplicationService struct {
 	// listening to. This is needed in the case of port mappings.
 	PrivateNetworkInfo *common.Service
 
+	// PublicNetworkInfo provides the network information where the enforcer
+	// should listen for incoming connections of the service. This can be
+	// different than the PrivateNetworkInfo where the application is listening
+	// and it essentially allows users to create Virtual IPs and Virtual Ports
+	// for the new exposed TLS services. So, if an application is listening
+	// on port 80, users do not need to access the application from external
+	// network through TLS on port 80, that looks weird. They can instead create
+	// a PublicNetworkInfo and have the trireme listen on port 443, while the
+	// application is still listening on port 80.
+	PublicNetworkInfo *common.Service
+
 	// Type is the type of the service.
 	Type ServiceType
 


### PR DESCRIPTION
#### Description
This PR adds support for native NAT in HTTP proxies. The proxies can expose public ports that are different than the ports that the application is actually listening and we can implement the port translation ourselves. 
