### PR TITLE
Do not delete cgroup for network host services.

### DIFF
--- a/monitor/internal/linux/processor.go
+++ b/monitor/internal/linux/processor.go
@@ -155,7 +155,15 @@ func (l *linuxProcessor) Destroy(ctx context.Context, eventInfo *common.EventInf
 
 	l.Lock()
 	defer l.Unlock()
+
 	if eventInfo.HostService {
+		// For network only pus, we do not program cgroups and hence should not clean it.
+		// Cleaning this could result in removal of root cgroup that was configured for
+		// true host mode pu.
+		if eventInfo.NetworkOnlyTraffic {
+			return nil
+		}
+
 		if err := ioutil.WriteFile("/sys/fs/cgroup/net_cls,net_prio/net_cls.classid", []byte("0"), 0644); err != nil {
 			return fmt.Errorf("unable to write to net_cls.classid file for new cgroup: %s", err)
 		}

--- a/monitor/internal/linux/processor_test.go
+++ b/monitor/internal/linux/processor_test.go
@@ -109,7 +109,7 @@ func TestDestroy(t *testing.T) {
 
 		Convey("When I get a destroy event that is valid", func() {
 			event := &common.EventInfo{
-				PUID: "/trireme/1234",
+				PUID: "1234",
 			}
 			mockcls.EXPECT().DeleteCgroup(gomock.Any()).Return(nil)
 
@@ -120,6 +120,19 @@ func TestDestroy(t *testing.T) {
 			})
 		})
 
+		Convey("When I get a destroy event that is valid for hostpu", func() {
+			event := &common.EventInfo{
+				PUID:               "123",
+				HostService:        true,
+				NetworkOnlyTraffic: true,
+			}
+
+			puHandler.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			Convey("I should get the status of the upstream function", func() {
+				err := p.Destroy(context.Background(), event)
+				So(err, ShouldBeNil)
+			})
+		})
 	})
 }
 


### PR DESCRIPTION
cgroup mark is not programmed for network host services and hence shouldn't be removed. On removal of network host services, cgroup shouldn't be written "0" mark for network only host services. It should be written to 0 and removed only when a host pu (both incoming/outgoing in old parlance) is removed.