### PR TITLE
Enable TLS in exposed services

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -255,14 +255,6 @@ func (i *Instance) proxyRules(proxyPort string, proxyPortSetName string, cgroupM
 			"--match-set", destSetName, "src,src",
 			"-j", "ACCEPT",
 		},
-		{ // Needed for Web sockets
-			i.netPacketIPTableContext,
-			proxyInputChain,
-			"-p", tcpProto,
-			"-m", "set",
-			"--match-set", srvSetName, "dst",
-			"-j", "ACCEPT",
-		},
 		{ // APIServices
 			i.netPacketIPTableContext,
 			proxyInputChain,
@@ -291,14 +283,6 @@ func (i *Instance) proxyRules(proxyPort string, proxyPortSetName string, cgroupM
 			"-p", tcpProto,
 			"-m", "set",
 			"--match-set", srvSetName, "src",
-			"-j", "ACCEPT",
-		},
-		{ // Needed for websocket support
-			i.appPacketIPTableContext,
-			proxyOutputChain,
-			"-p", tcpProto,
-			"-m", "set",
-			"--match-set", srvSetName, "dst",
 			"-j", "ACCEPT",
 		},
 		{

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -47,6 +47,10 @@ type ApplicationService struct {
 	// listening to. This is needed in the case of port mappings.
 	PrivateNetworkInfo *common.Service
 
+	// PrivateTLSListener indicates that the service uses a TLS listener. As a
+	// result we must TLS for traffic send locally in the service.
+	PrivateTLSListener bool
+
 	// PublicNetworkInfo provides the network information where the enforcer
 	// should listen for incoming connections of the service. This can be
 	// different than the PrivateNetworkInfo where the application is listening


### PR DESCRIPTION
This PR enables TLS for proxies when the exposed service is listening on a TLS port.