### PR TITLE
Fix the syn logic for uknown syn packets

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -1021,7 +1021,8 @@ func (d *Datapath) netSynRetrieveState(p *packet.Packet) (*connection.TCPConnect
 
 		return nil, errNonPUTraffic
 	}
-	return connection.NewTCPConnection(context, p), nil
+
+	return nil, errInvalidNetState
 }
 
 // netSynAckRetrieveState retrieves the state for SynAck packets at the network


### PR DESCRIPTION
Syn packets with no context must be dropped.