### PR TITLE
Remove sync dns

### DIFF
--- a/controller/internal/enforcer/acls/acl.go
+++ b/controller/internal/enforcer/acls/acl.go
@@ -88,7 +88,7 @@ func (a *acl) addRule(rule policy.IPRule) (err error) {
 	}
 
 	for _, proto := range rule.Protocols {
-		if strings.ToLower(proto) == "tcp" || strings.ToLower(proto) == "all" {
+		if strings.ToLower(proto) == "tcp" {
 			for _, address := range rule.Addresses {
 				for _, port := range rule.Ports {
 					if err := ruleAdd(address, port, rule.Policy); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -868,7 +868,7 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if (strings.ToLower(proto) == udpProto || strings.ToLower(proto) == "all") &&
+				if (strings.ToLower(proto) == udpProto) &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProto, "dst", "Insert"); err != nil {

--- a/controller/pkg/pucontext/pucontext.go
+++ b/controller/pkg/pucontext/pucontext.go
@@ -184,7 +184,6 @@ func (p *PUContext) dnsToACLs(dnsList *policy.DNSRuleList, ipcache map[string]bo
 func (p *PUContext) startDNS(ctx context.Context, dnsList *policy.DNSRuleList) {
 
 	ipcache := make(map[string]bool)
-	p.dnsToACLs(dnsList, ipcache)
 
 	go func() {
 		curTime := time.Now()


### PR DESCRIPTION
There was a synchronous call to convert dns to acls in pucontext. That can delay the start of the PU. This change removes the synchronous call. 

Also removing "all" protocol which was inserted in the last commit. "all" protocol is being deprecated. 