### PR TITLE
Ignore target nets when checking for ACL matching

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -65,7 +65,8 @@ type Datapath struct {
 	nflogger       nflog.NFLogger
 	procMountPoint string
 
-	targetNetworks *acls.ACLCache
+	targetNetworks    *acls.ACLCache
+	targetNetworksSet bool
 	// Internal structures and caches
 	// Key=ContextId Value=puContext
 	puFromContextID cache.DataStore
@@ -452,7 +453,10 @@ func (d *Datapath) SetTargetNetworks(cfg *runtime.Configuration) error {
 	networks := cfg.TCPTargetNetworks
 
 	if len(networks) == 0 {
+		d.targetNetworksSet = false
 		networks = []string{"0.0.0.0/1", "128.0.0.0/1"}
+	} else {
+		d.targetNetworksSet = true
 	}
 
 	d.targetNetworks = acls.NewACLCache()

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -641,7 +641,7 @@ func (d *Datapath) processNetworkSynAckPacket(context *pucontext.PUContext, conn
 	// Packets with no authorization are processed as external services based on the ACLS
 	if err = tcpPacket.CheckTCPAuthenticationOption(enforcerconstants.TCPAuthenticationOptionBaseLen); err != nil {
 
-		if _, _, err := d.targetNetworks.GetMatchingAction(tcpPacket.DestinationAddress(), tcpPacket.DestPort()); err == nil && d.targetNetworksSet {
+		if _, _, err := d.targetNetworks.GetMatchingAction(tcpPacket.SourceAddress(), tcpPacket.SourcePort()); err == nil && d.targetNetworksSet {
 			return nil, nil, fmt.Errorf("SYNACK received from target networks-drop")
 		}
 


### PR DESCRIPTION
When external ACLs are processed, if the targets match the target networks then we always require authorization.

So, if a SynAck arrives from a network that matches a target network and the SynAck does not have authorization information, then it is dropped. We consider that target networks take priority over 0.0.0.0/0 type of ACLs.