### PR TITLE
Fix regex for cgroup name

### DIFF
--- a/monitor/internal/linux/monitor.go
+++ b/monitor/internal/linux/monitor.go
@@ -66,8 +66,8 @@ func (l *LinuxMonitor) SetupConfig(registerer registerer.Registerer, cfg interfa
 	l.proc.host = linuxConfig.Host
 	l.proc.netcls = cgnetcls.NewCgroupNetController(common.TriremeCgroupPath, linuxConfig.ReleasePath)
 
-	l.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_].{0,11}$")
-	l.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_].{0,11}$")
+	l.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_]{0,11}$")
+	l.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{0,11}$")
 
 	l.proc.metadataExtractor = linuxConfig.EventMetadataExtractor
 	if l.proc.metadataExtractor == nil {

--- a/monitor/internal/linux/monitor.go
+++ b/monitor/internal/linux/monitor.go
@@ -66,8 +66,8 @@ func (l *LinuxMonitor) SetupConfig(registerer registerer.Registerer, cfg interfa
 	l.proc.host = linuxConfig.Host
 	l.proc.netcls = cgnetcls.NewCgroupNetController(common.TriremeCgroupPath, linuxConfig.ReleasePath)
 
-	l.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_]{0,11}$")
-	l.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{0,11}$")
+	l.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_]{1,11}$")
+	l.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{1,11}$")
 
 	l.proc.metadataExtractor = linuxConfig.EventMetadataExtractor
 	if l.proc.metadataExtractor == nil {

--- a/monitor/internal/uid/monitor.go
+++ b/monitor/internal/uid/monitor.go
@@ -65,8 +65,8 @@ func (u *UIDMonitor) SetupConfig(registerer registerer.Registerer, cfg interface
 
 	// Setup config
 	u.proc.netcls = cgnetcls.NewCgroupNetController(common.TriremeUIDCgroupPath, uidConfig.ReleasePath)
-	u.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_]{0,11}$")
-	u.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{0,11}$")
+	u.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_]{1,11}$")
+	u.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{1,11}$")
 	u.proc.putoPidMap = cache.NewCache("putoPidMap")
 	u.proc.pidToPU = cache.NewCache("pidToPU")
 	u.proc.metadataExtractor = uidConfig.EventMetadataExtractor

--- a/monitor/internal/uid/monitor.go
+++ b/monitor/internal/uid/monitor.go
@@ -65,8 +65,8 @@ func (u *UIDMonitor) SetupConfig(registerer registerer.Registerer, cfg interface
 
 	// Setup config
 	u.proc.netcls = cgnetcls.NewCgroupNetController(common.TriremeUIDCgroupPath, uidConfig.ReleasePath)
-	u.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_].{0,11}$")
-	u.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_].{0,11}$")
+	u.proc.regStart = regexp.MustCompile("^[a-zA-Z0-9_]{0,11}$")
+	u.proc.regStop = regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{0,11}$")
 	u.proc.putoPidMap = cache.NewCache("putoPidMap")
 	u.proc.pidToPU = cache.NewCache("pidToPU")
 	u.proc.metadataExtractor = uidConfig.EventMetadataExtractor

--- a/monitor/remoteapi/server/server.go
+++ b/monitor/remoteapi/server/server.go
@@ -234,7 +234,7 @@ func validateEvent(event *common.EventInfo) error {
 	}
 
 	if event.EventType == common.EventStop || event.EventType == common.EventDestroy {
-		regStop := regexp.MustCompile("^/trireme/[a-zA-Z0-9_].{0,11}$")
+		regStop := regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{0,11}$")
 		if event.Cgroup != "" && !regStop.Match([]byte(event.Cgroup)) {
 			return fmt.Errorf("Cgroup is not of the right format")
 		}

--- a/monitor/remoteapi/server/server.go
+++ b/monitor/remoteapi/server/server.go
@@ -234,7 +234,7 @@ func validateEvent(event *common.EventInfo) error {
 	}
 
 	if event.EventType == common.EventStop || event.EventType == common.EventDestroy {
-		regStop := regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{0,11}$")
+		regStop := regexp.MustCompile("^/trireme/[a-zA-Z0-9_]{1,11}$")
 		if event.Cgroup != "" && !regStop.Match([]byte(event.Cgroup)) {
 			return fmt.Errorf("Cgroup is not of the right format")
 		}


### PR DESCRIPTION
CGroup are limited to 12 characters due to iptables.
It should only contains alphanumeric characters.

The current regex allows any character because of the use of `.`