### PR TITLE
Health API

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -617,7 +617,10 @@ func (p *Config) isSecretsRequest(w http.ResponseWriter, r *http.Request, sctx *
 			zap.L().Error("Unable to write response")
 		}
 	case "/health":
-		data, err := json.Marshal(sctx.PU.Policy.ToPublicPolicy())
+		plc := sctx.PU.Policy.ToPublicPolicy()
+		plc.ServicesCertificate = ""
+		plc.ServicesPrivateKey = ""
+		data, err := json.Marshal(plc)
 		if err != nil {
 			data = []byte("Internal Server Error")
 		}


### PR DESCRIPTION
Introduce a /health API where enforcers will respond with their current policy configuration for a given PU. This allows initialization of applications and especially init containers, where an application is not started until the enforcer health is detected.
