### PR TITLE
fixed: use session cookie for tokens.

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -113,9 +113,17 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 	// for the listener from the network, but not for the listener from a PU.
 	if encrypted {
 		config := &tls.Config{
-			GetCertificate: p.GetCertificateFunc(),
-			NextProtos:     []string{"h2"},
-			CipherSuites:   []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+			GetCertificate:           p.GetCertificateFunc(),
+			NextProtos:               []string{"h2"},
+			SessionTicketsDisabled:   true,
+			PreferServerCipherSuites: true,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			},
 		}
 		config.GetConfigForClient = func(helloMsg *tls.ClientHelloInfo) (*tls.Config, error) {
 			if mconn, ok := helloMsg.Conn.(*markedconn.ProxiedConnection); ok {

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 
 	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
 	"go.aporeto.io/trireme-lib/controller/pkg/servicetokens"
@@ -180,7 +179,7 @@ func (p *Processor) Callback(name string, w http.ResponseWriter, r *http.Request
 		Value:    token,
 		HttpOnly: true,
 		Path:     "/",
-		Expires:  time.Now().Add(1 * time.Minute),
+		// Expires:  time.Now().Add(1 * time.Minute),
 	}
 
 	http.SetCookie(w, cookie)


### PR DESCRIPTION
- support for a wider range of safe TLS ciphers
- disable the cookie expiration for now. When the cookie expires, it makes all Ajax calls fail as they are redirected to the OIDC provider. They are now session cookies that expires when the browser closes. In order to be perfect, we need to add an option to set the expiration time, if desired