### PR TITLE
Clean up the certificate claims and certificate related code

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -116,6 +116,7 @@ func (p *Config) clientTLSConfiguration(conn net.Conn, originalConfig *tls.Confi
 			config.ClientCAs = clientCAs
 			return config, nil
 		}
+		return originalConfig, nil
 	}
 	return nil, fmt.Errorf("Invalid connection")
 }

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -98,6 +98,54 @@ func NewHTTPProxy(
 	}
 }
 
+// clientTLSConfiguration calculates the right certificates and requests to the clients.
+func (p *Config) clientTLSConfiguration(conn net.Conn, originalConfig *tls.Config) (*tls.Config, error) {
+	if mconn, ok := conn.(*markedconn.ProxiedConnection); ok {
+		_, port := mconn.GetOriginalDestination()
+		service, ok := p.portCache[port]
+		if !ok {
+			return originalConfig, fmt.Errorf("Unknown service")
+		}
+		if service.UserAuthorizationType == policy.UserAuthorizationMutualTLS {
+			clientCAs := x509.NewCertPool()
+			if len(service.MutualTLSTrustedRoots) > 0 {
+				if !clientCAs.AppendCertsFromPEM(service.MutualTLSTrustedRoots) {
+					return nil, fmt.Errorf("Cannot parse trusted roots")
+				}
+			} else {
+				clientCAs = p.ca
+			}
+			return &tls.Config{
+				GetCertificate:           p.GetCertificateFunc(),
+				ClientAuth:               tls.RequestClientCert,
+				ClientCAs:                clientCAs,
+				NextProtos:               []string{"h2"},
+				SessionTicketsDisabled:   originalConfig.SessionTicketsDisabled,
+				PreferServerCipherSuites: originalConfig.PreferServerCipherSuites,
+				CipherSuites:             originalConfig.CipherSuites,
+			}, nil
+		}
+	}
+	return originalConfig, nil
+}
+
+// newBaseTLSConfig creates the new basic TLS configuration for the server.
+func (p *Config) newBaseTLSConfig() *tls.Config {
+	return &tls.Config{
+		GetCertificate:           p.GetCertificateFunc(),
+		NextProtos:               []string{"h2"},
+		PreferServerCipherSuites: true,
+		SessionTicketsDisabled:   true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		},
+	}
+}
+
 // RunNetworkServer runs an HTTP network server. If TLS is needed, the
 // listener should be already a TLS listener.
 func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted bool) error {
@@ -112,46 +160,9 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 	// If its an encrypted, wrap the listener in a TLS context. This is activated
 	// for the listener from the network, but not for the listener from a PU.
 	if encrypted {
-		config := &tls.Config{
-			GetCertificate:           p.GetCertificateFunc(),
-			NextProtos:               []string{"h2"},
-			SessionTicketsDisabled:   true,
-			PreferServerCipherSuites: true,
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			},
-		}
+		config := p.newBaseTLSConfig()
 		config.GetConfigForClient = func(helloMsg *tls.ClientHelloInfo) (*tls.Config, error) {
-			if mconn, ok := helloMsg.Conn.(*markedconn.ProxiedConnection); ok {
-				_, port := mconn.GetOriginalDestination()
-				service, ok := p.portCache[port]
-				if !ok {
-					return config, nil
-				}
-				if service.UserAuthorizationType == policy.UserAuthorizationMutualTLS &&
-					service.PublicNetworkInfo != nil &&
-					service.PublicNetworkInfo.Ports.Min == uint16(port) {
-					clientCAs := x509.NewCertPool()
-					if len(service.MutualTLSTrustedRoots) > 0 {
-						if !clientCAs.AppendCertsFromPEM(service.MutualTLSTrustedRoots) {
-							return nil, fmt.Errorf("Cannot parse trusted roots")
-						}
-					} else {
-						clientCAs = p.ca
-					}
-					return &tls.Config{
-						GetCertificate: p.GetCertificateFunc(),
-						ClientAuth:     tls.VerifyClientCertIfGiven,
-						NextProtos:     []string{"h2"},
-						ClientCAs:      clientCAs,
-					}, nil
-				}
-			}
-			return config, nil
+			return p.clientTLSConfiguration(helloMsg.Conn, config)
 		}
 		l = tls.NewListener(l, config)
 	}

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -116,15 +116,15 @@ func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certi
 		// This is used in case of client authorization with certificates.
 		attributes := []string{}
 		for _, cert := range certs {
-			attributes = append(attributes, "user="+cert.Subject.CommonName)
+			attributes = append(attributes, "CN="+cert.Subject.CommonName)
 			for _, email := range cert.EmailAddresses {
-				attributes = append(attributes, "email="+email)
+				attributes = append(attributes, "Email="+email)
 			}
 			for _, org := range cert.Subject.Organization {
-				attributes = append(attributes, "organization=", org)
+				attributes = append(attributes, "O="+org)
 			}
 			for _, org := range cert.Subject.OrganizationalUnit {
-				attributes = append(attributes, "ou=", org)
+				attributes = append(attributes, "OU="+org)
 			}
 		}
 		return attributes, false, nil

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -48,7 +48,7 @@ func NewClient(ctx context.Context, v *TokenVerifier) (*TokenVerifier, error) {
 		stateCache = gcache.New(2048).LRU().Expiration(60 * time.Second).Build()
 	}
 	if tokenCache == nil {
-		tokenCache = gcache.New(2048).LRU().Expiration(120 * time.Second).Build()
+		tokenCache = gcache.New(2048).LRU().Expiration(20 * time.Minute).Build()
 	}
 
 	// Create a new generic OIDC provider based on the provider URL.


### PR DESCRIPTION
Cleans up the certificate code and makes it more robust. 

Cleans up the calculation of claims based on user certificates.

Allows user certificates on both the protected port and the public application port.
