### PR TITLE
Renew service certificates at half their lifetime interval

### DIFF
--- a/collector/default.go
+++ b/collector/default.go
@@ -33,10 +33,11 @@ func StatsFlowHash(r *FlowRecord) string {
 	hash.Write([]byte(r.Destination.ID)) // nolint errcheck
 	port := make([]byte, 2)
 	binary.BigEndian.PutUint16(port, r.Destination.Port)
-	hash.Write(port)                      // nolint errcheck
-	hash.Write([]byte(r.Action.String())) // nolint errcheck
-	hash.Write([]byte(r.DropReason))      // nolint errcheck
-	hash.Write([]byte(r.Destination.URI)) // nolint errcheck
+	hash.Write(port)                              // nolint errcheck
+	hash.Write([]byte(r.Action.String()))         // nolint errcheck
+	hash.Write([]byte(r.ObservedAction.String())) // nolint errcheck
+	hash.Write([]byte(r.DropReason))              // nolint errcheck
+	hash.Write([]byte(r.Destination.URI))         // nolint errcheck
 
 	return fmt.Sprintf("%d", hash.Sum64())
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -402,7 +402,12 @@ func (p *PUPolicy) UpdateServiceCertificates(cert, key string) {
 		zap.L().Error("Invalid certificate", zap.Error(err))
 		return
 	}
-	p.serviceCertificateExpiration = time.Now().Add(certificate.NotAfter.Sub(time.Now()) / 2)
+
+	if time.Now().After(certificate.NotAfter) {
+		p.serviceCertificateExpiration = time.Now()
+	} else {
+		p.serviceCertificateExpiration = time.Now().Add(time.Until(certificate.NotAfter) / 2)
+	}
 
 }
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -402,7 +402,7 @@ func (p *PUPolicy) UpdateServiceCertificates(cert, key string) {
 		zap.L().Error("Invalid certificate", zap.Error(err))
 		return
 	}
-	p.serviceCertificateExpiration = certificate.NotAfter
+	p.serviceCertificateExpiration = time.Now().Add(certificate.NotAfter.Sub(time.Now()) / 2)
 
 }
 


### PR DESCRIPTION
#### Description
Fixes the renewal of service certificates. They will be renewed when 50% if their lifetime passes. This avoids any outages if the control plane is out of reach for a while.
