### PR TITLE
Fix load lock

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -125,11 +125,7 @@ func (t *trireme) UnEnforce(ctx context.Context, puID string, policy *policy.PUP
 
 // UpdatePolicy updates a policy for an already activated PU. The PU is identified by the contextID
 func (t *trireme) UpdatePolicy(ctx context.Context, puID string, plc *policy.PUPolicy, runtime *policy.PURuntime) error {
-	lock, ok := t.locks.Load(puID)
-	if !ok {
-		return nil
-	}
-
+	lock, _ := t.locks.LoadOrStore(puID, &sync.Mutex{})
 	lock.(*sync.Mutex).Lock()
 	defer lock.(*sync.Mutex).Unlock()
 	return t.doUpdatePolicy(puID, plc, runtime)

--- a/controller/pkg/cleaner/cleaner.go
+++ b/controller/pkg/cleaner/cleaner.go
@@ -1,0 +1,21 @@
+package cleaner
+
+import (
+	"fmt"
+
+	"go.aporeto.io/trireme-lib/controller/constants"
+	"go.aporeto.io/trireme-lib/controller/internal/supervisor/iptablesctrl"
+	"go.aporeto.io/trireme-lib/controller/pkg/fqconfig"
+	"go.aporeto.io/trireme-lib/controller/runtime"
+)
+
+// CleanAllTriremeACLs cleans up all previous Trireme ACLs. It can be called from
+// other packages for housekeeping.
+func CleanAllTriremeACLs() error {
+	ipt, err := iptablesctrl.NewInstance(fqconfig.NewFilterQueueWithDefaults(), constants.LocalServer, &runtime.Configuration{})
+	if err != nil {
+		return fmt.Errorf("unable to initialize cleaning iptables controller:  %s", err)
+	}
+
+	return ipt.CleanUp()
+}


### PR DESCRIPTION
Fixes the load of a lock with update events. It is possible to receive an update event without first receiving an enforce event because the policy engine fails. In this case we should be able to recover.