### PR TITLE
Use protocol numbers for iptable rules

### DIFF
--- a/controller/constants/constants.go
+++ b/controller/constants/constants.go
@@ -85,3 +85,9 @@ const (
 const (
 	CallbackURIExtension = "/aporeto/oidc/callback"
 )
+
+// Protocol constants
+const (
+	TCPProtoNum = "6"
+	UDPProtoNum = "17"
+)

--- a/controller/internal/enforcer/acls/acl.go
+++ b/controller/internal/enforcer/acls/acl.go
@@ -88,7 +88,7 @@ func (a *acl) addRule(rule policy.IPRule) (err error) {
 	}
 
 	for _, proto := range rule.Protocols {
-		if strings.ToLower(proto) == "tcp" {
+		if strings.ToLower(proto) == "6" {
 			for _, address := range rule.Addresses {
 				for _, port := range rule.Ports {
 					if err := ruleAdd(address, port, rule.Policy); err != nil {

--- a/controller/internal/enforcer/acls/acl.go
+++ b/controller/internal/enforcer/acls/acl.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/policy"
 )
 
@@ -88,7 +89,7 @@ func (a *acl) addRule(rule policy.IPRule) (err error) {
 	}
 
 	for _, proto := range rule.Protocols {
-		if strings.ToLower(proto) == "6" {
+		if strings.ToLower(proto) == constants.TCPProtoNum {
 			for _, address := range rule.Addresses {
 				for _, port := range rule.Ports {
 					if err := ruleAdd(address, port, rule.Policy); err != nil {

--- a/controller/internal/enforcer/acls/acl_test.go
+++ b/controller/internal/enforcer/acls/acl_test.go
@@ -13,7 +13,7 @@ var (
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"400:500"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172/8"},
@@ -21,14 +21,14 @@ var (
 		policy.IPRule{
 			Addresses: []string{"172.17.0.0/16"},
 			Ports:     []string{"400:500"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172.17/16"},
 		},
 		policy.IPRule{
 			Addresses: []string{"192.168.100.0/24"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Ports:     []string{"80"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
@@ -36,14 +36,14 @@ var (
 		},
 		policy.IPRule{
 			Addresses: []string{"10.1.1.1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Ports:     []string{"80"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp10.1.1.1"}},
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Ports:     []string{"443"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
@@ -144,7 +144,7 @@ func TestObservedLookup(t *testing.T) {
 			policy.IPRule{
 				Addresses: []string{"200.17.0.0/17"},
 				Ports:     []string{"401"},
-				Protocols: []string{"tcp"},
+				Protocols: []string{"6"},
 				Policy: &policy.FlowPolicy{
 					Action:        policy.Accept,
 					ObserveAction: policy.ObserveContinue,
@@ -153,7 +153,7 @@ func TestObservedLookup(t *testing.T) {
 			policy.IPRule{
 				Addresses: []string{"200.18.0.0/17"},
 				Ports:     []string{"401"},
-				Protocols: []string{"tcp"},
+				Protocols: []string{"6"},
 				Policy: &policy.FlowPolicy{
 					Action:        policy.Accept,
 					ObserveAction: policy.ObserveApply,
@@ -162,7 +162,7 @@ func TestObservedLookup(t *testing.T) {
 			policy.IPRule{
 				Addresses: []string{"200.0.0.0/9"},
 				Ports:     []string{"401"},
-				Protocols: []string{"tcp"},
+				Protocols: []string{"6"},
 				Policy: &policy.FlowPolicy{
 					Action:   policy.Accept,
 					PolicyID: "tcp200/9"},

--- a/controller/internal/enforcer/acls/acl_test.go
+++ b/controller/internal/enforcer/acls/acl_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/policy"
 )
 
@@ -13,7 +14,7 @@ var (
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"400:500"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172/8"},
@@ -21,14 +22,14 @@ var (
 		policy.IPRule{
 			Addresses: []string{"172.17.0.0/16"},
 			Ports:     []string{"400:500"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172.17/16"},
 		},
 		policy.IPRule{
 			Addresses: []string{"192.168.100.0/24"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Ports:     []string{"80"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
@@ -36,14 +37,14 @@ var (
 		},
 		policy.IPRule{
 			Addresses: []string{"10.1.1.1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Ports:     []string{"80"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp10.1.1.1"}},
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Ports:     []string{"443"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
@@ -144,7 +145,7 @@ func TestObservedLookup(t *testing.T) {
 			policy.IPRule{
 				Addresses: []string{"200.17.0.0/17"},
 				Ports:     []string{"401"},
-				Protocols: []string{"6"},
+				Protocols: []string{constants.TCPProtoNum},
 				Policy: &policy.FlowPolicy{
 					Action:        policy.Accept,
 					ObserveAction: policy.ObserveContinue,
@@ -153,7 +154,7 @@ func TestObservedLookup(t *testing.T) {
 			policy.IPRule{
 				Addresses: []string{"200.18.0.0/17"},
 				Ports:     []string{"401"},
-				Protocols: []string{"6"},
+				Protocols: []string{constants.TCPProtoNum},
 				Policy: &policy.FlowPolicy{
 					Action:        policy.Accept,
 					ObserveAction: policy.ObserveApply,
@@ -162,7 +163,7 @@ func TestObservedLookup(t *testing.T) {
 			policy.IPRule{
 				Addresses: []string{"200.0.0.0/9"},
 				Ports:     []string{"401"},
-				Protocols: []string{"6"},
+				Protocols: []string{constants.TCPProtoNum},
 				Policy: &policy.FlowPolicy{
 					Action:   policy.Accept,
 					PolicyID: "tcp200/9"},

--- a/controller/internal/enforcer/acls/aclcache_test.go
+++ b/controller/internal/enforcer/acls/aclcache_test.go
@@ -31,7 +31,7 @@ func TestRejectPrioritizedOverAcceptCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172/8"},
@@ -39,7 +39,7 @@ func TestRejectPrioritizedOverAcceptCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Reject,
 				PolicyID: "catchAllDrop"},
@@ -71,7 +71,7 @@ func TestEmptyACLWithObserveContinueCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Accept,
 				ObserveAction: policy.ObserveContinue,
@@ -104,7 +104,7 @@ func TestEmptyACLWithObserveApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Accept,
 				ObserveAction: policy.ObserveApply,
@@ -137,7 +137,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.1.0.0/16"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Reject,
 				ObserveAction: policy.ObserveContinue,
@@ -146,7 +146,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172/8"},
@@ -154,7 +154,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Accept,
 				ObserveAction: policy.ObserveApply,
@@ -163,7 +163,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"tcp"},
+			Protocols: []string{"6"},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Reject,
 				ObserveAction: policy.ObserveContinue,

--- a/controller/internal/enforcer/acls/aclcache_test.go
+++ b/controller/internal/enforcer/acls/aclcache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/policy"
 )
 
@@ -31,7 +32,7 @@ func TestRejectPrioritizedOverAcceptCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172/8"},
@@ -39,7 +40,7 @@ func TestRejectPrioritizedOverAcceptCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Reject,
 				PolicyID: "catchAllDrop"},
@@ -71,7 +72,7 @@ func TestEmptyACLWithObserveContinueCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Accept,
 				ObserveAction: policy.ObserveContinue,
@@ -104,7 +105,7 @@ func TestEmptyACLWithObserveApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"0.0.0.0/0"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Accept,
 				ObserveAction: policy.ObserveApply,
@@ -137,7 +138,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.1.0.0/16"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Reject,
 				ObserveAction: policy.ObserveContinue,
@@ -146,7 +147,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:   policy.Accept,
 				PolicyID: "tcp172/8"},
@@ -154,7 +155,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Accept,
 				ObserveAction: policy.ObserveApply,
@@ -163,7 +164,7 @@ func TestObserveContinueApplyCacheLookup(t *testing.T) {
 		policy.IPRule{
 			Addresses: []string{"172.0.0.0/8"},
 			Ports:     []string{"1"},
-			Protocols: []string{"6"},
+			Protocols: []string{constants.TCPProtoNum},
 			Policy: &policy.FlowPolicy{
 				Action:        policy.Reject,
 				ObserveAction: policy.ObserveContinue,

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -142,7 +142,7 @@ func createPolicy(networks []string) policy.IPRuleList {
 	iprule := policy.IPRule{
 		Addresses: addresses,
 		Ports:     []string{"0:65535"},
-		Protocols: []string{"6"},
+		Protocols: []string{constants.TCPProtoNum},
 		Policy:    &f,
 	}
 

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -142,7 +142,7 @@ func createPolicy(networks []string) policy.IPRuleList {
 	iprule := policy.IPRule{
 		Addresses: addresses,
 		Ports:     []string{"0:65535"},
-		Protocols: []string{"tcp"},
+		Protocols: []string{"6"},
 		Policy:    &f,
 	}
 

--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -167,7 +167,7 @@ func TestEnforcerExternalNetworks(t *testing.T) {
 			iprules := policy.IPRuleList{policy.IPRule{
 				Addresses: []string{"10.1.10.76/32"},
 				Ports:     []string{"80"},
-				Protocols: []string{"tcp"},
+				Protocols: []string{"6"},
 				Policy: &policy.FlowPolicy{
 					Action:   policy.Accept,
 					PolicyID: "tcp172/8"},
@@ -4635,7 +4635,7 @@ func TestDNS(t *testing.T) {
 		puInfo.Policy.UpdateDNSNetworks([]policy.DNSRule{{
 			Name:     externalFQDN,
 			Port:     "80",
-			Protocol: "tcp",
+			Protocol: "6",
 			Policy:   &policy.FlowPolicy{Action: policy.Accept},
 		}})
 
@@ -4715,7 +4715,7 @@ func TestDNSWithError(t *testing.T) {
 		puInfo.Policy.UpdateDNSNetworks([]policy.DNSRule{{
 			Name:     externalFQDN,
 			Port:     "80",
-			Protocol: "tcp",
+			Protocol: "6",
 			Policy:   &policy.FlowPolicy{Action: policy.Accept},
 		}})
 

--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -167,7 +167,7 @@ func TestEnforcerExternalNetworks(t *testing.T) {
 			iprules := policy.IPRuleList{policy.IPRule{
 				Addresses: []string{"10.1.10.76/32"},
 				Ports:     []string{"80"},
-				Protocols: []string{"6"},
+				Protocols: []string{constants.TCPProtoNum},
 				Policy: &policy.FlowPolicy{
 					Action:   policy.Accept,
 					PolicyID: "tcp172/8"},
@@ -4635,7 +4635,7 @@ func TestDNS(t *testing.T) {
 		puInfo.Policy.UpdateDNSNetworks([]policy.DNSRule{{
 			Name:     externalFQDN,
 			Port:     "80",
-			Protocol: "6",
+			Protocol: constants.TCPProtoNum,
 			Policy:   &policy.FlowPolicy{Action: policy.Accept},
 		}})
 
@@ -4715,7 +4715,7 @@ func TestDNSWithError(t *testing.T) {
 		puInfo.Policy.UpdateDNSNetworks([]policy.DNSRule{{
 			Name:     externalFQDN,
 			Port:     "80",
-			Protocol: "6",
+			Protocol: constants.TCPProtoNum,
 			Policy:   &policy.FlowPolicy{Action: policy.Accept},
 		}})
 

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -18,6 +18,8 @@ import (
 const (
 	tcpProto     = "tcp"
 	udpProto     = "udp"
+	tcpProtoNum  = "6"
+	udpProtoNum  = "17"
 	numPackets   = "100"
 	initialCount = "99"
 )
@@ -827,7 +829,7 @@ func (i *Instance) addTCPAppACLS(contextID, chain string, rules []aclIPset) erro
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == tcpProto &&
+				if strings.ToLower(proto) == tcpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, chain, "10", tcpProto, "dst", "Insert"); err != nil {
@@ -964,7 +966,7 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if (strings.ToLower(proto) == udpProto) &&
+				if (strings.ToLower(proto) == udpProtoNum) &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProto, "dst", "Insert"); err != nil {
@@ -1779,7 +1781,7 @@ func (i *Instance) removeMarkRule() error {
 	return nil
 }
 
-func (i *Instance) removeProxyRules(natproxyTableContext string, proxyTableContext string, inputProxySection string, outputProxySection string, natProxyInputChain, natProxyOutputChain, proxyInputChain, proxyOutputChain string) (err error) {
+func (i *Instance) removeProxyRules(natproxyTableContext string, proxyTableContext string, inputProxySection string, outputProxySection string, natProxyInputChain, natProxyOutputChain, proxyInputChain, proxyOutputChain string) (err error) { // nolint
 
 	zap.L().Debug("Called remove ProxyRules",
 		zap.String("natproxyTableContext", natproxyTableContext),
@@ -1836,7 +1838,7 @@ func (i *Instance) removeProxyRules(natproxyTableContext string, proxyTableConte
 	return nil
 }
 
-func (i *Instance) cleanACLs() error {
+func (i *Instance) cleanACLs() error { // nolint
 
 	// Clean the mark rule
 	if err := i.removeMarkRule(); err != nil {
@@ -1872,7 +1874,7 @@ func (i *Instance) cleanACLs() error {
 }
 
 // cleanTriremeChains clear the trireme/hostmode chains.
-func (i *Instance) cleanTriremeChains(context string) error {
+func (i *Instance) cleanTriremeChains(context string) error { // nolint
 
 	// clear Trireme-Input/Trireme-Output/NetworkSvc-Input/NetworkSvc-Output/Hostmode-Input/Hostmode-Output
 	if err := i.ipt.ClearChain(context, HostModeOutput); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -18,8 +18,6 @@ import (
 const (
 	tcpProto     = "tcp"
 	udpProto     = "udp"
-	tcpProtoNum  = "6"
-	udpProtoNum  = "17"
 	numPackets   = "100"
 	initialCount = "99"
 )
@@ -768,13 +766,13 @@ func (i *Instance) programRule(contextID string, rule *aclIPset, insertOrder *in
 			"-m", "set", "--match-set", rule.ipset, ipMatchDirection}
 
 		// only tcp uses target networks
-		if proto == tcpProtoNum {
+		if proto == constants.TCPProtoNum {
 			targetNet := []string{"-m", "set", "!", "--match-set", targetNetworkSet, ipMatchDirection}
 			iptRule = append(iptRule, targetNet...)
 		}
 
 		// port match is required only for tcp and udp protocols
-		if proto == tcpProtoNum || proto == udpProtoNum {
+		if proto == constants.TCPProtoNum || proto == constants.UDPProtoNum {
 			portMatchSet := []string{"--match", "multiport", "--dports", strings.Join(rule.ports, ",")}
 			iptRule = append(iptRule, portMatchSet...)
 		}
@@ -829,10 +827,10 @@ func (i *Instance) addTCPAppACLS(contextID, chain string, rules []aclIPset) erro
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == tcpProtoNum &&
+				if strings.ToLower(proto) == constants.TCPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, chain, "10", tcpProtoNum, "dst", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, chain, "10", constants.TCPProtoNum, "dst", "Insert"); err != nil {
 						return err
 					}
 				}
@@ -898,8 +896,8 @@ func (i *Instance) addOtherAppACLs(contextID, appChain string, rules []aclIPset)
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
 				proto = strings.ToLower(proto)
-				if proto != tcpProtoNum &&
-					proto != udpProtoNum &&
+				if proto != constants.TCPProtoNum &&
+					proto != constants.UDPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, appChain, "10", proto, "dst", "Append"); err != nil {
@@ -966,10 +964,10 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if (strings.ToLower(proto) == udpProtoNum) &&
+				if (strings.ToLower(proto) == constants.UDPProtoNum) &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProtoNum, "dst", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, appChain, "10", constants.UDPProtoNum, "dst", "Insert"); err != nil {
 						return err
 					}
 
@@ -1096,10 +1094,10 @@ func (i *Instance) addTCPNetACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == tcpProtoNum &&
+				if strings.ToLower(proto) == constants.TCPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, netChain, "11", tcpProtoNum, "src", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, netChain, "11", constants.TCPProtoNum, "src", "Insert"); err != nil {
 						return err
 					}
 
@@ -1178,10 +1176,10 @@ func (i *Instance) addUDPNetACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == udpProtoNum &&
+				if strings.ToLower(proto) == constants.UDPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, netChain, "11", udpProtoNum, "src", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, netChain, "11", constants.UDPProtoNum, "src", "Insert"); err != nil {
 						return err
 					}
 
@@ -1259,8 +1257,8 @@ func (i *Instance) addOtherNetACLS(contextID, netChain string, rules []aclIPset)
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
 				proto = strings.ToLower(proto)
-				if proto != tcpProtoNum &&
-					proto != udpProtoNum &&
+				if proto != constants.TCPProtoNum &&
+					proto != constants.UDPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, netChain, "11", proto, "src", "Append"); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -827,7 +827,7 @@ func (i *Instance) addTCPAppACLS(contextID, chain string, rules []aclIPset) erro
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == constants.TCPProtoNum &&
+				if proto == constants.TCPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, chain, "10", constants.TCPProtoNum, "dst", "Insert"); err != nil {
@@ -895,7 +895,6 @@ func (i *Instance) addOtherAppACLs(contextID, appChain string, rules []aclIPset)
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				proto = strings.ToLower(proto)
 				if proto != constants.TCPProtoNum &&
 					proto != constants.UDPProtoNum &&
 					actionPredicate(rule.policy) &&
@@ -964,7 +963,7 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if (strings.ToLower(proto) == constants.UDPProtoNum) &&
+				if (proto == constants.UDPProtoNum) &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, appChain, "10", constants.UDPProtoNum, "dst", "Insert"); err != nil {
@@ -1094,7 +1093,7 @@ func (i *Instance) addTCPNetACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == constants.TCPProtoNum &&
+				if proto == constants.TCPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, netChain, "11", constants.TCPProtoNum, "src", "Insert"); err != nil {
@@ -1176,7 +1175,7 @@ func (i *Instance) addUDPNetACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == constants.UDPProtoNum &&
+				if proto == constants.UDPProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, netChain, "11", constants.UDPProtoNum, "src", "Insert"); err != nil {
@@ -1256,7 +1255,6 @@ func (i *Instance) addOtherNetACLS(contextID, netChain string, rules []aclIPset)
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				proto = strings.ToLower(proto)
 				if proto != constants.TCPProtoNum &&
 					proto != constants.UDPProtoNum &&
 					actionPredicate(rule.policy) &&

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -768,13 +768,13 @@ func (i *Instance) programRule(contextID string, rule *aclIPset, insertOrder *in
 			"-m", "set", "--match-set", rule.ipset, ipMatchDirection}
 
 		// only tcp uses target networks
-		if proto == tcpProto {
+		if proto == tcpProtoNum {
 			targetNet := []string{"-m", "set", "!", "--match-set", targetNetworkSet, ipMatchDirection}
 			iptRule = append(iptRule, targetNet...)
 		}
 
 		// port match is required only for tcp and udp protocols
-		if proto == tcpProto || proto == udpProto {
+		if proto == tcpProtoNum || proto == udpProtoNum {
 			portMatchSet := []string{"--match", "multiport", "--dports", strings.Join(rule.ports, ",")}
 			iptRule = append(iptRule, portMatchSet...)
 		}
@@ -832,7 +832,7 @@ func (i *Instance) addTCPAppACLS(contextID, chain string, rules []aclIPset) erro
 				if strings.ToLower(proto) == tcpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, chain, "10", tcpProto, "dst", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, chain, "10", tcpProtoNum, "dst", "Insert"); err != nil {
 						return err
 					}
 				}
@@ -898,8 +898,8 @@ func (i *Instance) addOtherAppACLs(contextID, appChain string, rules []aclIPset)
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
 				proto = strings.ToLower(proto)
-				if proto != tcpProto &&
-					proto != udpProto &&
+				if proto != tcpProtoNum &&
+					proto != udpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, appChain, "10", proto, "dst", "Append"); err != nil {
@@ -969,7 +969,7 @@ func (i *Instance) addUDPAppACLS(contextID, appChain, netChain string, rules []a
 				if (strings.ToLower(proto) == udpProtoNum) &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProto, "dst", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, appChain, "10", udpProtoNum, "dst", "Insert"); err != nil {
 						return err
 					}
 
@@ -1099,7 +1099,7 @@ func (i *Instance) addTCPNetACLS(contextID, appChain, netChain string, rules []a
 				if strings.ToLower(proto) == tcpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, netChain, "11", tcpProto, "src", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, netChain, "11", tcpProtoNum, "src", "Insert"); err != nil {
 						return err
 					}
 
@@ -1181,7 +1181,7 @@ func (i *Instance) addUDPNetACLS(contextID, appChain, netChain string, rules []a
 				if strings.ToLower(proto) == udpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
-					if err := i.programRule(contextID, &rule, intP, netChain, "11", udpProto, "src", "Insert"); err != nil {
+					if err := i.programRule(contextID, &rule, intP, netChain, "11", udpProtoNum, "src", "Insert"); err != nil {
 						return err
 					}
 
@@ -1259,8 +1259,8 @@ func (i *Instance) addOtherNetACLS(contextID, netChain string, rules []aclIPset)
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
 				proto = strings.ToLower(proto)
-				if proto != tcpProto &&
-					proto != udpProto &&
+				if proto != tcpProtoNum &&
+					proto != udpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, netChain, "11", proto, "src", "Append"); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -1096,7 +1096,7 @@ func (i *Instance) addTCPNetACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == tcpProto &&
+				if strings.ToLower(proto) == tcpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, netChain, "11", tcpProto, "src", "Insert"); err != nil {
@@ -1178,7 +1178,7 @@ func (i *Instance) addUDPNetACLS(contextID, appChain, netChain string, rules []a
 	programACLs := func(actionPredicate rulePred, observePredicate rulePred) error {
 		for _, rule := range rules {
 			for _, proto := range rule.protocols {
-				if strings.ToLower(proto) == udpProto &&
+				if strings.ToLower(proto) == udpProtoNum &&
 					actionPredicate(rule.policy) &&
 					observePredicate(rule.policy) {
 					if err := i.programRule(contextID, &rule, intP, netChain, "11", udpProto, "src", "Insert"); err != nil {

--- a/controller/internal/supervisor/iptablesctrl/acls_test.go
+++ b/controller/internal/supervisor/iptablesctrl/acls_test.go
@@ -916,14 +916,14 @@ func TestAddAppACLs(t *testing.T) {
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"80"},
-					Protocols: []string{"TCP"},
+					Protocols: []string{"6"},
 					Policy:    &policy.FlowPolicy{Action: (policy.Reject | policy.Log)},
 				},
 
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"443"},
-					Protocols: []string{"UDP"},
+					Protocols: []string{"17"},
 					Policy:    &policy.FlowPolicy{Action: policy.Accept},
 				},
 
@@ -1012,14 +1012,14 @@ func TestAddNetACLs(t *testing.T) {
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"80"},
-					Protocols: []string{"TCP"},
+					Protocols: []string{"6"},
 					Policy:    &policy.FlowPolicy{Action: (policy.Reject | policy.Log)},
 				},
 
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"443"},
-					Protocols: []string{"UDP"},
+					Protocols: []string{"17"},
 					Policy:    &policy.FlowPolicy{Action: policy.Accept},
 				},
 

--- a/controller/internal/supervisor/iptablesctrl/acls_test.go
+++ b/controller/internal/supervisor/iptablesctrl/acls_test.go
@@ -916,14 +916,14 @@ func TestAddAppACLs(t *testing.T) {
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"80"},
-					Protocols: []string{"6"},
+					Protocols: []string{constants.TCPProtoNum},
 					Policy:    &policy.FlowPolicy{Action: (policy.Reject | policy.Log)},
 				},
 
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"443"},
-					Protocols: []string{"17"},
+					Protocols: []string{constants.UDPProtoNum},
 					Policy:    &policy.FlowPolicy{Action: policy.Accept},
 				},
 
@@ -1012,14 +1012,14 @@ func TestAddNetACLs(t *testing.T) {
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"80"},
-					Protocols: []string{"6"},
+					Protocols: []string{constants.TCPProtoNum},
 					Policy:    &policy.FlowPolicy{Action: (policy.Reject | policy.Log)},
 				},
 
 				policy.IPRule{
 					Addresses: []string{"192.30.253.0/24"},
 					Ports:     []string{"443"},
-					Protocols: []string{"17"},
+					Protocols: []string{constants.UDPProtoNum},
 					Policy:    &policy.FlowPolicy{Action: policy.Accept},
 				},
 

--- a/controller/pkg/pucontext/pucontext.go
+++ b/controller/pkg/pucontext/pucontext.go
@@ -124,7 +124,7 @@ func createACLRules(rules policy.IPRuleList, dnsrule *policy.DNSRule, ip string)
 	rules = append(rules, policy.IPRule{
 		Addresses: []string{ip},
 		Ports:     []string{dnsrule.Port},
-		Protocols: []string{"TCP"},
+		Protocols: []string{"6"},
 		Policy:    dnsrule.Policy,
 	})
 
@@ -138,9 +138,9 @@ func (p *PUContext) dnsToACLs(dnsList *policy.DNSRuleList, ipcache map[string]bo
 
 		if ips, err := LookupHost(dnsrule.Name); err == nil {
 			for _, ip := range ips {
-				if !ipcache[ip+dnsrule.Port] {
+				if !ipcache[ip+":"+dnsrule.Port] {
 					rules = createACLRules(rules, dnsrule, ip)
-					ipcache[ip+dnsrule.Port] = true
+					ipcache[ip+":"+dnsrule.Port] = true
 				}
 			}
 

--- a/controller/pkg/pucontext/pucontext.go
+++ b/controller/pkg/pucontext/pucontext.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.aporeto.io/trireme-lib/common"
+	"go.aporeto.io/trireme-lib/controller/constants"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/acls"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/lookup"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
@@ -124,7 +125,7 @@ func createACLRules(rules policy.IPRuleList, dnsrule *policy.DNSRule, ip string)
 	rules = append(rules, policy.IPRule{
 		Addresses: []string{ip},
 		Ports:     []string{dnsrule.Port},
-		Protocols: []string{"6"},
+		Protocols: []string{constants.TCPProtoNum},
 		Policy:    dnsrule.Policy,
 	})
 


### PR DESCRIPTION
On some os variants like alpine, protocol names like vrrp/l2tp are not defined in /etc/protocols. iptables would fail with "unknown protocol" error in such cases. 