### PR TITLE
check if both ends are loopback and don't update connmark on application ack. Let network ack be processed to update connamrk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ install:
   - dep ensure -v
   
 script:
-  - ./.test.sh
   - gometalinter.v2 --vendor --skip=mockdocker --disable-all --enable=vet --enable=vetshadow --enable=errcheck --enable=golint --enable=deadcode --enable=ineffassign --enable=gotype --enable=goimports --enable=interfacer --enable=goconst --enable=misspell --deadline=10m ./...
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   - dep ensure -v
   
 script:
+  - ./.test.sh
   - gometalinter.v2 --vendor --skip=mockdocker --disable-all --enable=vet --enable=vetshadow --enable=errcheck --enable=golint --enable=deadcode --enable=ineffassign --enable=gotype --enable=goimports --enable=interfacer --enable=goconst --enable=misspell --deadline=10m ./...
 
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -17,7 +17,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/allocator"
-
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/acls/acl_test.go
+++ b/controller/internal/enforcer/acls/acl_test.go
@@ -4,9 +4,8 @@ import (
 	"net"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 var (

--- a/controller/internal/enforcer/acls/aclcache_test.go
+++ b/controller/internal/enforcer/acls/aclcache_test.go
@@ -4,9 +4,8 @@ import (
 	"net"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func TestEmptyACLCacheLookup(t *testing.T) {

--- a/controller/internal/enforcer/acls/ports_test.go
+++ b/controller/internal/enforcer/acls/ports_test.go
@@ -3,9 +3,8 @@ package acls
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func TestEmptyPortListLookup(t *testing.T) {

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -22,7 +22,6 @@ import (
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	cryptohelpers "go.aporeto.io/trireme-lib/utils/crypto"
-
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/applicationproxy/connproc/connproc.go
+++ b/controller/internal/enforcer/applicationproxy/connproc/connproc.go
@@ -11,10 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/applicationproxy/markedconn"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
 // GetInterfaces retrieves all the local interfaces.

--- a/controller/internal/enforcer/applicationproxy/servicecache/servicecache_test.go
+++ b/controller/internal/enforcer/applicationproxy/servicecache/servicecache_test.go
@@ -4,11 +4,9 @@ import (
 	"net"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/utils/portspec"
-
-	"go.aporeto.io/trireme-lib/common"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/utils/portspec"
 )
 
 func TestServiceCache(t *testing.T) {

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -15,8 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/applicationproxy/connproc"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/applicationproxy/markedconn"
@@ -28,6 +26,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 const (

--- a/controller/internal/enforcer/lookup/lookup.go
+++ b/controller/internal/enforcer/lookup/lookup.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"sort"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/policy"
+	"go.uber.org/zap"
 )
 
 // ForwardingPolicy is an instance of the forwarding policy

--- a/controller/internal/enforcer/lookup/lookup_test.go
+++ b/controller/internal/enforcer/lookup/lookup_test.go
@@ -3,9 +3,8 @@ package lookup
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 var (

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -7,8 +7,6 @@ import (
 	"os/exec"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/netlink-go/conntrack"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
@@ -28,6 +26,7 @@ import (
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/portcache"
 	"go.aporeto.io/trireme-lib/utils/portspec"
+	"go.uber.org/zap"
 )
 
 // DefaultExternalIPTimeout is the default used for the cache for External IPTimeout.

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -401,6 +401,8 @@ func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context
 		// packets after the first data packet, that might be already in the queue
 		// will be transmitted through the kernel directly. Service connections are
 		// delegated to the service module
+		// Check for both ends not being loopback. in such a case we will let the network ack
+		// update the connmark on the flow
 		if !conn.ServiceConnection &&
 			tcpPacket.SourceAddress.String() != tcpPacket.DestinationAddress.String() &&
 			!(tcpPacket.SourceAddress.IsLoopback() && tcpPacket.DestinationAddress.IsLoopback()) {

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
@@ -19,6 +17,7 @@ import (
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
 	"go.aporeto.io/trireme-lib/utils/portspec"
+	"go.uber.org/zap"
 )
 
 // processNetworkPackets processes packets arriving from network and are destined to the application

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -401,7 +401,9 @@ func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context
 		// packets after the first data packet, that might be already in the queue
 		// will be transmitted through the kernel directly. Service connections are
 		// delegated to the service module
-		if !conn.ServiceConnection && tcpPacket.SourceAddress.String() != tcpPacket.DestinationAddress.String() {
+		if !conn.ServiceConnection &&
+			tcpPacket.SourceAddress.String() != tcpPacket.DestinationAddress.String() &&
+			!(tcpPacket.SourceAddress.IsLoopback() && tcpPacket.DestinationAddress.IsLoopback()) {
 			if err := d.conntrackHdl.ConntrackTableUpdateMark(
 				tcpPacket.SourceAddress.String(),
 				tcpPacket.DestinationAddress.String(),

--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/bvandewalle/go-ipset/ipset"
 	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/collector/mockcollector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
-
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/packetgen"
 	"go.aporeto.io/trireme-lib/controller/pkg/connection"
@@ -25,8 +25,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/portspec"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/controller/internal/enforcer/nfqdatapath/datapath_udp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_udp.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
@@ -17,6 +15,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/controller/pkg/pucontext"
 	"go.aporeto.io/trireme-lib/controller/pkg/tokens"
+	"go.uber.org/zap"
 )
 
 // ProcessNetworkUDPPacket processes packets arriving from network and are destined to the application

--- a/controller/internal/enforcer/nfqdatapath/nflog/nflog_linux.go
+++ b/controller/internal/enforcer/nfqdatapath/nflog/nflog_linux.go
@@ -12,7 +12,6 @@ import (
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/policy"
-
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/proxy/enforcerproxy.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -25,6 +23,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 // ProxyInfo is the struct used to hold state about active enforcers in the system

--- a/controller/internal/enforcer/proxy/enforcerproxy_test.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	gomock "github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -16,10 +18,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
-	gomock "github.com/golang/mock/gomock"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 const procMountPoint = "/proc"

--- a/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -7,24 +7,20 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
-
-	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/oidc"
-	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/pkitokens"
-
-	"go.uber.org/zap"
-
 	"net"
 	"net/http"
+	"net/rpc"
 	"os"
 	"strconv"
 	"sync"
 	"time"
 
-	"net/rpc"
-
 	"github.com/mitchellh/hashstructure"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/oidc"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/pkitokens"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 // RPCHdl is a per client handle

--- a/controller/internal/processmon/processmon.go
+++ b/controller/internal/processmon/processmon.go
@@ -13,13 +13,12 @@ import (
 	"syscall"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 var (

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -6,13 +6,12 @@ import (
 	"strconv"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
+	"go.uber.org/zap"
 )
 
 const (

--- a/controller/internal/supervisor/iptablesctrl/iptables.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables.go
@@ -9,14 +9,13 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/bvandewalle/go-ipset/ipset"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/portset"
 	"go.aporeto.io/trireme-lib/controller/pkg/aclprovider"
 	"go.aporeto.io/trireme-lib/controller/pkg/fqconfig"
 	"go.aporeto.io/trireme-lib/policy"
-
-	"github.com/bvandewalle/go-ipset/ipset"
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/supervisor/proxy/supervisorproxy.go
+++ b/controller/internal/supervisor/proxy/supervisorproxy.go
@@ -11,12 +11,11 @@ import (
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
+	"go.aporeto.io/trireme-lib/controller/internal/processmon"
 	"go.aporeto.io/trireme-lib/controller/pkg/fqconfig"
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer"
-	"go.aporeto.io/trireme-lib/utils/cache"
-
-	"go.aporeto.io/trireme-lib/controller/internal/processmon"
 	"go.aporeto.io/trireme-lib/policy"
+	"go.aporeto.io/trireme-lib/utils/cache"
 )
 
 //ProxyInfo is a struct used to store state for the remote launcher.

--- a/controller/internal/supervisor/supervisor.go
+++ b/controller/internal/supervisor/supervisor.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/controller/constants"
@@ -19,6 +17,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/packetprocessor"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 type cacheData struct {

--- a/controller/internal/supervisor/supervisor_test.go
+++ b/controller/internal/supervisor/supervisor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -14,8 +15,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/internal/supervisor/mocksupervisor"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func createPUInfo() *policy.PUInfo {

--- a/controller/pkg/connection/connection.go
+++ b/controller/pkg/connection/connection.go
@@ -5,14 +5,13 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/controller/pkg/pucontext"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 // TCPFlowState identifies the constants of the state of a TCP connectioncon

--- a/controller/pkg/pkiverifier/pkiverifier.go
+++ b/controller/pkg/pkiverifier/pkiverifier.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-
 	"go.aporeto.io/trireme-lib/utils/cache"
 )
 

--- a/controller/pkg/pkiverifier/pkiverifier_test.go
+++ b/controller/pkg/pkiverifier/pkiverifier_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"go.aporeto.io/trireme-lib/utils/crypto"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/utils/crypto"
 )
 
 var (

--- a/controller/pkg/remoteenforcer/internal/statsclient/client.go
+++ b/controller/pkg/remoteenforcer/internal/statsclient/client.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/statscollector"
+	"go.uber.org/zap"
 )
 
 const (

--- a/controller/pkg/remoteenforcer/internal/statscollector/collector_test.go
+++ b/controller/pkg/remoteenforcer/internal/statscollector/collector_test.go
@@ -3,11 +3,10 @@ package statscollector
 import (
 	"testing"
 
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/policy"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNewCollector(t *testing.T) {

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -19,10 +19,9 @@ import (
 	"sync"
 	"syscall"
 
-	_ "go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/nsenter" // nolint
-
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
+	_ "go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/nsenter" // nolint
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
 	"go.aporeto.io/trireme-lib/controller/internal/supervisor"
 	"go.aporeto.io/trireme-lib/controller/pkg/packetprocessor"
@@ -30,7 +29,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/statscollector"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )

--- a/controller/pkg/remoteenforcer/remoteenforcer_test.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/mitchellh/hashstructure"
-
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -28,9 +29,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/statsclient/mockstatsclient"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 const (

--- a/controller/pkg/secrets/compactpki_test.go
+++ b/controller/pkg/secrets/compactpki_test.go
@@ -5,11 +5,10 @@ import (
 	"crypto/x509"
 	"testing"
 
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/pkg/pkiverifier"
 	"go.aporeto.io/trireme-lib/utils/crypto"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/controller/pkg/secrets/pkisecrets.go
+++ b/controller/pkg/secrets/pkisecrets.go
@@ -6,9 +6,8 @@ import (
 	"errors"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 // PKISecrets holds all PKI information

--- a/controller/pkg/secrets/pkisecrets_test.go
+++ b/controller/pkg/secrets/pkisecrets_test.go
@@ -5,9 +5,8 @@ import (
 	"crypto/x509"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/utils/crypto"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/utils/crypto"
 )
 
 func TestNewPKISecrets(t *testing.T) {

--- a/controller/pkg/servicetokens/servicetokens.go
+++ b/controller/pkg/servicetokens/servicetokens.go
@@ -9,10 +9,9 @@ import (
 
 	"github.com/bluele/gcache"
 	"github.com/dgrijalva/jwt-go"
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 var (

--- a/controller/pkg/tokens/jwt.go
+++ b/controller/pkg/tokens/jwt.go
@@ -8,14 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.uber.org/zap"
-
-	"github.com/dgrijalva/jwt-go"
 )
 
 var (

--- a/controller/pkg/tokens/jwt_test.go
+++ b/controller/pkg/tokens/jwt_test.go
@@ -6,11 +6,10 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/crypto"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/controller/pkg/urisearch/uriregex_test.go
+++ b/controller/pkg/urisearch/uriregex_test.go
@@ -3,9 +3,8 @@ package urisearch
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func initRules() []*policy.HTTPRule {

--- a/controller/pkg/urisearch/urisearch_test.go
+++ b/controller/pkg/urisearch/urisearch_test.go
@@ -3,9 +3,8 @@ package urisearch
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func initTrieRules() []*policy.HTTPRule {

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -10,12 +10,10 @@ import (
 	"time"
 
 	"github.com/bluele/gcache"
-	"github.com/rs/xid"
-	"golang.org/x/oauth2"
-
-	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
-
 	oidc "github.com/coreos/go-oidc"
+	"github.com/rs/xid"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
+	"golang.org/x/oauth2"
 )
 
 var (

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"github.com/dgrijalva/jwt-go"
-
 	"go.aporeto.io/tg/tglib"
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
 )

--- a/monitor/extractors/docker_test.go
+++ b/monitor/extractors/docker_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-
 	"testing"
 )
 

--- a/monitor/extractors/linux_test.go
+++ b/monitor/extractors/linux_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/utils/portspec"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestComputeFileMd5(t *testing.T) {

--- a/monitor/internal/cni/monitor.go
+++ b/monitor/internal/cni/monitor.go
@@ -7,7 +7,6 @@ import (
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
 	"go.aporeto.io/trireme-lib/monitor/extractors"
-
 	"go.aporeto.io/trireme-lib/monitor/registerer"
 )
 

--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -10,25 +10,22 @@ import (
 	"strconv"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/dchest/siphash"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	dockerClient "github.com/docker/docker/client"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
-	"go.aporeto.io/trireme-lib/monitor/constants"
-	"go.aporeto.io/trireme-lib/policy"
-
 	tevents "go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
+	"go.aporeto.io/trireme-lib/monitor/constants"
 	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/monitor/registerer"
+	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
 	"go.aporeto.io/trireme-lib/utils/portspec"
-
-	dockerClient "github.com/docker/docker/client"
+	"go.uber.org/zap"
 )
 
 // DockerMonitor implements the connection to Docker and monitoring based on docker events.

--- a/monitor/internal/docker/monitor_test.go
+++ b/monitor/internal/docker/monitor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	tevents "go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
@@ -20,8 +21,6 @@ import (
 	"go.aporeto.io/trireme-lib/monitor/internal/docker/mockdocker"
 	"go.aporeto.io/trireme-lib/policy/mockpolicy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls/mockcgnetcls"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"go.aporeto.io/trireme-lib/collector"
+	"go.aporeto.io/trireme-lib/monitor/config"
+	"go.aporeto.io/trireme-lib/monitor/extractors"
+	dockermonitor "go.aporeto.io/trireme-lib/monitor/internal/docker"
+	"go.aporeto.io/trireme-lib/monitor/registerer"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	kubecache "k8s.io/client-go/tools/cache"
-
-	"go.aporeto.io/trireme-lib/collector"
-	"go.aporeto.io/trireme-lib/monitor/extractors"
-
-	"go.aporeto.io/trireme-lib/monitor/config"
-	"go.aporeto.io/trireme-lib/monitor/registerer"
-
-	dockermonitor "go.aporeto.io/trireme-lib/monitor/internal/docker"
 )
 
 // KubernetesMonitor implements a monitor that sends pod events upstream

--- a/monitor/internal/linux/processor.go
+++ b/monitor/internal/linux/processor.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
 	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
+	"go.uber.org/zap"
 )
 
 var ignoreNames = map[string]*struct{}{

--- a/monitor/internal/linux/processor_test.go
+++ b/monitor/internal/linux/processor_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
@@ -14,9 +16,6 @@ import (
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/policy/mockpolicy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls/mockcgnetcls"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func testLinuxProcessor(puHandler policy.Resolver) *linuxProcessor {

--- a/monitor/internal/uid/processor.go
+++ b/monitor/internal/uid/processor.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
@@ -17,6 +15,7 @@ import (
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
+	"go.uber.org/zap"
 )
 
 var ignoreNames = map[string]*struct{}{

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"go.aporeto.io/trireme-lib/monitor/internal/kubernetes"
-
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
 	"go.aporeto.io/trireme-lib/monitor/internal/cni"
 	"go.aporeto.io/trireme-lib/monitor/internal/docker"
+	"go.aporeto.io/trireme-lib/monitor/internal/kubernetes"
 	"go.aporeto.io/trireme-lib/monitor/internal/linux"
 	"go.aporeto.io/trireme-lib/monitor/internal/uid"
 	"go.aporeto.io/trireme-lib/monitor/registerer"

--- a/monitor/registerer/registerer_test.go
+++ b/monitor/registerer/registerer_test.go
@@ -3,11 +3,10 @@ package registerer
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/common"
-	"go.aporeto.io/trireme-lib/monitor/processor/mockprocessor"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/monitor/processor/mockprocessor"
 )
 
 func TestNew(t *testing.T) {

--- a/monitor/remoteapi/server/server.go
+++ b/monitor/remoteapi/server/server.go
@@ -12,9 +12,8 @@ import (
 	"strings"
 
 	"github.com/shirou/gopsutil/process"
-	"go.aporeto.io/trireme-lib/monitor/registerer"
-
 	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/monitor/registerer"
 )
 
 // EventServer is a new event server

--- a/monitor/remoteapi/server/server_test.go
+++ b/monitor/remoteapi/server/server_test.go
@@ -10,12 +10,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/processor/mockprocessor"
 	"go.aporeto.io/trireme-lib/monitor/registerer"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNewEventServer(t *testing.T) {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -5,9 +5,8 @@ import (
 	"time"
 
 	"go.aporeto.io/tg/tglib"
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens"
+	"go.uber.org/zap"
 )
 
 // PUPolicy captures all policy information related ot the container

--- a/utils/cgnetcls/cgnetcls.go
+++ b/utils/cgnetcls/cgnetcls.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 
 	"github.com/kardianos/osext"
-
 	"go.uber.org/zap"
 )
 

--- a/utils/portcache/portcache_test.go
+++ b/utils/portcache/portcache_test.go
@@ -3,9 +3,8 @@ package portcache
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/utils/portspec"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/utils/portspec"
 )
 
 func TestNewPortCache(t *testing.T) {


### PR DESCRIPTION
#### Description
Fixes the problem with access to localhost on an IP other than 127.0.0.1 that is the IP of the loopback interface.

#### Test plan
Enhance integration tests with this use case. 

