### PR TITLE
Fix crash when connection doesn't have a remote address

### DIFF
--- a/controller/internal/enforcer/applicationproxy/protomux/protomux.go
+++ b/controller/internal/enforcer/applicationproxy/protomux/protomux.go
@@ -206,13 +206,14 @@ func (m *MultiplexedListener) serve(conn net.Conn) {
 
 	defer m.wg.Done()
 	ip, port := c.GetOriginalDestination()
-	if c.RemoteAddr() == nil {
+	remoteAddr := c.RemoteAddr()
+	if remoteAddr == nil {
 		zap.L().Error("Connection remote address cannot be found. Abort")
 		return
 	}
 
 	local := false
-	if _, ok = m.localIPs[networkOfAddress(c.RemoteAddr().String())]; ok {
+	if _, ok = m.localIPs[networkOfAddress(remoteAddr.String())]; ok {
 		local = true
 	}
 
@@ -223,7 +224,7 @@ func (m *MultiplexedListener) serve(conn net.Conn) {
 	if entry == nil {
 		// Let's see if we can match the source address.
 		// Compatibility with deprecated model. TODO: Remove
-		ip = c.RemoteAddr().(*net.TCPAddr).IP
+		ip = remoteAddr.(*net.TCPAddr).IP
 		entry = servicecache.Find(ip, port, !local)
 		if entry == nil {
 			// Failed with source as well.

--- a/controller/internal/enforcer/applicationproxy/protomux/protomux.go
+++ b/controller/internal/enforcer/applicationproxy/protomux/protomux.go
@@ -224,7 +224,14 @@ func (m *MultiplexedListener) serve(conn net.Conn) {
 	if entry == nil {
 		// Let's see if we can match the source address.
 		// Compatibility with deprecated model. TODO: Remove
-		ip = remoteAddr.(*net.TCPAddr).IP
+		var tcpAddr *net.TCPAddr
+		var ok bool
+		if tcpAddr, ok = remoteAddr.(*net.TCPAddr); !ok {
+			c.Close()
+			return
+		}
+		ip = tcpAddr.IP
+
 		entry = servicecache.Find(ip, port, !local)
 		if entry == nil {
 			// Failed with source as well.

--- a/controller/internal/enforcer/applicationproxy/protomux/protomux.go
+++ b/controller/internal/enforcer/applicationproxy/protomux/protomux.go
@@ -227,7 +227,7 @@ func (m *MultiplexedListener) serve(conn net.Conn) {
 		var tcpAddr *net.TCPAddr
 		var ok bool
 		if tcpAddr, ok = remoteAddr.(*net.TCPAddr); !ok {
-			c.Close()
+			c.Close() // nolint errcheck
 			return
 		}
 		ip = tcpAddr.IP

--- a/controller/internal/enforcer/applicationproxy/protomux/protomux.go
+++ b/controller/internal/enforcer/applicationproxy/protomux/protomux.go
@@ -201,10 +201,16 @@ func (m *MultiplexedListener) serve(conn net.Conn) {
 	c, ok := conn.(*markedconn.ProxiedConnection)
 	if !ok {
 		zap.L().Error("Wrong connection type")
+		return
 	}
 
 	defer m.wg.Done()
 	ip, port := c.GetOriginalDestination()
+	if c.RemoteAddr() == nil {
+		zap.L().Error("Connection remote address cannot be found. Abort")
+		return
+	}
+
 	local := false
 	if _, ok = m.localIPs[networkOfAddress(c.RemoteAddr().String())]; ok {
 		local = true


### PR DESCRIPTION
Fixes a rare crash when net.Conn doesn't have the remote address.

https://github.com/golang/go/issues/23022