### PR TITLE
Return v4 addresses from custom dns lookup

### DIFF
--- a/controller/pkg/usertokens/oidc/oidc.go
+++ b/controller/pkg/usertokens/oidc/oidc.go
@@ -311,9 +311,12 @@ func resolveDNSMarked(ctx context.Context, addr string) (string, error) {
 		return "", fmt.Errorf("unable to resolve address %s: %s", addr, err)
 	}
 
-	if len(addresses) == 0 {
-		return "", fmt.Errorf("unable to resolve to a valid address for address %s", addr)
+	for _, saddr := range addresses {
+		addr := net.ParseIP(saddr)
+		if addr != nil && addr.To4() != nil {
+			return saddr + ":" + port, nil
+		}
 	}
 
-	return addresses[0] + ":" + port, nil
+	return "", fmt.Errorf("unable to resolve to a valid address for address %s", addr)
 }


### PR DESCRIPTION
For the time being limit the outgoing calls to v4 addresses only.
