### PR TITLE
Disable flow message when only packet is dropped

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -770,7 +770,8 @@ func (d *Datapath) processNetworkAckPacket(context *pucontext.PUContext, conn *c
 	if conn.GetState() == connection.TCPSynAckSend || conn.GetState() == connection.TCPSynReceived {
 
 		if err := tcpPacket.CheckTCPAuthenticationOption(enforcerconstants.TCPAuthenticationOptionBaseLen); err != nil {
-			d.reportRejectedFlow(tcpPacket, conn, collector.DefaultEndPoint, context.ManagementID(), context, collector.InvalidHeader, nil, nil)
+			// TODO: this needs to be converted to a rejected packet messages. It doesn't mean rejected flow. Disabling.
+			// d.reportRejectedFlow(tcpPacket, conn, collector.DefaultEndPoint, context.ManagementID(), context, collector.InvalidHeader, nil, nil)
 			return nil, nil, fmt.Errorf("TCP authentication option not found: %s", err)
 		}
 

--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -3101,8 +3101,6 @@ func TestFlowReportingUptoFirstInvalidAck(t *testing.T) {
 							flowRecord.Destination = &dstEndPoint
 							flowRecord.Action = policy.Reject
 
-							mockCollector.EXPECT().CollectFlowEvent(MyMatcher(&flowRecord)).Times(1)
-
 							puInfo1, puInfo2, enforcer, err1, err2, _, _ = setupProcessingUnitsInDatapathAndEnforce(mockCollector, "container", false)
 							So(puInfo1, ShouldNotBeNil)
 							So(puInfo2, ShouldNotBeNil)
@@ -3123,8 +3121,6 @@ func TestFlowReportingUptoFirstInvalidAck(t *testing.T) {
 							flowRecord.Source = &srcEndPoint
 							flowRecord.Destination = &dstEndPoint
 							flowRecord.Action = policy.Reject
-
-							mockCollector.EXPECT().CollectFlowEvent(MyMatcher(&flowRecord)).Times(1)
 
 							puInfo1, puInfo2, enforcer, err1, err2, _, _ = setupProcessingUnitsInDatapathAndEnforce(mockCollector, "server", false)
 							So(puInfo1, ShouldNotBeNil)


### PR DESCRIPTION
#### Description
We need to report dropped packets (potentially out-of-order) as dropped packets and not rejected flows. We can disable the flow report for the time being.
