### PR TITLE
Fix logging bug in nfq_linux

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@ required = ["github.com/docker/distribution"]
 
 [[constraint]]
   name = "go.aporeto.io/netlink-go"
-  branch = "master"
+  branch = "setVerdictFix"
 
 [[constraint]]
   name = "github.com/hashicorp/go-version"

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -242,7 +242,10 @@ func (t *trireme) doUpdatePolicy(contextID string, newPolicy *policy.PUPolicy, r
 	if !mustEnforce(contextID, containerInfo) {
 		return nil
 	}
-
+	zap.L().Error("Updating policy",
+		zap.String("contextID", contextID),
+		zap.String("policyID", newPolicy.ManagementID()),
+	)
 	if err := t.enforcers[t.puTypeToEnforcerType[containerInfo.Runtime.PUType()]].Enforce(contextID, containerInfo); err != nil {
 		//We lost communication with the remote and killed it lets restart it here by feeding a create event in the request channel
 		if werr := t.supervisors[t.puTypeToEnforcerType[containerInfo.Runtime.PUType()]].Unsupervise(contextID); werr != nil {

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -291,7 +291,6 @@ func NewWithDefaults(
 	}
 
 	puFromContextID := cache.NewCache("puFromContextID")
-
 	e := New(
 		defaultMutualAuthorization,
 		defaultFQConfig,
@@ -308,7 +307,6 @@ func NewWithDefaults(
 		puFromContextID,
 		&runtime.Configuration{TCPTargetNetworks: targetNetworks},
 	)
-
 	conntrackClient, err := flowtracking.NewClient(context.Background())
 	if err != nil {
 		return nil

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -380,6 +380,7 @@ func (d *Datapath) Enforce(contextID string, puInfo *policy.PUInfo) error {
 	zap.L().Error("Updated policy",
 		zap.String("contextID", puInfo.ContextID),
 		zap.String("policyID", puInfo.Policy.ManagementID()),
+		zap.Time("Log Time", time.Now()),
 	)
 	// Cache PU from contextID for management and policy updates
 	d.puFromContextID.AddOrUpdate(contextID, pu)

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -377,6 +377,10 @@ func (d *Datapath) Enforce(contextID string, puInfo *policy.PUInfo) error {
 		prevPU.(*pucontext.PUContext).CancelFunc()
 	}
 
+	zap.L().Error("Updated policy",
+		zap.String("contextID", puInfo.ContextID),
+		zap.String("policyID", puInfo.Policy.ManagementID()),
+	)
 	// Cache PU from contextID for management and policy updates
 	d.puFromContextID.AddOrUpdate(contextID, pu)
 

--- a/controller/internal/enforcer/nfqdatapath/nfq_linux.go
+++ b/controller/internal/enforcer/nfqdatapath/nfq_linux.go
@@ -20,6 +20,7 @@ import (
 func errorCallback(err error, _ interface{}) {
 	zap.L().Error("Error while processing packets on queue", zap.Error(err))
 }
+
 func networkCallback(packet *nfqueue.NFPacket, d interface{}) {
 	d.(*Datapath).processNetworkPacketsFromNFQ(packet)
 }
@@ -106,7 +107,7 @@ func (d *Datapath) processNetworkPacketsFromNFQ(p *nfqueue.NFPacket) {
 		)
 		length := uint32(len(p.Buffer))
 		buffer := p.Buffer
-		p.QueueHandle.SetVerdict2(uint32(p.QueueHandle.QueueNum), 0, uint32(p.Mark), length, uint32(p.ID), buffer)
+		p.QueueHandle.SetVerdict2(0, uint32(p.Mark), length, uint32(p.ID), buffer)
 		if netPacket.IPProto() == packet.IPProtocolTCP {
 			d.collectTCPPacket(&debugpacketmessage{
 				Mark:    p.Mark,
@@ -137,9 +138,9 @@ func (d *Datapath) processNetworkPacketsFromNFQ(p *nfqueue.NFPacket) {
 		copyIndex += copy(buffer[copyIndex:], netPacket.GetTCPOptions())
 		copyIndex += copy(buffer[copyIndex:], netPacket.GetTCPData())
 
-		p.QueueHandle.SetVerdict2(uint32(p.QueueHandle.QueueNum), 1, uint32(p.Mark), uint32(copyIndex), uint32(p.ID), buffer)
+		p.QueueHandle.SetVerdict2(1, uint32(p.Mark), uint32(copyIndex), uint32(p.ID), buffer)
 	} else {
-		p.QueueHandle.SetVerdict2(uint32(p.QueueHandle.QueueNum), 1, uint32(p.Mark), uint32(len(netPacket.GetBuffer(0))), uint32(p.ID), netPacket.GetBuffer(0))
+		p.QueueHandle.SetVerdict2(1, uint32(p.Mark), uint32(len(netPacket.GetBuffer(0))), uint32(p.ID), netPacket.GetBuffer(0))
 	}
 	if netPacket.IPProto() == packet.IPProtocolTCP {
 		d.collectTCPPacket(&debugpacketmessage{
@@ -198,7 +199,7 @@ func (d *Datapath) processApplicationPacketsFromNFQ(p *nfqueue.NFPacket) {
 		)
 		length := uint32(len(p.Buffer))
 		buffer := p.Buffer
-		p.QueueHandle.SetVerdict2(uint32(p.QueueHandle.QueueNum), 0, uint32(p.Mark), length, uint32(p.ID), buffer)
+		p.QueueHandle.SetVerdict2(0, uint32(p.Mark), length, uint32(p.ID), buffer)
 		if appPacket.IPProto() == packet.IPProtocolTCP {
 
 			d.collectTCPPacket(&debugpacketmessage{
@@ -229,10 +230,10 @@ func (d *Datapath) processApplicationPacketsFromNFQ(p *nfqueue.NFPacket) {
 		copyIndex += copy(buffer[copyIndex:], appPacket.GetTCPOptions())
 		copyIndex += copy(buffer[copyIndex:], appPacket.GetTCPData())
 
-		p.QueueHandle.SetVerdict2(uint32(p.QueueHandle.QueueNum), 1, uint32(p.Mark), uint32(copyIndex), uint32(p.ID), buffer)
+		p.QueueHandle.SetVerdict2(1, uint32(p.Mark), uint32(copyIndex), uint32(p.ID), buffer)
 
 	} else {
-		p.QueueHandle.SetVerdict2(uint32(p.QueueHandle.QueueNum), 1, uint32(p.Mark), uint32(len(appPacket.GetBuffer(0))), uint32(p.ID), appPacket.GetBuffer(0))
+		p.QueueHandle.SetVerdict2(1, uint32(p.Mark), uint32(len(appPacket.GetBuffer(0))), uint32(p.ID), appPacket.GetBuffer(0))
 	}
 	if appPacket.IPProto() == packet.IPProtocolTCP {
 		d.collectTCPPacket(&debugpacketmessage{

--- a/controller/internal/enforcer/nfqdatapath/nfq_linux.go
+++ b/controller/internal/enforcer/nfqdatapath/nfq_linux.go
@@ -97,7 +97,7 @@ func (d *Datapath) processNetworkPacketsFromNFQ(p *nfqueue.NFPacket) {
 	}
 
 	if err != nil {
-		zap.L().Debug("Dropping packet on network path",
+		zap.L().Error("Dropping packet on network path",
 			zap.Error(err),
 			zap.String("SourceIP", netPacket.SourceAddress().String()),
 			zap.String("DestiatnionIP", netPacket.DestinationAddress().String()),

--- a/controller/internal/enforcer/nfqdatapath/nfq_linux.go
+++ b/controller/internal/enforcer/nfqdatapath/nfq_linux.go
@@ -104,6 +104,7 @@ func (d *Datapath) processNetworkPacketsFromNFQ(p *nfqueue.NFPacket) {
 			zap.Int("SourcePort", int(netPacket.SourcePort())),
 			zap.Int("DestinationPort", int(netPacket.DestPort())),
 			zap.Int("Protocol", int(netPacket.IPProto())),
+			zap.String("Timestamp", time.Now().String()),
 		)
 		length := uint32(len(p.Buffer))
 		buffer := p.Buffer

--- a/controller/internal/enforcer/nfqdatapath/nfq_linux_test.go
+++ b/controller/internal/enforcer/nfqdatapath/nfq_linux_test.go
@@ -1,0 +1,115 @@
+// +build linux
+
+package nfqdatapath
+
+import (
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+	nfqueue "go.aporeto.io/netlink-go/nfqueue"
+	"go.aporeto.io/trireme-lib/collector"
+	"go.aporeto.io/trireme-lib/controller/constants"
+	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
+	"go.aporeto.io/trireme-lib/controller/pkg/claimsheader"
+	"go.aporeto.io/trireme-lib/controller/pkg/secrets"
+)
+
+// Go libraries
+
+type nothing struct {
+	verdict int
+}
+
+func (n *nothing) SetVerdict2(verdict uint32, mark uint32, packetLen uint32, packetID uint32, packet []byte) {
+	n.verdict = 1
+}
+
+func createDatapath() *Datapath {
+	secret, _ := secrets.NewCompactPKI([]byte(secrets.PrivateKeyPEM), []byte(secrets.PublicPEM), []byte(secrets.CAPEM), secrets.CreateTxtToken(), claimsheader.CompressionTypeNone)
+	collector := &collector.DefaultCollector{}
+	// mock the call
+	prevRawSocket := GetUDPRawSocket
+	defer func() {
+		GetUDPRawSocket = prevRawSocket
+	}()
+	GetUDPRawSocket = func(mark int, device string) (afinetrawsocket.SocketWriter, error) {
+		return nil, nil
+	}
+	enforcer := NewWithDefaults(testServerID, collector, nil, secret, constants.LocalServer, "/proc", []string{"0.0.0.0/0"})
+
+	return enforcer
+}
+
+func TestNFQApplicationPathCorrectPkt(t *testing.T) {
+	n := &nothing{}
+	datapath := createDatapath()
+
+	// SYN packet captured from 'telnet localhost 99'.
+	// Everything is correct.
+	buffer := []byte{0x45, 0x10, 0x00, 0x3c, 0xec, 0x6c, 0x40, 0x00, 0x40, 0x06, 0x50,
+		0x3d, 0x7f, 0x00, 0x00, 0x01, 0x7f, 0x00, 0x00, 0x01, 0x8c, 0x80, 0x00, 0x63, 0x2c, 0x32,
+		0xa8, 0xd6, 0x00, 0x00, 0x00, 0x00, 0xa0, 0x02, 0xaa, 0xaa, 0xfe, 0x88, 0x00, 0x00, 0x02,
+		0x04, 0xff, 0xd7, 0x04, 0x02, 0x08, 0x0a, 0xff, 0xff, 0x44, 0xba, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x03, 0x03, 0x07}
+
+	packet := &nfqueue.NFPacket{
+		Buffer:      buffer,
+		QueueHandle: n,
+	}
+
+	datapath.processApplicationPacketsFromNFQ(packet)
+	assert.Equal(t, n.verdict, 1)
+}
+
+func TestNFQApplicationPathCorruptPkt(t *testing.T) {
+	n := &nothing{}
+	datapath := createDatapath()
+
+	// Corrupt packet: less than min ipv4 packet
+	buffer := []byte{0x45, 0x10, 0x00, 0x3c, 0xec, 0x6c, 0x40, 0x00, 0x40, 0x06, 0x50}
+
+	packet := &nfqueue.NFPacket{
+		Buffer:      buffer,
+		QueueHandle: n,
+	}
+
+	datapath.processApplicationPacketsFromNFQ(packet)
+	assert.Equal(t, n.verdict, 0)
+}
+
+func TestNFQNetworkPathCorrectPkt(t *testing.T) {
+	n := &nothing{}
+	datapath := createDatapath()
+
+	// SYN packet captured from 'telnet localhost 99'.
+	// Everything is correct.
+	buffer := []byte{0x45, 0x10, 0x00, 0x3c, 0xec, 0x6c, 0x40, 0x00, 0x40, 0x06, 0x50,
+		0x3d, 0x7f, 0x00, 0x00, 0x01, 0x7f, 0x00, 0x00, 0x01, 0x8c, 0x80, 0x00, 0x63, 0x2c, 0x32,
+		0xa8, 0xd6, 0x00, 0x00, 0x00, 0x00, 0xa0, 0x02, 0xaa, 0xaa, 0xfe, 0x88, 0x00, 0x00, 0x02,
+		0x04, 0xff, 0xd7, 0x04, 0x02, 0x08, 0x0a, 0xff, 0xff, 0x44, 0xba, 0x00, 0x00, 0x00, 0x00,
+		0x01, 0x03, 0x03, 0x07}
+
+	packet := &nfqueue.NFPacket{
+		Buffer:      buffer,
+		QueueHandle: n,
+	}
+
+	datapath.processNetworkPacketsFromNFQ(packet)
+	assert.Equal(t, n.verdict, 1)
+}
+
+func TestNFQNetworkPathCorruptPkt(t *testing.T) {
+	n := &nothing{}
+	datapath := createDatapath()
+
+	// Corrupt packet: less than min ipv4 packet
+	buffer := []byte{0x45, 0x10, 0x00, 0x3c, 0xec, 0x6c, 0x40, 0x00, 0x40, 0x06, 0x50}
+
+	packet := &nfqueue.NFPacket{
+		Buffer:      buffer,
+		QueueHandle: n,
+	}
+
+	datapath.processNetworkPacketsFromNFQ(packet)
+	assert.Equal(t, n.verdict, 0)
+}


### PR DESCRIPTION
This PR fixes the following issues:

1) First if the packet creation fails the logging later will panic as it accesses the packet field.
2) The actual reason of the packet drop from the above layers is not logged.
3) Add debug Log in the application path also if the packet is dropped.