### PR TITLE
Oidc behavior when only authorization is needed

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -502,7 +502,7 @@ func (p *Config) processNetRequest(w http.ResponseWriter, r *http.Request) {
 	// is mepty the DecodeAporetoClaims method will return no error.
 	sourceID, aporetoClaims, err := pctx.Authorizer.DecodeAporetoClaims(token, key)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Invalid Authorization Token"), http.StatusForbidden)
+		http.Error(w, fmt.Sprintf("Invalid Authorization Token: %s", err), http.StatusForbidden)
 		state.stats.DropReason = collector.PolicyDrop
 		return
 	}
@@ -725,7 +725,7 @@ func processHeaders(r *http.Request) (string, string) {
 	}
 	key := r.Header.Get("X-APORETO-KEY")
 	if key != "" {
-		r.Header.Del("X-APORETO-LEN")
+		r.Header.Del("X-APORETO-KEY")
 	}
 	return token, key
 }

--- a/controller/internal/enforcer/applicationproxy/markedconn/markedconn.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/markedconn.go
@@ -18,9 +18,9 @@ const (
 	sockOptOriginalDst = 80
 )
 
-// DialMarkedTCPWithContext will dial a TCP connection to the provide address and mark the socket
+// DialMarkedWithContext will dial a TCP connection to the provide address and mark the socket
 // with the provided mark.
