### PR TITLE
Support for multiple JWT signing certs and public keys

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -659,11 +659,14 @@ func userCredentials(serviceID string, r *http.Request, authorizer *auth.Process
 	}
 
 	userAttributes, redirect, refreshedToken, err := authorizer.DecodeUserClaims(serviceID, userToken, userCerts, r)
-	if err == nil && len(userAttributes) > 0 {
+	if len(userAttributes) > 0 {
 		userRecord := &collector.UserRecord{Claims: userAttributes}
 		c.CollectUserEvent(userRecord)
 		state.stats.Source.UserID = userRecord.ID
 		state.stats.Source.Type = collector.EndpointTypeClaims
+	}
+	if err != nil && len(userAttributes) > 0 {
+		zap.L().Warn("Partially failed to extract and decode user claims", zap.Error(err))
 	} else if err != nil {
 		zap.L().Error("Failed to decode user claims", zap.Error(err))
 	}

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -90,10 +90,11 @@ func (p *Processor) DecodeUserClaims(name, userToken string, certs []*x509.Certi
 			if err != nil {
 				return attributes, false, userToken, fmt.Errorf("Unable to decode JWT: %s", err)
 			}
-			return append(attributes, jwtAttributes...), false, userToken, nil
+			attributes = append(attributes, jwtAttributes...)
 		}
 
 		return attributes, false, userToken, nil
+
 	case policy.UserAuthorizationOIDC:
 		// Now we can parse the user claims.
 		if p.userTokenHandler == nil {

--- a/controller/pkg/usertokens/pkitokens/jwt.go
+++ b/controller/pkg/usertokens/pkitokens/jwt.go
@@ -2,15 +2,12 @@ package pkitokens
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/rsa"
-	"crypto/x509"
+	"crypto"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"go.aporeto.io/tg/tglib"
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
 )
 
@@ -20,7 +17,7 @@ import (
 // for validating the tokens. The public key is provided out-of-band.
 type PKIJWTVerifier struct {
 	JWTCertPEM  []byte
-	jwtCert     *x509.Certificate
+	keys        []crypto.PublicKey
 	RedirectURL string
 }
 
@@ -28,20 +25,22 @@ type PKIJWTVerifier struct {
 func NewVerifierFromFile(jwtcertPath string, redirectURI string, redirectOnFail, redirectOnNoToken bool) (*PKIJWTVerifier, error) {
 	jwtCertPEM, err := ioutil.ReadFile(jwtcertPath)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read jwt signing certificate from file: %s", err)
+		return nil, fmt.Errorf("failed to read JWT signing certificates or public keys from file: %s", err)
 	}
 	return NewVerifierFromPEM(jwtCertPEM, redirectURI, redirectOnFail, redirectOnNoToken)
 }
 
 // NewVerifierFromPEM assumes that the input is a PEM byte array.
 func NewVerifierFromPEM(jwtCertPEM []byte, redirectURI string, redirectOnFail, redirectOnNoToken bool) (*PKIJWTVerifier, error) {
-	jwtCertificate, err := tglib.ParseCertificate(jwtCertPEM)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read jwt signing certificate from PEM: %s", err)
+	keys, err := parsePublicKeysFromPEM(jwtCertPEM)
+	// pay attention to the return format of parsePublicKeysFromPEM
+	// when checking for an error here
+	if keys == nil && err != nil {
+		return nil, fmt.Errorf("failed to read JWT signing certificates or public keys from PEM: %s", err)
 	}
 	return &PKIJWTVerifier{
 		JWTCertPEM:  jwtCertPEM,
-		jwtCert:     jwtCertificate,
+		keys:        keys,
 		RedirectURL: redirectURI,
 	}, nil
 }
@@ -51,48 +50,78 @@ func NewVerifier(v *PKIJWTVerifier) (*PKIJWTVerifier, error) {
 	if len(v.JWTCertPEM) == 0 {
 		return v, nil
 	}
-	jwtCertificate, err := tglib.ParseCertificate(v.JWTCertPEM)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to parse certificate: %s", err)
+	keys, err := parsePublicKeysFromPEM(v.JWTCertPEM)
+	// pay attention to the return format of parsePublicKeysFromPEM
+	// when checking for an error here
+	if keys == nil && err != nil {
+		return nil, fmt.Errorf("failed to parse JWT signing certificates or public keys from PEM: %s", err)
 	}
-	v.jwtCert = jwtCertificate
+	v.keys = keys
 	return v, nil
 }
 
 // Validate parses a generic JWT token and flattens the claims in a normalized form. It
-// assumes that the JWT signing certificate will validate the token.
+// assumes that any of the JWT signing certs or public keys will validate the token.
 func (j *PKIJWTVerifier) Validate(ctx context.Context, tokenString string) ([]string, bool, string, error) {
 	if len(tokenString) == 0 {
 		return []string{}, false, tokenString, fmt.Errorf("Empty token")
 	}
-	claims := &jwt.MapClaims{}
-	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
-		if j.jwtCert == nil {
-			return nil, fmt.Errorf("Nil certificate - ignore")
-		}
-		switch token.Method {
-		case token.Method.(*jwt.SigningMethodECDSA):
-			if rcert, ok := j.jwtCert.PublicKey.(*ecdsa.PublicKey); ok {
-				return rcert, nil
-			}
-		case token.Method.(*jwt.SigningMethodRSA):
-			if rcert, ok := j.jwtCert.PublicKey.(*rsa.PublicKey); ok {
-				return rcert, nil
-			}
-		default:
-			return nil, fmt.Errorf("Unknown signing method")
-		}
-		return nil, fmt.Errorf("Signing method does not match certificate")
-	})
-	if err != nil || token == nil || !token.Valid {
-		return []string{}, false, tokenString, fmt.Errorf("Invalid token")
+	if len(j.keys) == 0 {
+		return []string{}, false, tokenString, fmt.Errorf("No public keys loaded into verifier")
 	}
 
-	attributes := []string{}
-	for k, v := range *claims {
-		attributes = append(attributes, common.FlattenClaim(k, v)...)
+	// iterate over all public keys that we have and try to validate the token
+	// the first one to succeed will be used
+	var errs []error
+	for _, key := range j.keys {
+		claims := &jwt.MapClaims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			switch token.Method.(type) {
+			case *jwt.SigningMethodECDSA:
+				if isECDSAPublicKey(key) {
+					return key, nil
+				}
+			case *jwt.SigningMethodRSA:
+				if isRSAPublicKey(key) {
+					return key, nil
+				}
+			default:
+				return nil, fmt.Errorf("unsupported signing method '%T'", token.Method)
+			}
+			return nil, fmt.Errorf("signing method '%T' and public key type '%T' mismatch", token.Method, key)
+		})
+
+		// cover all error cases after parsing/verifying
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if token == nil {
+			errs = append(errs, fmt.Errorf("no token was parsed"))
+			continue
+		}
+		if !token.Valid {
+			errs = append(errs, fmt.Errorf("token failed to verify against public key"))
+			continue
+		}
+
+		// return successful on match/verification with the first key
+		attributes := []string{}
+		for k, v := range *claims {
+			attributes = append(attributes, common.FlattenClaim(k, v)...)
+		}
+		return attributes, false, tokenString, nil
 	}
-	return attributes, false, tokenString, nil
+
+	// generate a detailed error
+	var detailedError string
+	for i, err := range errs {
+		detailedError += err.Error()
+		if i+1 < len(errs) {
+			detailedError += "; "
+		}
+	}
+	return []string{}, false, tokenString, fmt.Errorf("Invalid token - errors: [%s]", detailedError)
 }
 
 // VerifierType returns the type of the verifier.

