### PR TITLE
Add the loopback fix to master

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -400,7 +400,8 @@ func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context
 		// packets after the first data packet, that might be already in the queue
 		// will be transmitted through the kernel directly. Service connections are
 		// delegated to the service module
-		if !conn.ServiceConnection && tcpPacket.SourceAddress.String() != tcpPacket.DestinationAddress.String() {
+		if !conn.ServiceConnection && tcpPacket.SourceAddress.String() != tcpPacket.DestinationAddress.String() &&
+			!(tcpPacket.SourceAddress.IsLoopback() && tcpPacket.DestinationAddress.IsLoopback()) {
 			if err := d.conntrackHdl.ConntrackTableUpdateMark(
 				tcpPacket.SourceAddress.String(),
 				tcpPacket.DestinationAddress.String(),


### PR DESCRIPTION
It was only added to 3.3.0. Adding to master.

Takes into the account the case where loopback traffic can come from any IP and not just the IP address of the lo interface.
