### PR TITLE
Add log messages for OIDC errors

### DIFF
--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"go.aporeto.io/trireme-lib/controller/pkg/urisearch"
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens"
 	"go.aporeto.io/trireme-lib/policy"
+	"go.uber.org/zap"
 )
 
 // Processor holds all the local data of the authorization engine. A processor
@@ -87,6 +88,7 @@ func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certi
 	case policy.UserAuthorizationOIDC, policy.UserAuthorizationJWT:
 		// Now we can parse the user claims.
 		if p.userTokenHandler == nil {
+			zap.L().Error("Internal Server Error: OIDC User Token Handler not configured")
 			return []string{}, false, userToken, nil
 		}
 		return p.userTokenHandler.Validate(r.Context(), userToken)

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -15,6 +15,7 @@ import (
 	oidc "github.com/coreos/go-oidc"
 	"github.com/rs/xid"
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
+	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 )
 
@@ -67,6 +68,7 @@ func NewClient(ctx context.Context, v *TokenVerifier) (*TokenVerifier, error) {
 	// If it is not a compliant provider we should report and error here.
 	provider, err := oidc.NewProvider(ctx, v.ProviderURL)
 	if err != nil {
+		zap.L().Error("Failed to initialize OIDC provider", zap.Error(err), zap.String("Provider URL", v.ProviderURL))
 		return nil, fmt.Errorf("Failed to initialize provider: %s", err)
 	}
 	oidConfig := &oidc.Config{


### PR DESCRIPTION
#### Description
Add log messages for OIDC initialization errors. Mainly covering the case where the OIDC ID provider is not reachable for some reason.
