### PR TITLE
Check network external traffic on synack

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -93,7 +93,6 @@ func TestEnforcerExternalNetworks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			tcpPacket, _ := packet.New(0, synackPacket, "0", true)
-			fmt.Println(tcpPacket)
 			err1 := enforcer.processApplicationTCPPackets(tcpPacket)
 			So(err1, ShouldBeNil)
 		})


### PR DESCRIPTION
With the recent push, non target networks, external networks configured on the network side will not work as synack packets will be dropped, since we don't see network syn for non target networks as they are accepted in iptables acls. This patch lets through these packets.