### PR TITLE
Make ssh ACLs go in the PID chain

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/templates.go
+++ b/controller/internal/supervisor/iptablesctrl/templates.go
@@ -156,7 +156,7 @@ func (i *Instance) newACLInfo(version int, contextID string, p *policy.PUInfo, p
 	appSection := ""
 	netSection := ""
 	switch puType {
-	case common.LinuxProcessPU:
+	case common.LinuxProcessPU, common.SSHSessionPU:
 		appSection = TriremeOutput
 		netSection = TriremeInput
 	case common.HostNetworkPU:


### PR DESCRIPTION
Since SSH PU chains are like Linux processes we are moving them to the Pid chain . The host chain is always last and it will get any packets that do not match any other chain.