--- a/controller/pkg/usertokens/pkitokens/jwt_test.go
+++ b/controller/pkg/usertokens/pkitokens/jwt_test.go
@@ -1,0 +1,169 @@
+package pkitokens
+
+import (
+	"context"
+	"crypto"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPKIVerifierValidate(t *testing.T) {
+
+	ctx := context.TODO()
+	pemBytes := []byte(`
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyjDEPJD1Fv1IJIq4mnec
+oMlSve0vZOTuzDmKuMB4vfBXalKZgbp4ONL+BvWV9OPs22Smv9SAfnoQ25q8Q9so
+ihzUKhaIAY2CI70ll4exbLK9FD4uTi1bqn0FdIh04UIyW6s2EqTGMkSKx9THNvAM
+Kx++pPt3US2sQVEC24bWPxRN7RsBBpRjoiEamkA04ioGFhMBbas5MdCLt/fd92aR
+QCBISOb6PU08fQiARK8g/wdpBUTxy9/Ud1vUnNaZtWm+eLrwdTXgHM3/LG1M4lc0
+ZqHIL3rMxhae5W+j3SL3ApreiUYugv/0bCSypvJZjEXKS7SBR/+rtw0/mQpS8DpI
+kwIDAQAB
+-----END PUBLIC KEY-----
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnlK01BDTYbvRBxGM0o3vXNqqvI25
+eZ/s3Cq9OXnNpoCI3/DH/tuD3n7cnWcNSfl1qJIH2LVZ0cWUW/L/9i/jPA==
+-----END PUBLIC KEY-----
+	`)
+
+	// Here are the private keys in case you want to regenerate a new token:
+	//
+	// -----BEGIN RSA PRIVATE KEY-----
+	// MIIEpAIBAAKCAQEAyjDEPJD1Fv1IJIq4mnecoMlSve0vZOTuzDmKuMB4vfBXalKZ
+	// gbp4ONL+BvWV9OPs22Smv9SAfnoQ25q8Q9soihzUKhaIAY2CI70ll4exbLK9FD4u
+	// Ti1bqn0FdIh04UIyW6s2EqTGMkSKx9THNvAMKx++pPt3US2sQVEC24bWPxRN7RsB
+	// BpRjoiEamkA04ioGFhMBbas5MdCLt/fd92aRQCBISOb6PU08fQiARK8g/wdpBUTx
+	// y9/Ud1vUnNaZtWm+eLrwdTXgHM3/LG1M4lc0ZqHIL3rMxhae5W+j3SL3ApreiUYu
+	// gv/0bCSypvJZjEXKS7SBR/+rtw0/mQpS8DpIkwIDAQABAoIBAQCWkraxfCpp0nn1
+	// bLGJp2Ynf4Z1Frvi4XLM+FVMvVmt6dzPu2/CYsHBX6/6Ms5YL51mzZA47+I5TmJb
+	// iOKHjiCkqk9+gIUM0vuF7giezljdYEbbWmtVoQXQ84YqgKy6THgAOILuY3OOX+kS
+	// ZG1vhlkpjFyHtRXoiKDti40bO1E2a2+O/vpD417hZrezzb97JQ4Cw417jRs3+dpc
+	// BaVutFUiIm5HFeVdD0/hqwnYMPeoxxxdj4kiuzI2FZOexPufq9MSrSI0RMnegRGL
+	// 8fgg4ZhVuEONtA8eXFI8EpIEhaKOq9CPZuImyKh+Vx4pwcT7NVld70ohqhQaEVqs
+	// 6QblHf6hAoGBAOqimWdjGY6PKT6ipF9/6CsNnAAyyG1IRWSLweVDK36DkIxzTKGU
+	// fk2uXFw6GlAKu1J0lTfQjxtKoYVljUHjUvfvW9KE/GyuW6eWTxUIrvmpvpcyAV6H
+	// gHkt8/A+l8sQS3oMiLJ14c8/W5d4YdB/VBLQHsOi8I5EOGsO7a52fETLAoGBANyZ
+	// 3+nq/tyk6hGk+lNJSXnkURydbkONCFhU92iwPC+f/4ILcHdBVjwLOAYa/qUzHvEE
+	// H+MtMiuGbDrnjjCytvjmIKmMnJ30BHbXwn0dV+hes1O0EwHoIGtvQyWVH/6zB4ar
+	// YkhK9IBtOxfs3ORVeVBoHx/Mq40BAGzGxQQopVpZAoGAScFtCWPMb9SuuWK02tRB
+	// Le9sP1+3Qyr5rT6FZ8TykiVXNd80koI0JcUOgWs+RDTrZ2MAWPg1U/XkyiL/AVwt
+	// A4T5TzbAhoVUiFymZU1Ce3aRU8PDTGy5xN3eFYIHgyyPHUF9YuPNZLFc4ENWNA0i
+	// Z3uGgCbjCUWGmpipvDLAo3sCgYApQEDlvgLAgbofaIlCz76Eo5QjVLEMwq+fzOui
+	// 0OnAQhwGVltGgZo9ih+EzMF3ZNLRYOMRmR77kpxke25UXubmLipHajrTMpEvI/OD
+	// b9xDYIoKCe9P+Pcu/9Q/j942w4WRwjSTriiAZ2yYcbtwmycfSQkg6iXeLSTGMnke
+	// 6PbaqQKBgQDGNwOgdHtMdHyy2kDMLdGKCysEo2eBNAxdRqjGxmsjm6bsd4xyLxS2
+	// lkf7v3e9vE24HfBbwMoW4sx1eEDbFc4pai4l4vG3dpbrd3CJa5mpvL3mxGnTlPUy
+	// 1PopL5pyjSZ6bcRETolZNM4L8X4jgfwHl3Lvc5jBgQW0PCAVtBVp8g==
+	// -----END RSA PRIVATE KEY-----
+	//
+	// -----BEGIN EC PRIVATE KEY-----
+	// MHcCAQEEIBP/5KHpYJ1GwqdOUOCu4+264KP4loONT+9QIzNJwVGjoAoGCCqGSM49
+	// AwEHoUQDQgAEnlK01BDTYbvRBxGM0o3vXNqqvI25eZ/s3Cq9OXnNpoCI3/DH/tuD
+	// 3n7cnWcNSfl1qJIH2LVZ0cWUW/L/9i/jPA==
+	// -----END EC PRIVATE KEY-----
+	//
+	// And here is the payload data:
+	//
+	// {
+	// 	"sub": "Adam",
+	// 	"name": "Eve",
+	// 	"admin": true,
+	// 	"iat": 1516239022
+	// }
+	//
+	// Go to https://jwt.io/ and
+	// - select the right algorithm (RS256 / ES256)
+	// - fill in the public key
+	// - fill in the private key
+	// - ensure the token is still valid (shows Signature Verified)
+	// - copy the new token from the encoded section
+	//
+	validTokenRS256 := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBZGFtIiwibmFtZSI6IkV2ZSIsImFkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjJ9.WHDAmZzmX50GRSXTvB0MqQl2gFHFrQav-v6V2MdbqGXvmBZXus9Bl965Uuqs8uxdJzDad8Is05kC77iHElTasgQZqLwSTN5-WXpZFsW_EOGVcy0puDgREm2QcD8pQeagy6KxwDs0BAQIWwPSfjTCn05w-CRKveo1t0TsKUSMiZltebaZOtAr9etOAwBHIy7QzexrhIzlG6-7fqMbpsNZ8DbanUBc2fiL6Ogs461TQixBDHoRw2HjykGoPRvH3sy8bSRX5l1olBkRb4kic7xSKhiU_YlvmBo9ybC81TRGUtQZl87aLcnv4foDLtFvNAwTyTxfikt2Ka1peKJNgk82Dw"
+	validTokenES256 := "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBZGFtIiwibmFtZSI6IkV2ZSIsImFkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjJ9.V9HGK6yEZBbjgEsyhQeU6i0Io1KZaCMVgSC0u6fQTRd2TX4Ac-FSDnf44s89PPm8RCHqBATJdJMspIQM66y9Hw"
+
+	// currently unsupported algorithm PS256
+	unsupportedTokenPS256 := "eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.P9_X1ctIxnnoUpKSWpYw3rF62e-d8LXe3sETuLn4Lhigw5OQhi-mBBKoBMneHy4kimS84zxnMby0FYo9wKM3I3pEg8Qrz0Q00tNhKCwOnZ7Q-e86sW1luK1z82tufF-sZ9_BY_LGQsym0lQmQaHFzLmEDXnOzWsjUThHGVJTI64"
+
+	// supported algorithm but signed with a different key
+	invalidTokenRS256 := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
+
+	Convey("Given a valid PEM", t, func() {
+
+		Convey("it should create a new verifier successfully using NewVerifier()", func() {
+			verifier, err := NewVerifier(&PKIJWTVerifier{
+				JWTCertPEM: pemBytes,
+			})
+			So(err, ShouldBeNil)
+			So(verifier, ShouldNotBeNil)
+			So(len(verifier.keys), ShouldEqual, 2)
+		})
+
+		Convey("it should create a new verifier successfully using NewVerifierFromPEM()", func() {
+			verifier, err := NewVerifierFromPEM(pemBytes, "", false, false)
+			So(err, ShouldBeNil)
+			So(verifier, ShouldNotBeNil)
+			So(len(verifier.keys), ShouldEqual, 2)
+		})
+	})
+
+	Convey("Given a verifier with no loaded public keys", t, func() {
+		verifier := &PKIJWTVerifier{
+			JWTCertPEM: pemBytes,
+			keys:       []crypto.PublicKey{},
+		}
+
+		Convey("it should fail to validate", func() {
+			token := "not empty token"
+			_, _, _, err := verifier.Validate(ctx, token)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "No public keys loaded into verifier")
+		})
+	})
+
+	Convey("Given a valid verifier", t, func() {
+		verifier, err := NewVerifierFromPEM(pemBytes, "", false, false)
+		So(verifier, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(len(verifier.keys), ShouldEqual, 2)
+
+		Convey("it should fail to validate an empty token", func() {
+			token := ""
+			_, _, _, err := verifier.Validate(ctx, token)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "Empty token")
+		})
+
+		Convey("it should validate a valid RS256 token successfully", func() {
+			token := validTokenRS256
+			attributes, _, _, err := verifier.Validate(ctx, token)
+			So(err, ShouldBeNil)
+			So(len(attributes), ShouldBeGreaterThan, 0)
+			So(attributes, ShouldContain, "sub=Adam")
+			So(attributes, ShouldContain, "name=Eve")
+		})
+
+		Convey("it should validate a valid ES256 token successfully", func() {
+			token := validTokenES256
+			attributes, _, _, err := verifier.Validate(ctx, token)
+			So(err, ShouldBeNil)
+			So(len(attributes), ShouldBeGreaterThan, 0)
+			So(attributes, ShouldContain, "sub=Adam")
+			So(attributes, ShouldContain, "name=Eve")
+		})
+
+		Convey("it should fail to validate a token signed with an unsupported algorithm", func() {
+			token := unsupportedTokenPS256
+			_, _, _, err := verifier.Validate(ctx, token)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "Invalid token - errors: [unsupported signing method '*jwt.SigningMethodRSAPSS'; unsupported signing method '*jwt.SigningMethodRSAPSS']")
+		})
+
+		Convey("it should fail to validate a token signed with an unexpected key", func() {
+			token := invalidTokenRS256
+			_, _, _, err := verifier.Validate(ctx, token)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "Invalid token - errors: [crypto/rsa: verification error; signing method '*jwt.SigningMethodRSA' and public key type '*ecdsa.PublicKey' mismatch]")
+		})
+	})
+}

