### PR TITLE
Noclient

### DIFF
--- a/collector/default.go
+++ b/collector/default.go
@@ -55,5 +55,6 @@ func StatsUserHash(r *UserRecord) error {
 		}
 	}
 	r.ID = fmt.Sprintf("%d", hash.Sum64())
+
 	return nil
 }

--- a/controller/constants/constants.go
+++ b/controller/constants/constants.go
@@ -126,5 +126,5 @@ func String2CompressionType(s string) CompressionType {
 
 // API service related constants
 const (
-	CallbackURIExtension = "/.aporeto/oidc/callback"
+	CallbackURIExtension = "/aporeto/oidc/callback"
 )

--- a/controller/constants/constants.go
+++ b/controller/constants/constants.go
@@ -123,3 +123,8 @@ func String2CompressionType(s string) CompressionType {
 	}
 	return CompressionTypeNone
 }
+
+// API service related constants
+const (
+	CallbackURIExtension = "/.aporeto/oidc/callback"
+)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -17,7 +17,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/allocator"
-
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/acls/acl_test.go
+++ b/controller/internal/enforcer/acls/acl_test.go
@@ -4,9 +4,8 @@ import (
 	"net"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 var (

--- a/controller/internal/enforcer/acls/aclcache_test.go
+++ b/controller/internal/enforcer/acls/aclcache_test.go
@@ -4,9 +4,8 @@ import (
 	"net"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func TestEmptyACLCacheLookup(t *testing.T) {

--- a/controller/internal/enforcer/acls/ports_test.go
+++ b/controller/internal/enforcer/acls/ports_test.go
@@ -3,9 +3,8 @@ package acls
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func TestEmptyPortListLookup(t *testing.T) {

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -21,7 +21,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/urisearch"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
-	cryptohelpers "go.aporeto.io/trireme-lib/utils/crypto"
 
 	"go.uber.org/zap"
 )
@@ -121,7 +120,7 @@ func (p *AppProxy) Enforce(ctx context.Context, puID string, puInfo *policy.PUIn
 	// For updates we need to update the certificates if we have new ones. Otherwise
 	// we return. There is nothing else to do in case of policy update.
 	if c, cerr := p.clients.Get(puID); cerr == nil {
-		_, perr := p.processCertificateUpdates(puInfo, c.(*clientData), caPoolPEM)
+		_, perr := p.processCertificateUpdates(puInfo, c.(*clientData), caPool)
 		if perr != nil {
 			zap.L().Error("Failed to update certificates and services", zap.Error(perr))
 			return perr
@@ -177,7 +176,7 @@ func (p *AppProxy) Enforce(ctx context.Context, puID string, puInfo *policy.PUIn
 		return fmt.Errorf("Unable to register services: %s ", err)
 	}
 
-	if _, err := p.processCertificateUpdates(puInfo, client, caPoolPEM); err != nil {
+	if _, err := p.processCertificateUpdates(puInfo, client, caPool); err != nil {
 		zap.L().Error("Failed to update certificates", zap.Error(err))
 		return fmt.Errorf("Certificates not updated:  %s ", err)
 	}
@@ -316,7 +315,7 @@ func (p *AppProxy) createNetworkListener(port string) (net.Listener, error) {
 
 // processCertificateUpdates processes the certificate information and updates
 // the servers.
-func (p *AppProxy) processCertificateUpdates(puInfo *policy.PUInfo, client *clientData, externalCAs [][]byte) (bool, error) {
+func (p *AppProxy) processCertificateUpdates(puInfo *policy.PUInfo, client *clientData, caPool *x509.CertPool) (bool, error) {
 
 	// If there are certificates provided, we will need to update them for the
 	// services. If the certificates are nil, we ignore them.
@@ -326,16 +325,9 @@ func (p *AppProxy) processCertificateUpdates(puInfo *policy.PUInfo, client *clie
 	}
 
 	// Process any updates on the cert pool
-	var caPool *x509.CertPool
 	if caPEM != "" {
-		caPool = cryptohelpers.LoadRootCertificates([]byte(caPEM))
-	} else {
-		caPool = p.systemCAPool
-	}
-
-	for _, caCert := range externalCAs {
-		if !caPool.AppendCertsFromPEM(caCert) {
-			zap.L().Warn("Failed to add CA certificate to chain")
+		if !caPool.AppendCertsFromPEM([]byte(caPEM)) {
+			zap.L().Warn("Failed to add Services CA")
 		}
 	}
 
@@ -406,7 +398,7 @@ func buildExposedServices(p *auth.Processor, exposedServices policy.ApplicationS
 		}
 		ruleCache := urisearch.NewAPICache(service.HTTPRules, service.ID, false)
 		usedServices[service.ID] = true
-		p.AddOrUpdateService(service.ID, ruleCache, service.UserAuthorizationHandler, service.UserTokenToHTTPMappings)
+		p.AddOrUpdateService(service.ID, ruleCache, service.UserAuthorizationType, service.UserAuthorizationHandler, service.UserTokenToHTTPMappings)
 	}
 	p.RemoveUnusedServices(usedServices)
 	return portCache, portMapping

--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -21,7 +21,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/urisearch"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
-
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/applicationproxy/connproc/connproc.go
+++ b/controller/internal/enforcer/applicationproxy/connproc/connproc.go
@@ -11,10 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/applicationproxy/markedconn"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
 // GetInterfaces retrieves all the local interfaces.

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -279,10 +279,9 @@ func (p *Config) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certifica
 			_, port := mconn.GetOriginalDestination()
 			service, ok := p.portCache[port]
 			if !ok {
-
 				return nil, fmt.Errorf("service not available - cert is nil")
 			}
-			if service.PublicNetworkInfo.Ports.Min == uint16(port) && len(service.PublicServiceCertificate) > 0 {
+			if service.PublicNetworkInfo != nil && service.PublicNetworkInfo.Ports.Min == uint16(port) && len(service.PublicServiceCertificate) > 0 {
 				tlsCert, err := tls.X509KeyPair(service.PublicServiceCertificate, service.PublicServiceCertificateKey)
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse server certificate: %s", err)

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -461,7 +461,7 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 	record.PolicyID = aclPolicy.PolicyID
 	record.Source.ID = aclPolicy.ServiceID
 	if noNetAccessPolicy == nil && aclPolicy.Action.Rejected() {
-		http.Error(w, fmt.Sprintf("Access denied by network policy"), http.StatusNetworkAuthenticationRequired)
+		http.Error(w, fmt.Sprintf("Access denied by network policy - Rejected"), http.StatusNetworkAuthenticationRequired)
 		record.DropReason = collector.PolicyDrop
 		return
 	}
@@ -511,7 +511,7 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			http.Error(w, fmt.Sprintf("Access denied by network policy"), http.StatusNetworkAuthenticationRequired)
+			http.Error(w, fmt.Sprintf("Access denied by network policy - no policy found"), http.StatusNetworkAuthenticationRequired)
 			return
 		}
 	} else {
@@ -571,7 +571,7 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 		_, action, err := puContext.ApplicationACLPolicyFromAddr(originalDestination.IP.To4(), uint16(originalDestination.Port))
 		if err != nil || action.Action.Rejected() {
 			defer p.collector.CollectFlowEvent(reportDownStream(record, action))
-			http.Error(w, fmt.Sprintf("Access denied by network policy"), http.StatusNetworkAuthenticationRequired)
+			http.Error(w, fmt.Sprintf("Access to downstream denied by network policy"), http.StatusNetworkAuthenticationRequired)
 			return
 		}
 		if action.Action.Accepted() {

--- a/controller/internal/enforcer/applicationproxy/servicecache/servicecache_test.go
+++ b/controller/internal/enforcer/applicationproxy/servicecache/servicecache_test.go
@@ -4,11 +4,9 @@ import (
 	"net"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/utils/portspec"
-
-	"go.aporeto.io/trireme-lib/common"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/utils/portspec"
 )
 
 func TestServiceCache(t *testing.T) {

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -15,8 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/applicationproxy/connproc"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/applicationproxy/markedconn"
@@ -28,6 +26,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 const (

--- a/controller/internal/enforcer/lookup/lookup.go
+++ b/controller/internal/enforcer/lookup/lookup.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"sort"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/policy"
+	"go.uber.org/zap"
 )
 
 // ForwardingPolicy is an instance of the forwarding policy

--- a/controller/internal/enforcer/lookup/lookup_test.go
+++ b/controller/internal/enforcer/lookup/lookup_test.go
@@ -3,9 +3,8 @@ package lookup
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 var (

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -7,8 +7,6 @@ import (
 	"os/exec"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/netlink-go/conntrack"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
@@ -28,6 +26,7 @@ import (
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/portcache"
 	"go.aporeto.io/trireme-lib/utils/portspec"
+	"go.uber.org/zap"
 )
 
 // DefaultExternalIPTimeout is the default used for the cache for External IPTimeout.

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
@@ -19,6 +17,7 @@ import (
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
 	"go.aporeto.io/trireme-lib/utils/portspec"
+	"go.uber.org/zap"
 )
 
 // processNetworkPackets processes packets arriving from network and are destined to the application

--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/aporeto-inc/go-ipset/ipset"
 	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/collector/mockcollector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
-
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/packetgen"
 	"go.aporeto.io/trireme-lib/controller/pkg/connection"
@@ -25,8 +25,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/portspec"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/controller/internal/enforcer/nfqdatapath/datapath_udp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_udp.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
@@ -17,6 +15,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/controller/pkg/pucontext"
 	"go.aporeto.io/trireme-lib/controller/pkg/tokens"
+	"go.uber.org/zap"
 )
 
 const (

--- a/controller/internal/enforcer/nfqdatapath/nflog/nflog_linux.go
+++ b/controller/internal/enforcer/nfqdatapath/nflog/nflog_linux.go
@@ -12,7 +12,6 @@ import (
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/policy"
-
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/proxy/enforcerproxy.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -25,6 +23,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 // ProxyInfo is the struct used to hold state about active enforcers in the system

--- a/controller/internal/enforcer/proxy/enforcerproxy_test.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	gomock "github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -16,10 +18,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
-	gomock "github.com/golang/mock/gomock"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 const procMountPoint = "/proc"

--- a/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
+++ b/controller/internal/enforcer/utils/rpcwrapper/rpc_handle.go
@@ -7,24 +7,20 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
-	"sync"
-
-	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/oidc"
-	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/pkitokens"
-
-	"go.uber.org/zap"
-
 	"net"
 	"net/http"
+	"net/rpc"
 	"os"
 	"strconv"
+	"sync"
 	"time"
-
-	"net/rpc"
 
 	"github.com/mitchellh/hashstructure"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/oidc"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/pkitokens"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 // RPCHdl is a per client handle

--- a/controller/internal/processmon/processmon.go
+++ b/controller/internal/processmon/processmon.go
@@ -13,8 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
@@ -22,6 +20,7 @@ import (
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 var (

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -6,13 +6,12 @@ import (
 	"strconv"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
+	"go.uber.org/zap"
 )
 
 const (

--- a/controller/internal/supervisor/iptablesctrl/iptables.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables.go
@@ -39,8 +39,7 @@ const (
 	proxyOutputChain         = "Proxy-App"
 	proxyInputChain          = "Proxy-Net"
 	proxyMark                = "0x40"
-	// ProxyPort DefaultProxyPort
-	ProxyPort = "5000"
+
 	// TriremeInput represent the chain that contains pu input rules.
 	TriremeInput = "Trireme-Input"
 	// TriremeOutput represent the chain that contains pu output rules.

--- a/controller/internal/supervisor/iptablesctrl/iptables.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/aporeto-inc/go-ipset/ipset"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/portset"
@@ -16,8 +17,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/fqconfig"
 	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/policy"
-
-	"github.com/aporeto-inc/go-ipset/ipset"
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/supervisor/proxy/supervisorproxy.go
+++ b/controller/internal/supervisor/proxy/supervisorproxy.go
@@ -11,12 +11,11 @@ import (
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
+	"go.aporeto.io/trireme-lib/controller/internal/processmon"
 	"go.aporeto.io/trireme-lib/controller/pkg/fqconfig"
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer"
-	"go.aporeto.io/trireme-lib/utils/cache"
-
-	"go.aporeto.io/trireme-lib/controller/internal/processmon"
 	"go.aporeto.io/trireme-lib/policy"
+	"go.aporeto.io/trireme-lib/utils/cache"
 )
 
 //ProxyInfo is a struct used to store state for the remote launcher.

--- a/controller/internal/supervisor/supervisor.go
+++ b/controller/internal/supervisor/supervisor.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/controller/constants"
@@ -20,6 +18,7 @@ import (
 	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 type cacheData struct {

--- a/controller/internal/supervisor/supervisor_test.go
+++ b/controller/internal/supervisor/supervisor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -14,8 +15,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/internal/supervisor/mocksupervisor"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func createPUInfo() *policy.PUInfo {

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -50,7 +50,7 @@ func (p *Processor) UpdateSecrets(s secrets.Secrets, trustedCertificate *x509.Ce
 }
 
 // AddOrUpdateService adds or replaces a service in the authorization db.
-func (p *Processor) AddOrUpdateService(name string, apis *urisearch.APICache, handler usertokens.Verifier, mappings map[string]string) {
+func (p *Processor) AddOrUpdateService(name string, apis *urisearch.APICache, serviceType policy.UserAuthorizationTypeValues, handler usertokens.Verifier, mappings map[string]string) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -58,13 +58,15 @@ func (p *Processor) AddOrUpdateService(name string, apis *urisearch.APICache, ha
 		service.apis = apis
 		service.userTokenMappings = mappings
 		service.userTokenHandler = handler
+		service.userAuthorizationType = serviceType
 		return
 	}
 
 	p.serviceMap[name] = &service{
-		apis:              apis,
-		userTokenHandler:  handler,
-		userTokenMappings: mappings,
+		apis:                  apis,
+		userTokenHandler:      handler,
+		userTokenMappings:     mappings,
+		userAuthorizationType: serviceType,
 	}
 }
 

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -122,7 +122,6 @@ func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certi
 			attributes = append(attributes, "ou=", org)
 		}
 	}
-
 	// Now we can parse the user claims.
 	if srv.userJWThandler == nil {
 		return attributes, false, nil

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -13,12 +13,14 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/servicetokens"
 	"go.aporeto.io/trireme-lib/controller/pkg/urisearch"
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 type service struct {
-	apis                 *urisearch.APICache
-	userJWThandler       usertokens.Verifier
-	userJWTClaimMappings map[string]string
+	apis                  *urisearch.APICache
+	userTokenHandler      usertokens.Verifier
+	userTokenMappings     map[string]string
+	userAuthorizationType policy.UserAuthorizationTypeValues
 }
 
 // Processor holds all the local data of the authorization engine. A processor
@@ -54,15 +56,15 @@ func (p *Processor) AddOrUpdateService(name string, apis *urisearch.APICache, ha
 
 	if service, ok := p.serviceMap[name]; ok {
 		service.apis = apis
-		service.userJWTClaimMappings = mappings
-		service.userJWThandler = handler
+		service.userTokenMappings = mappings
+		service.userTokenHandler = handler
 		return
 	}
 
 	p.serviceMap[name] = &service{
-		apis:                 apis,
-		userJWThandler:       handler,
-		userJWTClaimMappings: mappings,
+		apis:              apis,
+		userTokenHandler:  handler,
+		userTokenMappings: mappings,
 	}
 }
 
@@ -101,40 +103,39 @@ func (p *Processor) UpdateServiceAPIs(name string, apis *urisearch.APICache) err
 
 // DecodeUserClaims decodes the user claims with the user authorization method.
 func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certificate, r *http.Request) ([]string, bool, error) {
-	attributes := []string{}
 
 	srv, ok := p.serviceMap[name]
 	if !ok {
-		return attributes, false, nil
+		return []string{}, false, nil
 	}
 
-	// First parse any incoming certificates and retrieve attributes from them.
-	// This is used in case of client authorization with certificates.
-	for _, cert := range certs {
-		attributes = append(attributes, "user="+cert.Subject.CommonName)
-		for _, email := range cert.EmailAddresses {
-			attributes = append(attributes, "email="+email)
-		}
-		for _, org := range cert.Subject.Organization {
-			attributes = append(attributes, "organization=", org)
-		}
-		for _, org := range cert.Subject.OrganizationalUnit {
-			attributes = append(attributes, "ou=", org)
-		}
-	}
-	// Now we can parse the user claims.
-	if srv.userJWThandler == nil {
-		return attributes, false, nil
-	}
-	claims, redirect, err := srv.userJWThandler.Validate(r.Context(), userToken)
-	if err != nil {
-		if len(attributes) == 0 {
-			return attributes, redirect, err
+	switch srv.userAuthorizationType {
+	case policy.UserAuthorizationMutualTLS:
+		// First parse any incoming certificates and retrieve attributes from them.
+		// This is used in case of client authorization with certificates.
+		attributes := []string{}
+		for _, cert := range certs {
+			attributes = append(attributes, "user="+cert.Subject.CommonName)
+			for _, email := range cert.EmailAddresses {
+				attributes = append(attributes, "email="+email)
+			}
+			for _, org := range cert.Subject.Organization {
+				attributes = append(attributes, "organization=", org)
+			}
+			for _, org := range cert.Subject.OrganizationalUnit {
+				attributes = append(attributes, "ou=", org)
+			}
 		}
 		return attributes, false, nil
+	case policy.UserAuthorizationOIDC, policy.UserAuthorizationJWT:
+		// Now we can parse the user claims.
+		if srv.userTokenHandler == nil {
+			return []string{}, false, nil
+		}
+		return srv.userTokenHandler.Validate(r.Context(), userToken)
+	default:
+		return []string{}, false, nil
 	}
-
-	return append(attributes, claims...), false, nil
 }
 
 // DecodeAporetoClaims decodes the Aporeto claims
@@ -166,7 +167,7 @@ func (p *Processor) Callback(name string, w http.ResponseWriter, r *http.Request
 	}
 
 	// Validate the JWT token through the handler.
-	token, originURL, status, err := srv.userJWThandler.Callback(r)
+	token, originURL, status, err := srv.userTokenHandler.Callback(r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid code %s:", err), http.StatusInternalServerError)
 		return
@@ -224,7 +225,7 @@ func (p *Processor) RedirectURI(name string, originURL string) string {
 		return ""
 	}
 	//TODO: erropr hanmdlign
-	return srv.userJWThandler.IssueRedirect(originURL)
+	return srv.userTokenHandler.IssueRedirect(originURL)
 }
 
 // UpdateRequestHeaders will update the request headers based on the user claims
@@ -238,13 +239,13 @@ func (p *Processor) UpdateRequestHeaders(name string, r *http.Request, claims []
 		return
 	}
 
-	if len(srv.userJWTClaimMappings) == 0 {
+	if len(srv.userTokenMappings) == 0 {
 		return
 	}
 
 	for _, claim := range claims {
 		parts := strings.SplitN(claim, "=", 2)
-		if header, ok := srv.userJWTClaimMappings[parts[0]]; ok && len(parts) == 2 {
+		if header, ok := srv.userTokenMappings[parts[0]]; ok && len(parts) == 2 {
 			r.Header.Add(header, parts[1])
 		}
 	}
@@ -253,7 +254,7 @@ func (p *Processor) UpdateRequestHeaders(name string, r *http.Request, claims []
 // RetrieveServiceHandler will retrieve the service that is stored in the serviceMap
 func (p *Processor) RetrieveServiceHandler(name string) (usertokens.Verifier, error) {
 	if s, ok := p.serviceMap[name]; ok {
-		return s.userJWThandler, nil
+		return s.userTokenHandler, nil
 	}
 	return nil, fmt.Errorf("Service not found")
 }

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -249,3 +249,11 @@ func (p *Processor) UpdateRequestHeaders(name string, r *http.Request, claims []
 		}
 	}
 }
+
+// RetrieveServiceHandler will retrieve the service that is stored in the serviceMap
+func (p *Processor) RetrieveServiceHandler(name string) (usertokens.Verifier, error) {
+	if s, ok := p.serviceMap[name]; ok {
+		return s.userJWThandler, nil
+	}
+	return nil, fmt.Errorf("Service not found")
+}

--- a/controller/pkg/connection/connection.go
+++ b/controller/pkg/connection/connection.go
@@ -5,14 +5,13 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/controller/pkg/pucontext"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 // TCPFlowState identifies the constants of the state of a TCP connectioncon

--- a/controller/pkg/pkiverifier/pkiverifier.go
+++ b/controller/pkg/pkiverifier/pkiverifier.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-
 	"go.aporeto.io/trireme-lib/utils/cache"
 )
 

--- a/controller/pkg/pkiverifier/pkiverifier_test.go
+++ b/controller/pkg/pkiverifier/pkiverifier_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"go.aporeto.io/trireme-lib/utils/crypto"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/utils/crypto"
 )
 
 var (

--- a/controller/pkg/remoteenforcer/internal/statsclient/client.go
+++ b/controller/pkg/remoteenforcer/internal/statsclient/client.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"time"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/statscollector"
+	"go.uber.org/zap"
 )
 
 const (

--- a/controller/pkg/remoteenforcer/internal/statscollector/collector_test.go
+++ b/controller/pkg/remoteenforcer/internal/statscollector/collector_test.go
@@ -3,11 +3,10 @@ package statscollector
 import (
 	"testing"
 
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/policy"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNewCollector(t *testing.T) {

--- a/controller/pkg/remoteenforcer/internal/statscollector/collector_trireme.go
+++ b/controller/pkg/remoteenforcer/internal/statscollector/collector_trireme.go
@@ -36,7 +36,7 @@ func (c *collectorImpl) CollectContainerEvent(record *collector.ContainerRecord)
 // CollectUserEvent collects a new user event and adds it to a local cache.
 func (c *collectorImpl) CollectUserEvent(record *collector.UserRecord) {
 	if err := collector.StatsUserHash(record); err != nil {
-		zap.L().Error("Cannot store user record")
+		zap.L().Error("Cannot store user record", zap.Error(err))
 		return
 	}
 

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -19,10 +19,9 @@ import (
 	"sync"
 	"syscall"
 
-	_ "go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/nsenter" // nolint
-
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
+	_ "go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/nsenter" // nolint
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
 	"go.aporeto.io/trireme-lib/controller/internal/supervisor"
 	"go.aporeto.io/trireme-lib/controller/pkg/packetprocessor"
@@ -30,7 +29,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/statscollector"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )

--- a/controller/pkg/remoteenforcer/remoteenforcer_test.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/mitchellh/hashstructure"
-
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer"
@@ -28,9 +29,6 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/statsclient/mockstatsclient"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 const (

--- a/controller/pkg/secrets/compactpki_test.go
+++ b/controller/pkg/secrets/compactpki_test.go
@@ -5,11 +5,10 @@ import (
 	"crypto/x509"
 	"testing"
 
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/pkg/pkiverifier"
 	"go.aporeto.io/trireme-lib/utils/crypto"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/controller/pkg/secrets/pkisecrets.go
+++ b/controller/pkg/secrets/pkisecrets.go
@@ -6,9 +6,8 @@ import (
 	"errors"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/utils/crypto"
+	"go.uber.org/zap"
 )
 
 // PKISecrets holds all PKI information

--- a/controller/pkg/secrets/pkisecrets_test.go
+++ b/controller/pkg/secrets/pkisecrets_test.go
@@ -5,9 +5,8 @@ import (
 	"crypto/x509"
 	"testing"
 
-	"go.aporeto.io/trireme-lib/utils/crypto"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/utils/crypto"
 )
 
 func TestNewPKISecrets(t *testing.T) {

--- a/controller/pkg/servicetokens/servicetokens.go
+++ b/controller/pkg/servicetokens/servicetokens.go
@@ -9,10 +9,9 @@ import (
 
 	"github.com/bluele/gcache"
 	"github.com/dgrijalva/jwt-go"
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/utils/cache"
+	"go.uber.org/zap"
 )
 
 var (

--- a/controller/pkg/tokens/jwt.go
+++ b/controller/pkg/tokens/jwt.go
@@ -8,14 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/constants"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.uber.org/zap"
-
-	"github.com/dgrijalva/jwt-go"
 )
 
 var (

--- a/controller/pkg/tokens/jwt_test.go
+++ b/controller/pkg/tokens/jwt_test.go
@@ -6,11 +6,10 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/crypto"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/controller/pkg/urisearch/uriregex_test.go
+++ b/controller/pkg/urisearch/uriregex_test.go
@@ -3,9 +3,8 @@ package urisearch
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func initRules() []*policy.HTTPRule {

--- a/controller/pkg/urisearch/urisearch_test.go
+++ b/controller/pkg/urisearch/urisearch_test.go
@@ -3,9 +3,8 @@ package urisearch
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/policy"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/policy"
 )
 
 func initTrieRules() []*policy.HTTPRule {

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -10,12 +10,10 @@ import (
 	"time"
 
 	"github.com/bluele/gcache"
-	"github.com/rs/xid"
-	"golang.org/x/oauth2"
-
-	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
-
 	oidc "github.com/coreos/go-oidc"
+	"github.com/rs/xid"
+	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
+	"golang.org/x/oauth2"
 )
 
 var (

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -31,18 +31,16 @@ var (
 
 // TokenVerifier is an OIDC validator.
 type TokenVerifier struct {
-	ProviderURL       string
-	ClientID          string
-	ClientSecret      string
-	RedirectURL       string
-	RedirectOnFail    bool
-	RedirectOnNoToken bool
-	NonceSize         int
-	CookieDuration    time.Duration
-	Scopes            []string
-	provider          *oidc.Provider // nolint: structcheck
-	clientConfig      *oauth2.Config
-	oauthVerifier     *oidc.IDTokenVerifier
+	ProviderURL    string
+	ClientID       string
+	ClientSecret   string
+	RedirectURL    string
+	NonceSize      int
+	CookieDuration time.Duration
+	Scopes         []string
+	provider       *oidc.Provider // nolint: structcheck
+	clientConfig   *oauth2.Config
+	oauthVerifier  *oidc.IDTokenVerifier
 }
 
 // NewClient creates a new validator client
@@ -136,8 +134,8 @@ func (v *TokenVerifier) Callback(r *http.Request) (string, string, int, error) {
 // token is not in the cache, it will validate it with the central authorizer.
 func (v *TokenVerifier) Validate(ctx context.Context, token string) ([]string, bool, error) {
 
-	if len(token) == 0 && v.RedirectOnNoToken {
-		return []string{}, v.RedirectOnNoToken, fmt.Errorf("Invalid token presented")
+	if len(token) == 0 {
+		return []string{}, true, fmt.Errorf("Invalid token presented")
 	}
 
 	if data, err := tokenCache.Get(token); err == nil {
@@ -146,7 +144,7 @@ func (v *TokenVerifier) Validate(ctx context.Context, token string) ([]string, b
 
 	idToken, err := v.oauthVerifier.Verify(ctx, token)
 	if err != nil {
-		return []string{}, v.RedirectOnFail, fmt.Errorf("Token validation failed: %s", err)
+		return []string{}, true, fmt.Errorf("Token validation failed: %s", err)
 	}
 
 	// Get the claims out of the token. Use the standard data structure for
@@ -155,7 +153,7 @@ func (v *TokenVerifier) Validate(ctx context.Context, token string) ([]string, b
 		IDTokenClaims map[string]interface{} // ID Token payload is just JSON.
 	}{map[string]interface{}{}}
 	if err := idToken.Claims(&resp.IDTokenClaims); err != nil {
-		return []string{}, v.RedirectOnFail, fmt.Errorf("Unable to process claims: %s", err)
+		return []string{}, true, fmt.Errorf("Unable to process claims: %s", err)
 	}
 
 	// Flatten the claims in a generic format.

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"github.com/dgrijalva/jwt-go"
-
 	"go.aporeto.io/tg/tglib"
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
 )

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -63,8 +63,9 @@ func NewVerifier(v *PKIJWTVerifier) (*PKIJWTVerifier, error) {
 // Validate parses a generic JWT token and flattens the claims in a normalized form. It
 // assumes that the JWT signing certificate will validate the token.
 func (j *PKIJWTVerifier) Validate(ctx context.Context, tokenString string) ([]string, bool, error) {
+	fmt.Prinln("Validating JWT")
 	if len(tokenString) == 0 {
-		return []string{}, true, fmt.Errorf("Empty token")
+		return []string{}, false, fmt.Errorf("Empty token")
 	}
 	claims := &jwt.MapClaims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
@@ -86,7 +87,7 @@ func (j *PKIJWTVerifier) Validate(ctx context.Context, tokenString string) ([]st
 		return nil, fmt.Errorf("Signing method does not match certificate")
 	})
 	if err != nil || token == nil || !token.Valid {
-		return []string{}, true, fmt.Errorf("Invalid token")
+		return []string{}, false, fmt.Errorf("Invalid token")
 	}
 
 	attributes := []string{}

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -20,11 +20,9 @@ import (
 // This is a simple and stateless verifier that doesn't depend on central server
 // for validating the tokens. The public key is provided out-of-band.
 type PKIJWTVerifier struct {
-	JWTCertPEM        []byte
-	jwtCert           *x509.Certificate
-	RedirectOnFail    bool
-	RedirectOnNoToken bool
-	RedirectURL       string
+	JWTCertPEM  []byte
+	jwtCert     *x509.Certificate
+	RedirectURL string
 }
 
 // NewVerifierFromFile assumes that the input is provided as file path.
@@ -66,7 +64,7 @@ func NewVerifier(v *PKIJWTVerifier) (*PKIJWTVerifier, error) {
 // assumes that the JWT signing certificate will validate the token.
 func (j *PKIJWTVerifier) Validate(ctx context.Context, tokenString string) ([]string, bool, error) {
 	if len(tokenString) == 0 {
-		return []string{}, j.RedirectOnNoToken, fmt.Errorf("Empty token")
+		return []string{}, true, fmt.Errorf("Empty token")
 	}
 	claims := &jwt.MapClaims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
@@ -88,7 +86,7 @@ func (j *PKIJWTVerifier) Validate(ctx context.Context, tokenString string) ([]st
 		return nil, fmt.Errorf("Signing method does not match certificate")
 	})
 	if err != nil || token == nil || !token.Valid {
-		return []string{}, j.RedirectOnFail, fmt.Errorf("Invalid token")
+		return []string{}, true, fmt.Errorf("Invalid token")
 	}
 
 	attributes := []string{}

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -63,7 +63,6 @@ func NewVerifier(v *PKIJWTVerifier) (*PKIJWTVerifier, error) {
 // Validate parses a generic JWT token and flattens the claims in a normalized form. It
 // assumes that the JWT signing certificate will validate the token.
 func (j *PKIJWTVerifier) Validate(ctx context.Context, tokenString string) ([]string, bool, error) {
-	fmt.Prinln("Validating JWT")
 	if len(tokenString) == 0 {
 		return []string{}, false, fmt.Errorf("Empty token")
 	}

--- a/monitor/extractors/docker_test.go
+++ b/monitor/extractors/docker_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-
 	"testing"
 )
 

--- a/monitor/internal/cni/monitor.go
+++ b/monitor/internal/cni/monitor.go
@@ -7,7 +7,6 @@ import (
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
 	"go.aporeto.io/trireme-lib/monitor/extractors"
-
 	"go.aporeto.io/trireme-lib/monitor/registerer"
 )
 

--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -10,25 +10,22 @@ import (
 	"strconv"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/dchest/siphash"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	dockerClient "github.com/docker/docker/client"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
-	"go.aporeto.io/trireme-lib/monitor/constants"
-	"go.aporeto.io/trireme-lib/policy"
-
 	tevents "go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
+	"go.aporeto.io/trireme-lib/monitor/constants"
 	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/monitor/registerer"
+	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
 	"go.aporeto.io/trireme-lib/utils/portspec"
-
-	dockerClient "github.com/docker/docker/client"
+	"go.uber.org/zap"
 )
 
 // DockerMonitor implements the connection to Docker and monitoring based on docker events.

--- a/monitor/internal/docker/monitor_test.go
+++ b/monitor/internal/docker/monitor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	tevents "go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
@@ -20,8 +21,6 @@ import (
 	"go.aporeto.io/trireme-lib/monitor/internal/docker/mockdocker"
 	"go.aporeto.io/trireme-lib/policy/mockpolicy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls/mockcgnetcls"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/monitor/internal/kubernetes/monitor.go
+++ b/monitor/internal/kubernetes/monitor.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"go.aporeto.io/trireme-lib/collector"
+	"go.aporeto.io/trireme-lib/monitor/config"
+	"go.aporeto.io/trireme-lib/monitor/extractors"
+	dockermonitor "go.aporeto.io/trireme-lib/monitor/internal/docker"
+	"go.aporeto.io/trireme-lib/monitor/registerer"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	kubecache "k8s.io/client-go/tools/cache"
-
-	"go.aporeto.io/trireme-lib/collector"
-	"go.aporeto.io/trireme-lib/monitor/extractors"
-
-	"go.aporeto.io/trireme-lib/monitor/config"
-	"go.aporeto.io/trireme-lib/monitor/registerer"
-
-	dockermonitor "go.aporeto.io/trireme-lib/monitor/internal/docker"
 )
 
 // KubernetesMonitor implements a monitor that sends pod events upstream

--- a/monitor/internal/linux/processor.go
+++ b/monitor/internal/linux/processor.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
 	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
+	"go.uber.org/zap"
 )
 
 var ignoreNames = map[string]*struct{}{

--- a/monitor/internal/linux/processor_test.go
+++ b/monitor/internal/linux/processor_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
@@ -14,9 +16,6 @@ import (
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/policy/mockpolicy"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls/mockcgnetcls"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func testLinuxProcessor(puHandler policy.Resolver) *linuxProcessor {

--- a/monitor/internal/uid/processor.go
+++ b/monitor/internal/uid/processor.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/collector"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
@@ -17,6 +15,7 @@ import (
 	"go.aporeto.io/trireme-lib/policy"
 	"go.aporeto.io/trireme-lib/utils/cache"
 	"go.aporeto.io/trireme-lib/utils/cgnetcls"
+	"go.uber.org/zap"
 )
 
 var ignoreNames = map[string]*struct{}{

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"go.aporeto.io/trireme-lib/monitor/internal/kubernetes"
-
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
 	"go.aporeto.io/trireme-lib/monitor/internal/cni"
 	"go.aporeto.io/trireme-lib/monitor/internal/docker"
+	"go.aporeto.io/trireme-lib/monitor/internal/kubernetes"
 	"go.aporeto.io/trireme-lib/monitor/internal/linux"
 	"go.aporeto.io/trireme-lib/monitor/internal/uid"
 	"go.aporeto.io/trireme-lib/monitor/registerer"

--- a/monitor/registerer/registerer_test.go
+++ b/monitor/registerer/registerer_test.go
@@ -3,11 +3,10 @@ package registerer
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/common"
-	"go.aporeto.io/trireme-lib/monitor/processor/mockprocessor"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/monitor/processor/mockprocessor"
 )
 
 func TestNew(t *testing.T) {

--- a/monitor/remoteapi/server/server.go
+++ b/monitor/remoteapi/server/server.go
@@ -12,9 +12,8 @@ import (
 	"strings"
 
 	"github.com/shirou/gopsutil/process"
-	"go.aporeto.io/trireme-lib/monitor/registerer"
-
 	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/monitor/registerer"
 )
 
 // EventServer is a new event server

--- a/monitor/remoteapi/server/server_test.go
+++ b/monitor/remoteapi/server/server_test.go
@@ -10,12 +10,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/processor/mockprocessor"
 	"go.aporeto.io/trireme-lib/monitor/registerer"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNewEventServer(t *testing.T) {

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -16,6 +16,18 @@ const (
 	ServiceSecretsProxy
 )
 
+// UserAuthorizationTypeValues is the types of user authorization methods that
+// are supported.
+type UserAuthorizationTypeValues int
+
+// Values of UserAuthorizationTypeValues
+const (
+	UserAuthorizationNone UserAuthorizationTypeValues = iota
+	UserAuthorizationMutualTLS
+	UserAuthorizationJWT
+	UserAuthorizationOIDC
+)
+
 // ApplicationServicesList is a list of ApplicationServices.
 type ApplicationServicesList []*ApplicationService
 
@@ -56,14 +68,17 @@ type ApplicationService struct {
 	// Tags are the tags of the service.
 	Tags *TagStore
 
-	// JWTTokenHandler is the token handler for validating user JWT tokens.
-	JWTTokenHandler usertokens.Verifier
+	// UserAuthorizationType is the type of user authorization that must be used.
+	UserAuthorizationType UserAuthorizationTypeValues
 
-	// JWTClaimMappings is a map of mappings between JWT claims arriving in
+	// UserAuthorizationHandler is the token handler for validating user tokens.
+	UserAuthorizationHandler usertokens.Verifier
+
+	// UserTokenToHTTPMappings is a map of mappings between JWT claims arriving in
 	// a user request and outgoing HTTP headers towards an application. It
 	// is used to allow operators to map claims to HTTP headers that downstream
 	// applications can understand.
-	JWTClaimMappings map[string]string
+	UserTokenToHTTPMappings map[string]string
 
 	// External indicates if this is an external service. For external services
 	// access control is implemented at the ingress.

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -91,6 +91,16 @@ type ApplicationService struct {
 	// AuthToken is the authentication token for any external API service calls. It is
 	// used for example by the secrets proxy.
 	AuthToken string
+
+	// MutualTLSTrustedRoots is the CA that must be used for mutual TLS authentication.
+	MutualTLSTrustedRoots []byte
+
+	// PublicServiceCertificate is a publically signed certificate that can be used
+	// by the service to expose TLS to users without a Trireme client
+	PublicServiceCertificate []byte
+
+	// PublicServiceCertificateKey is the corresponding private key.
+	PublicServiceCertificateKey []byte
 }
 
 // HTTPRule holds a rule for a particular HTTPService. The rule

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -476,7 +476,7 @@ func (p *PUPolicyPublic) ToPrivatePolicy(convert bool) *PUPolicy {
 	exposedServices := ApplicationServicesList{}
 	for _, e := range p.ExposedServices {
 		if convert {
-			e.JWTTokenHandler = usertokens.NewVerifier(e.JWTTokenHandler)
+			e.UserAuthorizationHandler = usertokens.NewVerifier(e.UserAuthorizationHandler)
 		}
 		exposedServices = append(exposedServices, e)
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -5,9 +5,8 @@ import (
 	"time"
 
 	"go.aporeto.io/tg/tglib"
-	"go.uber.org/zap"
-
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens"
+	"go.uber.org/zap"
 )
 
 // PUPolicy captures all policy information related ot the container

--- a/utils/cgnetcls/cgnetcls.go
+++ b/utils/cgnetcls/cgnetcls.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 
 	"github.com/kardianos/osext"
-
 	"go.uber.org/zap"
 )
 

--- a/utils/portcache/portcache_test.go
+++ b/utils/portcache/portcache_test.go
@@ -3,9 +3,8 @@ package portcache
 import (
 	"testing"
 
-	"go.aporeto.io/trireme-lib/utils/portspec"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/utils/portspec"
 )
 
 func TestNewPortCache(t *testing.T) {


### PR DESCRIPTION
Updates to API services.

Cleanly separate the different authorization modes for users (OIDC, JWT, Certificate). Only one of them can be active at any given time. 

Provide ability to deploy external certificates for services and separate root CAs for client authorization.