-func DialMarkedTCPWithContext(ctx context.Context, network string, addr *net.TCPAddr, mark int) (net.Conn, error) {
+func DialMarkedWithContext(ctx context.Context, network string, addr string, mark int) (net.Conn, error) {
 	d := net.Dialer{
 		Control: func(_, _ string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
@@ -38,11 +38,11 @@ func DialMarkedTCPWithContext(ctx context.Context, network string, addr *net.TCP
 		},
 	}
 
-	conn, err := d.DialContext(ctx, network, addr.String())
+	conn, err := d.DialContext(ctx, network, addr)
 	if err != nil {
 		zap.L().Error("Failed to dial to downstream node",
 			zap.Error(err),
-			zap.String("Address", addr.String()),
+			zap.String("Address", addr),
 			zap.String("Network type", network),
 		)
 	}

--- a/controller/internal/enforcer/applicationproxy/markedconn/markedconn_osx.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/markedconn_osx.go
@@ -7,8 +7,8 @@ import (
 	"net"
 )
 
-// DialMarkedTCPWithContext dials a TCP connection and associates a mark. Propagates the context.
-func DialMarkedTCPWithContext(ctx context.Context, network string, addr *net.TCPAddr, mark int) (net.Conn, error) {
+// DialMarkedWithContext dials a TCP connection and associates a mark. Propagates the context.
+func DialMarkedWithContext(ctx context.Context, network string, addr string, mark int) (net.Conn, error) {
 	return nil, nil
 }
 

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -278,7 +278,7 @@ func (p *Proxy) downConnection(ctx context.Context, ip net.IP, port int) (net.Co
 		Port: port,
 	}
 
-	return markedconn.DialMarkedTCPWithContext(ctx, "tcp4", raddr, proxyMarkInt)
+	return markedconn.DialMarkedWithContext(ctx, "tcp4", raddr.String(), proxyMarkInt)
 
 }
 

--- a/controller/pkg/remoteenforcer/remoteenforcer_linux.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_linux.go
@@ -283,17 +283,21 @@ func (s *RemoteEnforcer) Supervise(req rpcwrapper.Request, resp *rpcwrapper.Resp
 
 	payload := req.Payload.(rpcwrapper.SuperviseRequestPayload)
 
+	plc, err := payload.Policy.ToPrivatePolicy(false)
+	if err != nil {
+		return err
+	}
+
 	puInfo := &policy.PUInfo{
 		ContextID: payload.ContextID,
-		Policy:    payload.Policy.ToPrivatePolicy(false),
+		Policy:    plc,
 		Runtime:   policy.NewPURuntimeWithDefaults(),
 	}
 
 	// TODO - Set PID to 1 - needed only for statistics
 	puInfo.Runtime.SetPid(1)
 
-	err := s.supervisor.Supervise(payload.ContextID, puInfo)
-	if err != nil {
+	if err = s.supervisor.Supervise(payload.ContextID, puInfo); err != nil {
 		zap.L().Error("unable to initialize supervisor",
 			zap.String("ContextID", payload.ContextID),
 			zap.Error(err),
@@ -373,9 +377,14 @@ func (s *RemoteEnforcer) Enforce(req rpcwrapper.Request, resp *rpcwrapper.Respon
 
 	payload := req.Payload.(rpcwrapper.EnforcePayload)
 
+	plc, err := payload.Policy.ToPrivatePolicy(true)
+	if err != nil {
+		return err
+	}
+
 	puInfo := &policy.PUInfo{
 		ContextID: payload.ContextID,
-		Policy:    payload.Policy.ToPrivatePolicy(true),
+		Policy:    plc,
 		Runtime:   policy.NewPURuntimeWithDefaults(),
 	}
 

--- a/controller/pkg/remoteenforcer/remoteenforcer_stub.go
+++ b/controller/pkg/remoteenforcer/remoteenforcer_stub.go
@@ -7,11 +7,12 @@ import (
 
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/utils/rpcwrapper"
 	"go.aporeto.io/trireme-lib/controller/pkg/packetprocessor"
+	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/debugclient"
 	"go.aporeto.io/trireme-lib/controller/pkg/remoteenforcer/internal/statsclient"
 )
 
 // newServer is a fake implementation for building on darwin.
-func newServer(ctx context.Context, cancel context.CancelFunc, service packetprocessor.PacketProcessor, rpchdl rpcwrapper.RPCServer, pcchan string, secret string, stats statsclient.StatsClient) (RemoteIntf, error) {
+func newServer(ctx context.Context, cancel context.CancelFunc, service packetprocessor.PacketProcessor, rpchdl rpcwrapper.RPCServer, pcchan string, secret string, stats statsclient.StatsClient, debugClient debugclient.DebugClient) (RemoteIntf, error) {
 	return nil, nil
 }
 
@@ -53,5 +54,15 @@ func (s *RemoteEnforcer) Enforce(req rpcwrapper.Request, resp *rpcwrapper.Respon
 // EnforcerExit this method is called when  we received a killrpocess message from the controller
 // This allows a graceful exit of the enforcer
 func (s *RemoteEnforcer) EnforcerExit(req rpcwrapper.Request, resp *rpcwrapper.Response) error {
+	return nil
+}
+
+// EnableDatapathPacketTracing enable nfq datapath packet tracing
+func (s *RemoteEnforcer) EnableDatapathPacketTracing(req rpcwrapper.Request, resp *rpcwrapper.Response) error {
+	return nil
+}
+
+// EnableIPTablesPacketTracing enables iptables trace packet tracing
+func (s *RemoteEnforcer) EnableIPTablesPacketTracing(req rpcwrapper.Request, resp *rpcwrapper.Response) error {
 	return nil
 }

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -211,7 +211,7 @@ func (v *TokenVerifier) Validate(ctx context.Context, token string) ([]string, b
 	// it now. This is possible if the token was created earlier
 	// but we never had a chance to verify it. In this case, the
 	// attributes were empty.
-	idToken, err := v.oauthVerifier.Verify(ctx, token)
+	idToken, err := v.oauthVerifier.Verify(dialContextPolicyBypass(ctx), token)
 	if err != nil {
 		var ok bool
 		// Token is expired. Let's try to refresh it if we have something

--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -14,6 +15,8 @@ import (
 	"github.com/bluele/gcache"
 	oidc "github.com/coreos/go-oidc"
 	"github.com/rs/xid"
+	"go.aporeto.io/trireme-lib/controller/constants"
+	"go.aporeto.io/trireme-lib/controller/internal/enforcer/applicationproxy/markedconn"
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -66,7 +69,12 @@ func NewClient(ctx context.Context, v *TokenVerifier) (*TokenVerifier, error) {
 	// Create a new generic OIDC provider based on the provider URL.
 	// The library will auto-discover the configuration of the provider.
 	// If it is not a compliant provider we should report and error here.
-	provider, err := oidc.NewProvider(ctx, v.ProviderURL)
+	dialContext, err := dialContextPolicyBypass(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, err := oidc.NewProvider(dialContext, v.ProviderURL)
 	if err != nil {
 		zap.L().Error("Failed to initialize OIDC provider", zap.Error(err), zap.String("Provider URL", v.ProviderURL))
 		return nil, fmt.Errorf("Failed to initialize provider: %s", err)
@@ -145,7 +153,11 @@ func (v *TokenVerifier) Callback(r *http.Request) (string, string, int, error) {
 
 	// We exchange the authorization code with an OAUTH token. This is the main
 	// step where the OAUTH provider will match the code to the token.
-	oauth2Token, err := v.clientConfig.Exchange(r.Context(), r.URL.Query().Get("code"), oauth2.AccessTypeOffline)
+	dialContext, err := dialContextPolicyBypass(r.Context())
+	if err != nil {
+		return "", "", http.StatusInternalServerError, fmt.Errorf("unable to validate with OIDC provider: %s", err)
+	}
+	oauth2Token, err := v.clientConfig.Exchange(dialContext, r.URL.Query().Get("code"), oauth2.AccessTypeOffline)
 	if err != nil {
 		return "", "", http.StatusInternalServerError, fmt.Errorf("Bad code: %s", err)
 	}
@@ -225,7 +237,11 @@ func (v *TokenVerifier) Validate(ctx context.Context, token string) ([]string, b
 		if !ok {
 			return []string{}, true, token, fmt.Errorf("Failed to find id_token - initiate re-authorization")
 		}
-		idToken, err = v.oauthVerifier.Verify(ctx, token)
+		dialContext, err := dialContextPolicyBypass(ctx)
+		if err != nil {
+			return nil, false, token, fmt.Errorf("unable to validate with OIDC provider: %s", err)
+		}
+		idToken, err = v.oauthVerifier.Verify(dialContext, token)
 		if err != nil {
 			return []string{}, true, token, fmt.Errorf("invalid token derived from refresh - manual authorization is required: %s", err)
 		}
@@ -271,4 +287,46 @@ func randomSha1(nonceSourceSize int) (string, error) {
 	}
 	sha := sha1.Sum(nonceSource)
 	return base64.StdEncoding.EncodeToString(sha[:]), nil
+}
+
+func dialContextPolicyBypass(ctx context.Context) (context.Context, error) {
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				ipAddr, err := resolveDNSMarked(ctx, addr)
+				if err != nil {
+					return nil, err
+				}
+				return markedconn.DialMarkedWithContext(ctx, network, ipAddr, int(constants.DefaultConnMark))
+			},
+		},
+	}
+
+	return context.WithValue(ctx, oauth2.HTTPClient, client), nil
+}
+
+func resolveDNSMarked(ctx context.Context, addr string) (string, error) {
+	r := net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return markedconn.DialMarkedWithContext(ctx, "udp", address, int(constants.DefaultConnMark))
+		},
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", fmt.Errorf("invalid address: %s", addr)
+	}
+
+	addresses, err := r.LookupHost(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve address %s: %s", addr, err)
+	}
+
+	if len(addresses) == 0 {
+		return "", fmt.Errorf("unable to resolve to a valid address for address %s", addr)
+	}
+
+	return addresses[0] + ":" + port, nil
 }

--- a/controller/pkg/usertokens/usetokens.go
+++ b/controller/pkg/usertokens/usetokens.go
@@ -2,6 +2,7 @@ package usertokens
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"go.aporeto.io/trireme-lib/controller/pkg/usertokens/common"
@@ -22,26 +23,25 @@ type Verifier interface {
 
 // NewVerifier initializes data structures based on the interface that
 // is transmitted over the RPC between main and remote enforcers.
-func NewVerifier(v Verifier) Verifier {
+func NewVerifier(v Verifier) (Verifier, error) {
 	if v == nil {
-		return nil
+		return nil, nil
 	}
 	switch v.VerifierType() {
 	case common.PKI:
 		p := v.(*pkitokens.PKIJWTVerifier)
 		v, err := pkitokens.NewVerifier(p)
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return v
+		return v, nil
 	case common.OIDC:
 		p := v.(*oidc.TokenVerifier)
 		verifier, err := oidc.NewClient(context.Background(), p)
-		// TODO figure out error handling
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		return verifier
+		return verifier, nil
 	}
-	return nil
+	return nil, fmt.Errorf("uknown verifier type")
 }

--- a/policy/apiservices.go
+++ b/policy/apiservices.go
@@ -72,6 +72,10 @@ type ApplicationService struct {
 	// Tags are the tags of the service.
 	Tags *TagStore
 
+	// FallbackJWTAuthorizationCert is the certificate that has been used to sign
+	// JWTs if they are not signed by the datapath
+	FallbackJWTAuthorizationCert string
+
 	// UserAuthorizationType is the type of user authorization that must be used.
 	UserAuthorizationType UserAuthorizationTypeValues
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -491,12 +492,16 @@ type PUPolicyPublic struct {
 }
 
 // ToPrivatePolicy converts the object to a private object.
-func (p *PUPolicyPublic) ToPrivatePolicy(convert bool) *PUPolicy {
+func (p *PUPolicyPublic) ToPrivatePolicy(convert bool) (*PUPolicy, error) {
+	var err error
 
 	exposedServices := ApplicationServicesList{}
 	for _, e := range p.ExposedServices {
 		if convert {
-			e.UserAuthorizationHandler = usertokens.NewVerifier(e.UserAuthorizationHandler)
+			e.UserAuthorizationHandler, err = usertokens.NewVerifier(e.UserAuthorizationHandler)
+			if err != nil {
+				return nil, fmt.Errorf("unable to initialize user authorization handler for service: %s - error %s", e.ID, err)
+			}
 		}
 		exposedServices = append(exposedServices, e)
 	}
@@ -522,5 +527,5 @@ func (p *PUPolicyPublic) ToPrivatePolicy(convert bool) *PUPolicy {
 		servicesCA:            p.ServicesCA,
 		servicesCertificate:   p.ServicesCertificate,
 		servicesPrivateKey:    p.ServicesPrivateKey,
-	}
+	}, nil
 }


### PR DESCRIPTION
#### Description
Fixes the OIDC behavior when requests arrive with valid tokens that were created through another
party and not as part of the local negotiation. Likely to happen in scenarios with a load balancer.

Modifies the format of the JWT tokens to rely on the subject for source identification rather than customer headers.

Allows JWT tokens to provide a Data section.

Removes the requirement for ACLs to the OIDC provider and bypasses policies for communication with the OIDC provider by using marking.