--- a/controller/pkg/usertokens/pkitokens/publickeys.go
+++ b/controller/pkg/usertokens/pkitokens/publickeys.go
@@ -1,0 +1,109 @@
+package pkitokens
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// parsePublicKeysFromPEM reads all public keys from PEMs that are either
+// in a "PUBLIC KEY", "RSA PUBLIC KEY" or "CERTIFICATE" type PEM and
+// returns them in an array. Only RSA and ECDSA keys are taken into account.
+// NOTE: pay attention to the special return logic!
+//
+// The return logic is as follows:
+// if no keys could be found or parsed: nil, err
+// if no errors were found at all: keys, nil
+// if some keys could be parsed, but others failed: keys, err
+//
+func parsePublicKeysFromPEM(bytesPEM []byte) ([]crypto.PublicKey, error) {
+	keys := make([]crypto.PublicKey, 0, 1)
+	rest := bytesPEM
+	var errs []error
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		switch block.Type {
+		case "CERTIFICATE":
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if !isSupportedPublicKeyType(cert.PublicKey) {
+				errs = append(errs, fmt.Errorf("unsupported key type %T", cert.PublicKey))
+				continue
+			}
+			keys = append(keys, cert.PublicKey)
+		case "PUBLIC KEY":
+			pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if !isSupportedPublicKeyType(pub) {
+				errs = append(errs, fmt.Errorf("unsupported key type %T", pub))
+				continue
+			}
+			keys = append(keys, pub)
+		case "RSA PUBLIC KEY":
+			pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if !isSupportedPublicKeyType(pub) {
+				errs = append(errs, fmt.Errorf("unsupported key type %T", pub))
+				continue
+			}
+			keys = append(keys, pub)
+		default:
+			// invalid type, read the next entry
+			errs = append(errs, fmt.Errorf("unsupported PEM type %s", block.Type))
+			continue
+		}
+	}
+
+	// create detailed error
+	var detailedErrors string
+	for i, err := range errs {
+		detailedErrors += err.Error()
+		if i+1 < len(errs) {
+			detailedErrors += "; "
+		}
+	}
+
+	// if no keys at all were found, be specific about this
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("no valid certificates or public keys found (errors: [%s])", detailedErrors)
+	}
+
+	// if some errors were encountered, but we have some keys, return both
+	if len(keys) > 0 && len(errs) > 0 {
+		return keys, fmt.Errorf("[%s]", detailedErrors)
+	}
+
+	// if all went well, return keys, but no error
+	return keys, nil
+}
+
+// isSupportedPublicKeyType returns true if `key` is an RSA or ECDSA public key
+func isSupportedPublicKeyType(key crypto.PublicKey) bool {
+	return isRSAPublicKey(key) || isECDSAPublicKey(key)
+}
+
+func isRSAPublicKey(key crypto.PublicKey) bool {
+	_, ok := key.(*rsa.PublicKey)
+	return ok
+}
+
+func isECDSAPublicKey(key crypto.PublicKey) bool {
+	_, ok := key.(*ecdsa.PublicKey)
+	return ok
+}

