### PR TITLE
Kill the remotes on unenforce

### DIFF
--- a/controller/internal/enforcer/proxy/enforcerproxy.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy.go
@@ -101,11 +101,10 @@ func (s *ProxyInfo) Unenforce(contextID string) error {
 	}
 
 	if err := s.rpchdl.RemoteCall(contextID, remoteenforcer.Unenforce, request, &rpcwrapper.Response{}); err != nil {
-		s.prochdl.KillRemoteEnforcer(contextID, true) // nolint errcheck
-		return fmt.Errorf("failed to send message to remote enforcer: %s", err)
+		zap.L().Error("failed to send message to remote enforcer", zap.Error(err))
 	}
 
-	return nil
+	return s.prochdl.KillRemoteEnforcer(contextID, true)
 }
 
 // UpdateSecrets updates the secrets used for signing communication between trireme instances

--- a/controller/internal/enforcer/proxy/enforcerproxy_test.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy_test.go
@@ -246,6 +246,7 @@ func TestUnenforce(t *testing.T) {
 
 		Convey("When I try to call unenforce", func() {
 			rpchdl.EXPECT().RemoteCall("testServerID", remoteenforcer.Unenforce, gomock.Any(), gomock.Any()).Times(1).Return(nil)
+			prochdl.EXPECT().KillRemoteEnforcer("testServerID", true)
 			err := e.Unenforce("testServerID")
 			So(err, ShouldBeNil)
 		})
@@ -255,8 +256,8 @@ func TestUnenforce(t *testing.T) {
 			prochdl.EXPECT().KillRemoteEnforcer("testServerID", true)
 			err := e.Unenforce("testServerID")
 
-			Convey("Then I should get an error", func() {
-				So(err, ShouldNotBeNil)
+			Convey("Then I should not get an error", func() {
+				So(err, ShouldBeNil)
 			})
 		})
 	})


### PR DESCRIPTION
The remotes were not killed after an unenforce command.