### PR TITLE
Fix NAT output chain handling for processes

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -647,7 +647,7 @@ func (d *Datapath) processNetworkSynAckPacket(context *pucontext.PUContext, conn
 		flowHash := tcpPacket.SourceAddress.String() + ":" + strconv.Itoa(int(tcpPacket.SourcePort))
 		if plci, plerr := context.RetrieveCachedExternalFlowPolicy(flowHash); plerr == nil {
 			plc := plci.(*policyPair)
-			d.releaseFlow(context, plc.report, plc.packet, tcpPacket)
+			d.releaseFlow(context, conn, plc.report, plc.packet, tcpPacket)
 			return plc.packet, nil, nil
 		}
 
@@ -670,7 +670,7 @@ func (d *Datapath) processNetworkSynAckPacket(context *pucontext.PUContext, conn
 		// Set the state to Data so the other state machines ignore subsequent packets
 		conn.SetState(connection.TCPData)
 
-		d.releaseFlow(context, report, pkt, tcpPacket)
+		d.releaseFlow(context, conn, report, pkt, tcpPacket)
 
 		return pkt, nil, nil
 	}
@@ -913,7 +913,7 @@ func (d *Datapath) appSynRetrieveState(p *packet.Packet) (*connection.TCPConnect
 	if conn, err := d.appOrigConnectionTracker.GetReset(p.L4FlowHash(), 0); err == nil {
 		return conn.(*connection.TCPConnection), nil
 	}
-	return connection.NewTCPConnection(context), nil
+	return connection.NewTCPConnection(context, p), nil
 }
 
 // appSynAckRetrieveState retrieves the state for application syn/ack packet.
@@ -965,7 +965,7 @@ func (d *Datapath) appRetrieveState(p *packet.Packet) (*connection.TCPConnection
 		if err != nil {
 			return nil, errors.New("No context in app processing")
 		}
-		conn = connection.NewTCPConnection(context)
+		conn = connection.NewTCPConnection(context, p)
 		conn.(*connection.TCPConnection).SetState(connection.UnknownState)
 		return conn.(*connection.TCPConnection), nil
 	}
@@ -1011,7 +1011,7 @@ func (d *Datapath) netSynRetrieveState(p *packet.Packet) (*connection.TCPConnect
 	if conn, err := d.netOrigConnectionTracker.GetReset(p.L4FlowHash(), 0); err == nil {
 		return conn.(*connection.TCPConnection), nil
 	}
-	return connection.NewTCPConnection(context), nil
+	return connection.NewTCPConnection(context, p), nil
 }
 
 // netSynAckRetrieveState retrieves the state for SynAck packets at the network
@@ -1059,7 +1059,7 @@ func (d *Datapath) netRetrieveState(p *packet.Packet) (*connection.TCPConnection
 		if cerr != nil {
 			return nil, errors.New("No context in app processing")
 		}
-		conn = connection.NewTCPConnection(context)
+		conn = connection.NewTCPConnection(context, p)
 		conn.(*connection.TCPConnection).SetState(connection.UnknownState)
 		return conn.(*connection.TCPConnection), nil
 	}
@@ -1079,7 +1079,7 @@ func updateTimer(c cache.DataStore, hash string, conn *connection.TCPConnection)
 }
 
 // releaseFlow releases the flow and updates the conntrack table
-func (d *Datapath) releaseFlow(context *pucontext.PUContext, report *policy.FlowPolicy, action *policy.FlowPolicy, tcpPacket *packet.Packet) {
+func (d *Datapath) releaseFlow(context *pucontext.PUContext, c *connection.TCPConnection, report *policy.FlowPolicy, action *policy.FlowPolicy, tcpPacket *packet.Packet) {
 
 	if err := d.appOrigConnectionTracker.Remove(tcpPacket.L4ReverseFlowHash()); err != nil {
 		zap.L().Debug("Failed to clean cache appOrigConnectionTracker", zap.Error(err))
@@ -1089,9 +1089,14 @@ func (d *Datapath) releaseFlow(context *pucontext.PUContext, report *policy.Flow
 		zap.L().Debug("Failed to clean cache sourcePortConnectionCache", zap.Error(err))
 	}
 
+	dst := tcpPacket.SourceAddress.String()
+	if o := c.GetOriginalDestination().String(); o != dst {
+		dst = o
+	}
+
 	if err := d.conntrackHdl.ConntrackTableUpdateMark(
 		tcpPacket.DestinationAddress.String(),
-		tcpPacket.SourceAddress.String(),
+		dst,
 		tcpPacket.IPProto,
 		tcpPacket.DestinationPort,
 		tcpPacket.SourcePort,

--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -4827,7 +4827,7 @@ func TestCollectTCPPacket(t *testing.T) {
 				SourceIP:      tcpPacket.SourceAddress.String(),
 			}
 			context, _ := enforcer.puFromContextID.Get(puInfo1.ContextID)
-			tcpConn := connection.NewTCPConnection(context.(*pucontext.PUContext))
+			tcpConn := connection.NewTCPConnection(context.(*pucontext.PUContext), nil)
 			mockCollector.EXPECT().CollectPacketEvent(PacketEventMatcher(&packetreport)).Times(1)
 			enforcer.collectTCPPacket(&debugpacketmessage{
 				Mark:    10,
@@ -4847,7 +4847,7 @@ func TestCollectTCPPacket(t *testing.T) {
 				SourceIP:      tcpPacket.SourceAddress.String(),
 			}
 			context, _ := enforcer.puFromContextID.Get(puInfo1.ContextID)
-			tcpConn := connection.NewTCPConnection(context.(*pucontext.PUContext))
+			tcpConn := connection.NewTCPConnection(context.(*pucontext.PUContext), nil)
 			mockCollector.EXPECT().CollectPacketEvent(PacketEventMatcher(&packetreport)).Times(0)
 			enforcer.collectTCPPacket(&debugpacketmessage{
 				Mark:    10,

--- a/controller/pkg/connection/connection.go
+++ b/controller/pkg/connection/connection.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -148,6 +149,9 @@ type TCPConnection struct {
 
 	// PacketFlowPolicy holds the last matched actual policy
 	PacketFlowPolicy *policy.FlowPolicy
+
+	// originalDestination is the original destination of the connection
+	originalDestination net.IP
 }
 
 // TCPConnectionExpirationNotifier handles processing the expiration of an element
@@ -213,19 +217,31 @@ func (c *TCPConnection) IsLoopbackConnection() bool {
 	return c.loopbackConnection
 }
 
+// GetOriginalDestination returns the original destination.
+func (c *TCPConnection) GetOriginalDestination() net.IP {
+	return c.originalDestination
+}
+
 // NewTCPConnection returns a TCPConnection information struct
-func NewTCPConnection(context *pucontext.PUContext) *TCPConnection {
+func NewTCPConnection(context *pucontext.PUContext, p *packet.Packet) *TCPConnection {
 
 	nonce, err := crypto.GenerateRandomBytes(16)
 	if err != nil {
 		return nil
 	}
+
+	var originalDestination net.IP
+	if p != nil {
+		originalDestination = p.DestinationAddress
+	}
+
 	return &TCPConnection{
 		state:   TCPSynSend,
 		Context: context,
 		Auth: AuthInfo{
 			LocalContext: nonce,
 		},
+		originalDestination: originalDestination,
 	}
 }
 


### PR DESCRIPTION
Fixes the connection release problem in conntrack for Linux services when there is a NAT on the output chain an return packets come back with a different source address.