--- a/controller/pkg/usertokens/pkitokens/publickeys_test.go
+++ b/controller/pkg/usertokens/pkitokens/publickeys_test.go
@@ -1,0 +1,157 @@
+package pkitokens
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestParsePublicKeysFromPEM(t *testing.T) {
+
+	Convey("Given a PEM with a PKIX RSA public key, a PKCS#1 RSA public key and an X509 certificate", t, func() {
+		pemBytes := []byte(`
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyjDEPJD1Fv1IJIq4mnec
+oMlSve0vZOTuzDmKuMB4vfBXalKZgbp4ONL+BvWV9OPs22Smv9SAfnoQ25q8Q9so
+ihzUKhaIAY2CI70ll4exbLK9FD4uTi1bqn0FdIh04UIyW6s2EqTGMkSKx9THNvAM
+Kx++pPt3US2sQVEC24bWPxRN7RsBBpRjoiEamkA04ioGFhMBbas5MdCLt/fd92aR
+QCBISOb6PU08fQiARK8g/wdpBUTxy9/Ud1vUnNaZtWm+eLrwdTXgHM3/LG1M4lc0
+ZqHIL3rMxhae5W+j3SL3ApreiUYugv/0bCSypvJZjEXKS7SBR/+rtw0/mQpS8DpI
+kwIDAQAB
+-----END PUBLIC KEY-----
+-----BEGIN RSA PUBLIC KEY-----
+MIIBCgKCAQEAyjDEPJD1Fv1IJIq4mnecoMlSve0vZOTuzDmKuMB4vfBXalKZgbp4
+ONL+BvWV9OPs22Smv9SAfnoQ25q8Q9soihzUKhaIAY2CI70ll4exbLK9FD4uTi1b
+qn0FdIh04UIyW6s2EqTGMkSKx9THNvAMKx++pPt3US2sQVEC24bWPxRN7RsBBpRj
+oiEamkA04ioGFhMBbas5MdCLt/fd92aRQCBISOb6PU08fQiARK8g/wdpBUTxy9/U
+d1vUnNaZtWm+eLrwdTXgHM3/LG1M4lc0ZqHIL3rMxhae5W+j3SL3ApreiUYugv/0
+bCSypvJZjEXKS7SBR/+rtw0/mQpS8DpIkwIDAQAB
+-----END RSA PUBLIC KEY-----
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUTBdVdOoTt+z1c+25X1WdKLEqc/IwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0xOTAxMzEwNTE4MDVaFw0yOTAx
+MjgwNTE4MDVaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDKMMQ8kPUW/Ugkiriad5ygyVK97S9k5O7MOYq4wHi9
+8FdqUpmBung40v4G9ZX04+zbZKa/1IB+ehDbmrxD2yiKHNQqFogBjYIjvSWXh7Fs
+sr0UPi5OLVuqfQV0iHThQjJbqzYSpMYyRIrH1Mc28AwrH76k+3dRLaxBUQLbhtY/
+FE3tGwEGlGOiIRqaQDTiKgYWEwFtqzkx0Iu39933ZpFAIEhI5vo9TTx9CIBEryD/
+B2kFRPHL39R3W9Sc1pm1ab54uvB1NeAczf8sbUziVzRmocgveszGFp7lb6PdIvcC
+mt6JRi6C//RsJLKm8lmMRcpLtIFH/6u3DT+ZClLwOkiTAgMBAAGjUzBRMB0GA1Ud
+DgQWBBRzt5Gi91WRLBU1PRlo/wCC44DNnzAfBgNVHSMEGDAWgBRzt5Gi91WRLBU1
+PRlo/wCC44DNnzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAv
++NayVYU//8QX2TIQ5CcH/3iOCOa9Qx4KHYtyv+/ElBm2WaWRbJiy470D/I2tjkO0
+J4a0kihMKEkwAVUvskbM+PjTcrgaE205YO/Pyn00s0Xt3yBp2Cf6rmcNtda4hqCs
+ZNhCEXxAXbLxGb5oXd+Wis/tzpBNYrw9x9r3Axr9U2pW+sSzXsUqRdBvaHpywIRq
+6FnpawXPJMIOaMohmWAPYnmqILUs0CslzmXQypayslAFC2adr1NQPwZw0FJ3UIQM
+AyfixuFuZbOVlwm/zJqX0G0NbitPybGV5XneC89OF90H0zfv47Us0akzyY6yGLp/
++3ASkOBz0ypQ6pgZK/kj
+-----END CERTIFICATE-----
+		`)
+
+		Convey("then parsePublicKeysFromPEM should return 3 public keys", func() {
+			keys, err := parsePublicKeysFromPEM(pemBytes)
+			So(err, ShouldBeNil)
+			So(len(keys), ShouldEqual, 3)
+		})
+	})
+
+	Convey("Given a PEM with an RSA private key and a DSA public key", t, func() {
+		pemBytes := []byte(`
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAyjDEPJD1Fv1IJIq4mnecoMlSve0vZOTuzDmKuMB4vfBXalKZ
+gbp4ONL+BvWV9OPs22Smv9SAfnoQ25q8Q9soihzUKhaIAY2CI70ll4exbLK9FD4u
+Ti1bqn0FdIh04UIyW6s2EqTGMkSKx9THNvAMKx++pPt3US2sQVEC24bWPxRN7RsB
+BpRjoiEamkA04ioGFhMBbas5MdCLt/fd92aRQCBISOb6PU08fQiARK8g/wdpBUTx
+y9/Ud1vUnNaZtWm+eLrwdTXgHM3/LG1M4lc0ZqHIL3rMxhae5W+j3SL3ApreiUYu
+gv/0bCSypvJZjEXKS7SBR/+rtw0/mQpS8DpIkwIDAQABAoIBAQCWkraxfCpp0nn1
+bLGJp2Ynf4Z1Frvi4XLM+FVMvVmt6dzPu2/CYsHBX6/6Ms5YL51mzZA47+I5TmJb
+iOKHjiCkqk9+gIUM0vuF7giezljdYEbbWmtVoQXQ84YqgKy6THgAOILuY3OOX+kS
+ZG1vhlkpjFyHtRXoiKDti40bO1E2a2+O/vpD417hZrezzb97JQ4Cw417jRs3+dpc
+BaVutFUiIm5HFeVdD0/hqwnYMPeoxxxdj4kiuzI2FZOexPufq9MSrSI0RMnegRGL
+8fgg4ZhVuEONtA8eXFI8EpIEhaKOq9CPZuImyKh+Vx4pwcT7NVld70ohqhQaEVqs
+6QblHf6hAoGBAOqimWdjGY6PKT6ipF9/6CsNnAAyyG1IRWSLweVDK36DkIxzTKGU
+fk2uXFw6GlAKu1J0lTfQjxtKoYVljUHjUvfvW9KE/GyuW6eWTxUIrvmpvpcyAV6H
+gHkt8/A+l8sQS3oMiLJ14c8/W5d4YdB/VBLQHsOi8I5EOGsO7a52fETLAoGBANyZ
+3+nq/tyk6hGk+lNJSXnkURydbkONCFhU92iwPC+f/4ILcHdBVjwLOAYa/qUzHvEE
+H+MtMiuGbDrnjjCytvjmIKmMnJ30BHbXwn0dV+hes1O0EwHoIGtvQyWVH/6zB4ar
+YkhK9IBtOxfs3ORVeVBoHx/Mq40BAGzGxQQopVpZAoGAScFtCWPMb9SuuWK02tRB
+Le9sP1+3Qyr5rT6FZ8TykiVXNd80koI0JcUOgWs+RDTrZ2MAWPg1U/XkyiL/AVwt
+A4T5TzbAhoVUiFymZU1Ce3aRU8PDTGy5xN3eFYIHgyyPHUF9YuPNZLFc4ENWNA0i
+Z3uGgCbjCUWGmpipvDLAo3sCgYApQEDlvgLAgbofaIlCz76Eo5QjVLEMwq+fzOui
+0OnAQhwGVltGgZo9ih+EzMF3ZNLRYOMRmR77kpxke25UXubmLipHajrTMpEvI/OD
+b9xDYIoKCe9P+Pcu/9Q/j942w4WRwjSTriiAZ2yYcbtwmycfSQkg6iXeLSTGMnke
+6PbaqQKBgQDGNwOgdHtMdHyy2kDMLdGKCysEo2eBNAxdRqjGxmsjm6bsd4xyLxS2
+lkf7v3e9vE24HfBbwMoW4sx1eEDbFc4pai4l4vG3dpbrd3CJa5mpvL3mxGnTlPUy
+1PopL5pyjSZ6bcRETolZNM4L8X4jgfwHl3Lvc5jBgQW0PCAVtBVp8g==
+-----END RSA PRIVATE KEY-----
+		`)
+
+		Convey("then parsePublicKeysFromPEM should return with an error", func() {
+			keys, err := parsePublicKeysFromPEM(pemBytes)
+			So(keys, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "no valid certificates or public keys found (errors: [unsupported PEM type RSA PRIVATE KEY])")
+		})
+	})
+
+	Convey("Given a PEM with a valid ECDSA and RSA public key, and a DSA public key and an invalid PKCS#1 RSA public key", t, func() {
+		pemBytes := []byte(`
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnlK01BDTYbvRBxGM0o3vXNqqvI25
+eZ/s3Cq9OXnNpoCI3/DH/tuD3n7cnWcNSfl1qJIH2LVZ0cWUW/L/9i/jPA==
+-----END PUBLIC KEY-----
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyjDEPJD1Fv1IJIq4mnec
+oMlSve0vZOTuzDmKuMB4vfBXalKZgbp4ONL+BvWV9OPs22Smv9SAfnoQ25q8Q9so
+ihzUKhaIAY2CI70ll4exbLK9FD4uTi1bqn0FdIh04UIyW6s2EqTGMkSKx9THNvAM
+Kx++pPt3US2sQVEC24bWPxRN7RsBBpRjoiEamkA04ioGFhMBbas5MdCLt/fd92aR
+QCBISOb6PU08fQiARK8g/wdpBUTxy9/Ud1vUnNaZtWm+eLrwdTXgHM3/LG1M4lc0
+ZqHIL3rMxhae5W+j3SL3ApreiUYugv/0bCSypvJZjEXKS7SBR/+rtw0/mQpS8DpI
+kwIDAQAB
+-----END PUBLIC KEY-----
+-----BEGIN PUBLIC KEY-----
+MIIDSDCCAjoGByqGSM44BAEwggItAoIBAQCsVBV4gVV/zdmxWu8cU95vxY5D2RVG
+n6r56BOmnBF6beLZJKIK17FsurubePRfhLiVSk/RIA3aECPe8kRdRYAR23daCptw
+THaZMZ0s2mNQfJEc6sXCE3/EVlPPEZqvm7RilYxb1PNZY55X7EzMhhBc1zRiSQck
+Va8qDHP98vvZjd4G9W+aF2UOMQko9iN6hTjFkUgmNhqIHS3UAoANQ3y2sYHXZZuq
+EP9EKk8EQ5wv4w73eFJXj84pN6L3VvhLjq1Akjk/gl2p7w8cCdXzcfKBD7qXQZZr
+Qt4Pmz/BQu6wr4QBX3FiIghUZULlnCjhFNIrXTYbOskK/XGg62aV7Qn5AiEA6hP4
+cBgclv0kO5Qyg3qLVwMWOO1e4opX6EbqmK+kXysCggEBAIF77NYg4ttsGG2OiIs2
+yVBsV4w7EORIC+lG2+ZzVRSHm3QtNPeLoN6PwDtagpER2pUyjpXuxOcgE47hSUCQ
+RpSjXGtj22WbKjXZ2p8mkTScFvA2btgR+O4Nx0f0eShCz1fkrt8BaKRumzrzgoNI
+mcAuVOVqLLl4VkOXwsGvuH5cBVhW1sNKDc3VMYTsh34MDSJJEutFZeCokYwd6wo2
+pYVdXsDmc7uhPRK3YhtBV3lrXIehNlIukyO7li+wKU7SLyneBY/huBzYrw1JBDWK
+1CHqRDJm38yzpEOKhu3gefR+j1BZqev9O2tsbFJe3F/cYV1hDWR8jsZz+gfDUXja
+z9oDggEGAAKCAQEAoIbxish+OZADAwMJRP8nGYVIfSkWBXvC96nfQG4tZtqB4Z14
+cjOyChnMuHlQnDIWYhVVmDiIHJFGtsHUb8iPGqbpGeEmScWG4HsSnsNAK/dOKVTE
+OxGaq/3+Lisg8uyTqzAR5W5OdFlCw3qhzYG6G7kHNxGicN5qLQILTQeHIJiuioiE
+oDhpga7IB8pGNsXHpO40KeFe2BaZBpKnCQUF32kMnEFP9AqYnZ/io2vhCViee+O3
+A5/Wjke753qo+HUPj7C41wUwvXbXNfkGpXE4nyJZb37Ed+IMQu3sE/X6A2Vgbl+F
+2mpfWPo/ZC23fGe4ExyTKsD+hRIP2LlxhWI1xw==
+-----END PUBLIC KEY-----
+-----BEGIN RSA PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyjDEPJD1Fv1IJIq4mnec
+oMlSve0vZOTuzDmKuMB4vfBXalKZgbp4ONL+BvWV9OPs22Smv9SAfnoQ25q8Q9so
+ihzUKhaIAY2CI70ll4exbLK9FD4uTi1bqn0FdIh04UIyW6s2EqTGMkSKx9THNvAM
+Kx++pPt3US2sQVEC24bWPxRN7RsBBpRjoiEamkA04ioGFhMBbas5MdCLt/fd92aR
+QCBISOb6PU08fQiARK8g/wdpBUTxy9/Ud1vUnNaZtWm+eLrwdTXgHM3/LG1M4lc0
+ZqHIL3rMxhae5W+j3SL3ApreiUYugv/0bCSypvJZjEXKS7SBR/+rtw0/mQpS8DpI
+kwIDAQAB
+-----END RSA PUBLIC KEY-----
+		`)
+
+		Convey("then parsePublicKeysFromPEM should return with an error", func() {
+			keys, err := parsePublicKeysFromPEM(pemBytes)
+			So(keys, ShouldNotBeNil)
+			So(err, ShouldNotBeNil)
+			So(len(keys), ShouldEqual, 2)
+			So(err.Error(), ShouldEqual, "[unsupported key type *dsa.PublicKey; asn1: structure error: tags don't match (2 vs {class:0 tag:16 length:13 isCompound:true}) {optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false}  @2]")
+			So(keys[0], ShouldHaveSameTypeAs, &ecdsa.PublicKey{})
+			So(keys[1], ShouldHaveSameTypeAs, &rsa.PublicKey{})
+		})
+	})
+}


### PR DESCRIPTION
Changes the `pkitoken.PKIJWTVerifier` to:
- read public keys from multiple PEMs if the byte array contains them
- not only reads keys from certs, but also from `PUBLIC KEY` and `RSA PUBLIC KEY` PEMs
- iterate over keys and tries to use all of them to verify a token
- be more specifc about the occuring errors and providing details
- be more specific on return of unsupported signing algorithm

Also adds the necessary unit tests in the pkitoken package for the instantiation of the verifier and the `Validate()` function, as well as the parsing of all the different PEMs (which covers pretty much the whole package). 

Implements https://github.com/aporeto-inc/aporeto/issues/890 .
