### PR TITLE
if proto for external is all, then apply explicit udp and tcp rules also

### DIFF
--- a/controller/internal/enforcer/acls/acl.go
+++ b/controller/internal/enforcer/acls/acl.go
@@ -88,7 +88,7 @@ func (a *acl) addRule(rule policy.IPRule) (err error) {
 	}
 
 	for _, proto := range rule.Protocols {
-		if strings.ToLower(proto) == "tcp" {
+		if strings.ToLower(proto) == "tcp" || strings.ToLower(proto) == "all" {
 			for _, address := range rule.Addresses {
 				for _, port := range rule.Ports {
 					if err := ruleAdd(address, port, rule.Policy); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -657,7 +657,7 @@ func (i *Instance) addPacketTrap(appChain string, netChain string, isHostPU bool
 
 }
 
-func (i *Instance) programRule(contextID string, rule *aclIPset, insertOrder *int, chain string, nfLogGroup, proto, ipMatchDirection string) error {
+func (i *Instance) programRule(contextID string, rule *aclIPset, insertOrder *int, chain string, nfLogGroup, proto, ipMatchDirection, order string) error {
 	iptRules := [][]string{}
 	observeContinue := rule.policy.ObserveAction.ObserveContinue()
 
@@ -711,7 +711,15 @@ func (i *Instance) programRule(contextID string, rule *aclIPset, insertOrder *in
 		}
 	}
 
-	return i.processRulesFromList(iptRules, "Insert")
+	if order == "Append" {
+		// remove the insertion order from rules
+		for i, rule := range iptRules {
+			iptRules[i] = append(rule[:2], rule[3:]...)
+		}
+		return i.processRulesFromList(iptRules, order)
+	}
+
+	return i.processRulesFromList(iptRules, order)
 }
 
 type rulePred func(policy *policy.FlowPolicy) bool
@@ -726,7 +734,7 @@ func (i *Instance) addTCPAppACLS(contextID, chain string, rules []aclIPset) erro
 				if strings.ToLower(proto) == tcpProto &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, chain, "10", tcpProto, "dst"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, chain, "10", tcpProto, "dst", "Insert"); err != nil {
 						return err
 					}
 				}
@@ -796,7 +804,7 @@ func (i *Instance) addOtherAppACLs(contextID, appChain string, rules []aclIPset)
 					proto != udpProto &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, appChain, "10", proto, "dst"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, appChain, "10", proto, "dst", "Append"); err != nil {
 						return err
 					}
 				}
@@ -863,7 +871,7 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 				if strings.ToLower(proto) == udpProto &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProto, "dst"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProto, "dst", "Insert"); err != nil {
 						return err
 					}
 
@@ -993,7 +1001,7 @@ func (i *Instance) addTCPNetACLS(contextID, appChain, netChain string, rules []a
 				if strings.ToLower(proto) == tcpProto &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, netChain, "11", tcpProto, "src"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, netChain, "11", tcpProto, "src", "Insert"); err != nil {
 						return err
 					}
 
@@ -1075,7 +1083,7 @@ func (i *Instance) addUDPNetACLS(contextID, appChain, netChain string, rules []a
 				if strings.ToLower(proto) == udpProto &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, netChain, "11", udpProto, "src"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, netChain, "11", udpProto, "src", "Insert"); err != nil {
 						return err
 					}
 
@@ -1157,7 +1165,7 @@ func (i *Instance) addOtherNetACLS(contextID, netChain string, rules []aclIPset)
 					proto != udpProto &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, netChain, "11", proto, "src"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, netChain, "11", proto, "src", "Append"); err != nil {
 						return err
 					}
 				}

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -868,7 +868,7 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == udpProto &&
+				if (strings.ToLower(proto) == udpProto || strings.ToLower(proto) == "all") &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProto, "dst", "Insert"); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -860,7 +860,7 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == udpProto &&
+				if (strings.ToLower(proto) == udpProto || strings.ToLower(proto) == "all") &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProto, "dst"); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls_test.go
+++ b/controller/internal/supervisor/iptablesctrl/acls_test.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	appChain = "appChain"
+	errChain = "errChain"
 	netChain = "netChain"
 	ruleType = "mark"
 )
@@ -925,6 +926,12 @@ func TestAddAppACLs(t *testing.T) {
 					Protocols: []string{"UDP"},
 					Policy:    &policy.FlowPolicy{Action: policy.Accept},
 				},
+
+				policy.IPRule{
+					Addresses: []string{"192.30.253.0/24"},
+					Protocols: []string{"all"},
+					Policy:    &policy.FlowPolicy{Action: policy.Accept},
+				},
 			}
 
 			ipsets.MockNewIpset(t, func(name string, hasht string, p *ipset.Params) (provider.Ipset, error) {
@@ -958,6 +965,10 @@ func TestAddAppACLs(t *testing.T) {
 					}
 				}
 
+				if chain == errChain {
+					return errors.New("chain is incorrect")
+				}
+
 				return errors.New("Chains and table are incorrect")
 			})
 
@@ -968,6 +979,12 @@ func TestAddAppACLs(t *testing.T) {
 			Convey("I should get no error", func() {
 				So(err, ShouldBeNil)
 			})
+
+			err = i.addAppACLs("chain", errChain, errChain, appACLIPset)
+			Convey("I should get an error", func() {
+				So(err, ShouldNotBeNil)
+			})
+
 		})
 
 	})
@@ -1003,6 +1020,12 @@ func TestAddNetACLs(t *testing.T) {
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"443"},
 					Protocols: []string{"UDP"},
+					Policy:    &policy.FlowPolicy{Action: policy.Accept},
+				},
+
+				policy.IPRule{
+					Addresses: []string{"192.30.253.0/24"},
+					Protocols: []string{"all"},
 					Policy:    &policy.FlowPolicy{Action: policy.Accept},
 				},
 			}


### PR DESCRIPTION
If an external network with "all" in protocol field is specified, then apply tcp and udp rules also in acls. 