### PR TITLE
Fix: Unregister pu from registry on unenforce

### DIFF
--- a/controller/internal/enforcer/applicationproxy/applicationproxy.go
+++ b/controller/internal/enforcer/applicationproxy/applicationproxy.go
@@ -190,6 +190,11 @@ func (p *AppProxy) Unenforce(ctx context.Context, puID string) error {
 	p.Lock()
 	defer p.Unlock()
 
+	// Remove pu from registry
+	if err := p.registry.Unregister(puID); err != nil {
+		return err
+	}
+
 	// Find the correct client.
 	c, err := p.clients.Get(puID)
 	if err != nil {


### PR DESCRIPTION
There was a bug in http proxy when you have two pu with same `publicListeningPort` and you kill the first pu then the second pu will fail because the first pu is not cleaned up properly. This PR makes sure that the pu is unregistered from the registry when it is removed