### PR TITLE
Add exclusion rules for proxies

### DIFF
--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -265,7 +265,6 @@ func (p *AppProxy) registerServices(client *clientData, puInfo *policy.PUInfo) e
 		}
 		if service.PublicNetworkInfo != nil {
 			// We also need to listen on the public ports in this case.
-			fmt.Println("Registering service with", service.PublicServiceNoTLS)
 			if err := register.Add(service.PublicNetworkInfo, serviceTypeToNetworkListenerType(service.Type, service.PublicServiceNoTLS), true); err != nil {
 				return fmt.Errorf("Public network information overlaps with exposed services or other definitions: %s", err)
 			}

--- a/controller/internal/supervisor/interfaces.go
+++ b/controller/internal/supervisor/interfaces.go
@@ -36,7 +36,7 @@ type Implementor interface {
 	UpdateRules(version int, contextID string, containerInfo *policy.PUInfo, oldContainerInfo *policy.PUInfo) error
 
 	// DeleteRules
-	DeleteRules(version int, context string, tcpPorts, udpPorts string, mark string, uid string, proxyPort string, puType string) error
+	DeleteRules(version int, context string, tcpPorts, udpPorts string, mark string, uid string, proxyPort string, puType string, exclusions []string) error
 
 	// SetTargetNetworks sets the target networks of the supervisor
 	SetTargetNetworks([]string, []string) error

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -150,6 +150,14 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			"-j", "ACCEPT",
 		},
 		{ // APIServices
+			i.netPacketIPTableContext,
+			proxyInputChain,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", srvSetName, "src",
+			"-j", "ACCEPT",
+		},
+		{ // APIServices
 			i.appPacketIPTableContext,
 			proxyInputChain,
 			"-p", "tcp",

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -149,6 +149,14 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			"--match-set", destSetName, "src,src",
 			"-j", "ACCEPT",
 		},
+		{ // Needed for Web sockets
+			i.netPacketIPTableContext,
+			proxyInputChain,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", srvSetName, "dst",
+			"-j", "ACCEPT",
+		},
 		{ // APIServices
 			i.netPacketIPTableContext,
 			proxyInputChain,
@@ -177,6 +185,14 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			"-p", "tcp",
 			"-m", "set",
 			"--match-set", srvSetName, "src",
+			"-j", "ACCEPT",
+		},
+		{ // Needed for websocket support
+			i.appPacketIPTableContext,
+			proxyOutputChain,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", srvSetName, "dst",
 			"-j", "ACCEPT",
 		},
 		{

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -141,6 +141,14 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			"-j", "REDIRECT",
 			"--to-port", proxyPort,
 		},
+		{
+			i.netPacketIPTableContext,
+			proxyInputChain,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", destSetName, "src,src",
+			"-j", "ACCEPT",
+		},
 		{ // APIServices
 			i.appPacketIPTableContext,
 			proxyInputChain,

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -158,14 +158,6 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			"-j", "ACCEPT",
 		},
 		{ // APIServices
-			i.netPacketIPTableContext,
-			proxyInputChain,
-			"-p", "tcp",
-			"-m", "set",
-			"--match-set", srvSetName, "dst",
-			"-j", "ACCEPT",
-		},
-		{ // APIServices
 			i.appPacketIPTableContext,
 			proxyInputChain,
 			"-p", "tcp",
@@ -185,14 +177,6 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			"-p", "tcp",
 			"-m", "set",
 			"--match-set", srvSetName, "src",
-			"-j", "ACCEPT",
-		},
-		{ // APIServices
-			i.appPacketIPTableContext,
-			proxyOutputChain,
-			"-p", "tcp",
-			"-m", "set",
-			"--match-set", srvSetName, "dst",
 			"-j", "ACCEPT",
 		},
 		{

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -158,6 +158,14 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			"-j", "ACCEPT",
 		},
 		{ // APIServices
+			i.netPacketIPTableContext,
+			proxyInputChain,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", srvSetName, "dst",
+			"-j", "ACCEPT",
+		},
+		{ // APIServices
 			i.appPacketIPTableContext,
 			proxyInputChain,
 			"-p", "tcp",
@@ -169,6 +177,22 @@ func (i *Instance) proxyRules(appChain string, netChain string, port string, pro
 			proxyOutputChain,
 			"-p", "tcp",
 			"--source-port", proxyPort,
+			"-j", "ACCEPT",
+		},
+		{ // APIServices
+			i.appPacketIPTableContext,
+			proxyOutputChain,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", srvSetName, "src",
+			"-j", "ACCEPT",
+		},
+		{ // APIServices
+			i.appPacketIPTableContext,
+			proxyOutputChain,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", srvSetName, "dst",
 			"-j", "ACCEPT",
 		},
 		{

--- a/controller/internal/supervisor/iptablesctrl/ipsets.go
+++ b/controller/internal/supervisor/iptablesctrl/ipsets.go
@@ -62,16 +62,11 @@ func (i *Instance) createTargetSet(networks []string) error {
 
 // createProxySet creates a new target set -- ipportset is a list of {ip,port}
 func (i *Instance) createProxySets(portSetName string) error {
-	destSetName, srcSetName, srvSetName := i.getSetNames(portSetName)
+	destSetName, srvSetName := i.getSetNames(portSetName)
 
 	_, err := i.ipset.NewIpset(destSetName, "hash:ip,port", &ipset.Params{})
 	if err != nil {
 		return fmt.Errorf("unable to create ipset for %s: %s", destSetName, err)
-	}
-
-	_, err = i.ipset.NewIpset(srcSetName, "hash:ip,port", &ipset.Params{})
-	if err != nil {
-		return fmt.Errorf("unable to create ipset for %s: %s", srcSetName, err)
 	}
 
 	err = i.createPUPortSet(srvSetName)
@@ -97,7 +92,7 @@ func (i *Instance) createUIDSets(contextID string, puInfo *policy.PUInfo) error 
 
 func (i *Instance) updateProxySet(policy *policy.PUPolicy, portSetName string) error {
 
-	dstSetName, srcSetName, srvSetName := i.getSetNames(portSetName)
+	dstSetName, srvSetName := i.getSetNames(portSetName)
 	vipTargetSet := ipset.IPSet{
 		Name: dstSetName,
 	}
@@ -116,13 +111,6 @@ func (i *Instance) updateProxySet(policy *policy.PUPolicy, portSetName string) e
 				}
 			}
 		}
-	}
-
-	pipTargetSet := ipset.IPSet{
-		Name: srcSetName,
-	}
-	if ferr := pipTargetSet.Flush(); ferr != nil {
-		zap.L().Warn("Unable to flush the pip proxy set")
 	}
 
 	srvTargetSet := ipset.IPSet{
@@ -154,8 +142,8 @@ func (i *Instance) updateProxySet(policy *policy.PUPolicy, portSetName string) e
 }
 
 //getSetNamePair returns a pair of strings represent proxySetNames
-func (i *Instance) getSetNames(portSetName string) (string, string, string) {
-	return "dst-" + portSetName, "src-" + portSetName, "srv-" + portSetName
+func (i *Instance) getSetNames(portSetName string) (string, string) {
+	return "dst-" + portSetName, "srv-" + portSetName
 
 }
 

--- a/controller/internal/supervisor/iptablesctrl/iptables_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables_test.go
@@ -629,7 +629,7 @@ func TestDeleteRules(t *testing.T) {
 			iptables.MockDeleteChain(t, func(table string, chain string) error {
 				return nil
 			})
-			err := i.DeleteRules(1, "context", "0", "0", "", "", "5000", "")
+			err := i.DeleteRules(1, "context", "0", "0", "", "", "5000", "", []string{})
 			So(err, ShouldBeNil)
 		})
 
@@ -643,7 +643,7 @@ func TestDeleteRules(t *testing.T) {
 			iptables.MockDeleteChain(t, func(table string, chain string) error {
 				return nil
 			})
-			err := i.DeleteRules(1, "context", "0", "0", "", "", "5000", "")
+			err := i.DeleteRules(1, "context", "0", "0", "", "", "5000", "", []string{})
 			So(err, ShouldBeNil)
 		})
 

--- a/controller/internal/supervisor/mocksupervisor/mocksupervisor.go
+++ b/controller/internal/supervisor/mocksupervisor/mocksupervisor.go
@@ -167,16 +167,16 @@ func (mr *MockImplementorMockRecorder) UpdateRules(version, contextID, container
 
 // DeleteRules mocks base method
 // nolint
-func (m *MockImplementor) DeleteRules(version int, context, tcpPorts, udpPorts, mark, uid, proxyPort string, isHostMode bool) error {
-	ret := m.ctrl.Call(m, "DeleteRules", version, context, tcpPorts, udpPorts, mark, uid, proxyPort, isHostMode)
+func (m *MockImplementor) DeleteRules(version int, context, tcpPorts, udpPorts, mark, uid, proxyPort, puType string, exclusions []string) error {
+	ret := m.ctrl.Call(m, "DeleteRules", version, context, tcpPorts, udpPorts, mark, uid, proxyPort, puType, exclusions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteRules indicates an expected call of DeleteRules
 // nolint
-func (mr *MockImplementorMockRecorder) DeleteRules(version, context, tcpPorts, udpPorts, mark, uid, proxyPort, isHostMode interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRules", reflect.TypeOf((*MockImplementor)(nil).DeleteRules), version, context, tcpPorts, udpPorts, mark, uid, proxyPort, isHostMode)
+func (mr *MockImplementorMockRecorder) DeleteRules(version, context, tcpPorts, udpPorts, mark, uid, proxyPort, puType, exclusions interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRules", reflect.TypeOf((*MockImplementor)(nil).DeleteRules), version, context, tcpPorts, udpPorts, mark, uid, proxyPort, puType, exclusions)
 }
 
 // SetTargetNetworks mocks base method

--- a/controller/internal/supervisor/supervisor.go
+++ b/controller/internal/supervisor/supervisor.go
@@ -130,7 +130,7 @@ func (s *Config) Unsupervise(contextID string) error {
 	// If local server, delete pu specific chains in Trireme/NetworkSvc/Hostmode chains.
 	puType := extractors.GetPuType(cfg.containerInfo.Runtime)
 
-	if err := s.impl.DeleteRules(cfg.version, contextID, cfg.tcpPorts, cfg.udpPorts, cfg.mark, cfg.uid, port, puType); err != nil {
+	if err := s.impl.DeleteRules(cfg.version, contextID, cfg.tcpPorts, cfg.udpPorts, cfg.mark, cfg.uid, port, puType, cfg.containerInfo.Policy.ExcludedNetworks()); err != nil {
 		zap.L().Warn("Some rules were not deleted during unsupervise", zap.Error(err))
 	}
 
@@ -243,6 +243,9 @@ func (s *Config) doUpdatePU(contextID string, pu *policy.PUInfo) error {
 		s.Unsupervise(contextID) // nolint
 		return err
 	}
+
+	// Updated the policy in the cached processing unit.
+	c.containerInfo.Policy = pu.Policy
 
 	return nil
 }

--- a/controller/internal/supervisor/supervisor_test.go
+++ b/controller/internal/supervisor/supervisor_test.go
@@ -151,7 +151,7 @@ func TestSupervise(t *testing.T) {
 
 		Convey("When I supervise a new PU with valid policy, but there is an error", func() {
 			impl.EXPECT().ConfigureRules(0, "errorPU", puInfo).Return(errors.New("error"))
-			impl.EXPECT().DeleteRules(0, "errorPU", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			impl.EXPECT().DeleteRules(0, "errorPU", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			err := s.Supervise("errorPU", puInfo)
 			Convey("I should  get an error", func() {
 				So(err, ShouldNotBeNil)
@@ -172,7 +172,7 @@ func TestSupervise(t *testing.T) {
 		Convey("When I send supervise command for a second time, and the update fails", func() {
 			impl.EXPECT().ConfigureRules(0, "contextID", puInfo).Return(nil)
 			impl.EXPECT().UpdateRules(1, "contextID", gomock.Any(), gomock.Any()).Return(errors.New("error"))
-			impl.EXPECT().DeleteRules(1, "contextID", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			impl.EXPECT().DeleteRules(1, "contextID", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			serr := s.Supervise("contextID", puInfo)
 			So(serr, ShouldBeNil)
 			err := s.Supervise("contextID", puInfo)
@@ -220,7 +220,7 @@ func TestUnsupervise(t *testing.T) {
 
 		Convey("When I try to unsupervise a valid PU ", func() {
 			impl.EXPECT().ConfigureRules(0, "contextID", puInfo).Return(nil)
-			impl.EXPECT().DeleteRules(0, "contextID", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			impl.EXPECT().DeleteRules(0, "contextID", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			serr := s.Supervise("contextID", puInfo)
 			So(serr, ShouldBeNil)
 			err := s.Unsupervise("contextID")


### PR DESCRIPTION
This PR does two things:

1. Cleans up the proxy ACLs. Several of them were left overs from the previous service model.

2. Adds exclusion rules to the proxies so that specific IPs (like localhost) can be ignored by the proxies based on policy.