### PR TITLE
Remove flow release on synack that was creating netlink errors

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -69,10 +69,6 @@ func (d *Datapath) processNetworkTCPPackets(p *packet.Packet) (conn *connection.
 	case packet.TCPSynAckMask:
 		conn, err = d.netSynAckRetrieveState(p)
 		if err != nil {
-			// This packet belongs to the client process that is not being enforcerd.
-			// At this point, we can release this flow to kernel as we are not interested in
-			// enforcing policy for the flow.
-			d.releaseUnmonitoredFlow(p)
 			return conn, nil
 		}
 
@@ -1116,6 +1112,6 @@ func (d *Datapath) releaseUnmonitoredFlow(tcpPacket *packet.Packet) {
 		tcpPacket.SourcePort,
 		constants.DefaultConnMark,
 	); err != nil {
-		zap.L().Error("Failed to update conntrack table", zap.Error(err))
+		zap.L().Error("Failed to update conntrack table for unmonitored flow", zap.Error(err))
 	}
 }


### PR DESCRIPTION
The release was creating netlink errors for host to container communication. This needs to be fixed.