### PR TITLE
new: management namespace

### DIFF
--- a/collector/default.go
+++ b/collector/default.go
@@ -58,7 +58,7 @@ func StatsUserHash(r *UserRecord) error {
 			continue
 		}
 		if _, err := hash.Write([]byte(r.Claims[i])); err != nil {
-			return fmt.Errorf("Cannot create hash")
+			return fmt.Errorf("unable to create hash: %v", err)
 		}
 	}
 	r.ID = fmt.Sprintf("%d", hash.Sum64())

--- a/collector/default.go
+++ b/collector/default.go
@@ -48,7 +48,7 @@ func StatsFlowHash(r *FlowRecord) string {
 	return fmt.Sprintf("%d", hash.Sum64())
 }
 
-// StatsUserHash is a hash function to hash user records
+// StatsUserHash is a hash function to hash user records.
 func StatsUserHash(r *UserRecord) error {
 	// Order matters for the hash function loop
 	sort.Strings(r.Claims)
@@ -61,7 +61,24 @@ func StatsUserHash(r *UserRecord) error {
 			return fmt.Errorf("unable to create hash: %v", err)
 		}
 	}
-	r.ID = fmt.Sprintf("%d", hash.Sum64())
+
+	hashWithNS, err := HashHashWithNamespace(fmt.Sprintf("%d", hash.Sum64()), r.Namespace)
+	if err != nil {
+		return err
+	}
+
+	r.ID = hashWithNS
 
 	return nil
+}
+
+// HashHashWithNamespace hash the given claim hash with the given namespace.
+func HashHashWithNamespace(claimsHash string, namespace string) (string, error) {
+
+	hash := xxhash.New()
+	if _, err := hash.Write(append([]byte(claimsHash), []byte(namespace)...)); err != nil {
+		return "", fmt.Errorf("unable to create namespace hash: %v", err)
+	}
+
+	return fmt.Sprintf("%d", hash.Sum64()), nil
 }

--- a/collector/interfaces.go
+++ b/collector/interfaces.go
@@ -133,6 +133,7 @@ type EndPoint struct {
 // FlowRecord describes a flow record for statistis
 type FlowRecord struct {
 	ContextID        string
+	Namespace        string
 	Source           *EndPoint
 	Destination      *EndPoint
 	Tags             *policy.TagStore
@@ -148,8 +149,9 @@ type FlowRecord struct {
 }
 
 func (f *FlowRecord) String() string {
-	return fmt.Sprintf("<flowrecord contextID:%s count:%d sourceID:%s destinationID:%s sourceIP: %s destinationIP:%s destinationPort:%d action:%s mode:%s>",
+	return fmt.Sprintf("<flowrecord contextID:%s namespace:%s count:%d sourceID:%s destinationID:%s sourceIP: %s destinationIP:%s destinationPort:%d action:%s mode:%s>",
 		f.ContextID,
+		f.Namespace,
 		f.Count,
 		f.Source.ID,
 		f.Destination.ID,
@@ -172,8 +174,9 @@ type ContainerRecord struct {
 // UserRecord reports a new user access. These will be reported
 // periodically.
 type UserRecord struct {
-	ID     string
-	Claims []string
+	ID        string
+	Namespace string
+	Claims    []string
 }
 
 // PacketReport is the struct which is used to report packets captured in datapath

--- a/controller/internal/enforcer/applicationproxy/http/state.go
+++ b/controller/internal/enforcer/applicationproxy/http/state.go
@@ -52,6 +52,7 @@ func newAppConnectionState(nativeID, serviceID string, p *pucontext.PUContext, r
 			ServiceType: policy.ServiceHTTP,
 			ServiceID:   serviceID,
 			Tags:        p.Annotations(),
+			Namespace:   p.ManagementNamespace(),
 			PolicyID:    "default",
 			Count:       1,
 		},
@@ -83,6 +84,7 @@ func newNetworkConnectionState(nativeID string, pctx *serviceregistry.PortContex
 			PolicyID:    "default",
 			ServiceID:   pctx.Service.ID,
 			Tags:        pctx.PUContext.Annotations(),
+			Namespace:   pctx.PUContext.ManagementNamespace(),
 			Count:       1,
 		},
 	}

--- a/controller/internal/enforcer/applicationproxy/serviceregistry/serviceregistry_test.go
+++ b/controller/internal/enforcer/applicationproxy/serviceregistry/serviceregistry_test.go
@@ -103,6 +103,7 @@ func newPU(name string, exposedPort, publicPort, privatePort, dependentPort uint
 	}
 	plc := policy.NewPUPolicy(
 		name+"-policyid1",
+		"/ns1",
 		policy.Police,
 		policy.IPRuleList{},
 		policy.IPRuleList{},
@@ -118,7 +119,7 @@ func newPU(name string, exposedPort, publicPort, privatePort, dependentPort uint
 		[]string{},
 	)
 
-	puInfo := policy.NewPUInfo(name, triremecommon.ContainerPU)
+	puInfo := policy.NewPUInfo(name, "/ns1", triremecommon.ContainerPU)
 	puInfo.Policy = plc
 	pctx, err := pucontext.NewPU(name, puInfo, time.Second*1000)
 	So(err, ShouldBeNil)

--- a/controller/internal/enforcer/applicationproxy/tcp/tcp.go
+++ b/controller/internal/enforcer/applicationproxy/tcp/tcp.go
@@ -517,6 +517,7 @@ func (p *Proxy) reportFlow(flowproperties *proxyFlowProperties, sourceID string,
 		L4Protocol:  packet.IPProtocolTCP,
 		ServiceType: policy.ServiceTCP,
 		ServiceID:   flowproperties.ServiceID,
+		Namespace:   context.ManagementNamespace(),
 	}
 
 	if report.ObserveAction.Observed() {

--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -502,7 +502,7 @@ func (d *Datapath) CleanUp() error {
 	return nil
 }
 
-func (d *Datapath) puInfoDelegate(contextID string) (ID string, tags *policy.TagStore) {
+func (d *Datapath) puInfoDelegate(contextID string) (ID string, namespace string, tags *policy.TagStore) {
 
 	item, err := d.puFromContextID.Get(contextID)
 	if err != nil {
@@ -512,6 +512,7 @@ func (d *Datapath) puInfoDelegate(contextID string) (ID string, tags *policy.Tag
 	ctx := item.(*pucontext.PUContext)
 
 	ID = ctx.ManagementID()
+	namespace = ctx.ManagementNamespace()
 	tags = ctx.Annotations().Copy()
 
 	return
@@ -528,6 +529,7 @@ func (d *Datapath) reportFlow(p *packet.Packet, src, dst *collector.EndPoint, co
 		DropReason:  mode,
 		PolicyID:    actual.PolicyID,
 		L4Protocol:  p.IPProto(),
+		Namespace:   context.ManagementNamespace(),
 		Count:       1,
 	}
 

--- a/controller/internal/enforcer/nfqdatapath/datapath_test.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_test.go
@@ -70,7 +70,7 @@ func setupProcessingUnitsInDatapathAndEnforce(collectors *mockcollector.MockEven
 	serverID := testServerID
 
 	// Create ProcessingUnit 1
-	puInfo1 = policy.NewPUInfo(puID1, common.ContainerPU)
+	puInfo1 = policy.NewPUInfo(puID1, "/ns1", common.ContainerPU)
 
 	ip1 := policy.ExtendedMap{}
 	ip1["bridge"] = puIP1
@@ -81,7 +81,7 @@ func setupProcessingUnitsInDatapathAndEnforce(collectors *mockcollector.MockEven
 	puInfo1.Policy.AddReceiverRules(tagSelector)
 
 	// Create processing unit 2
-	puInfo2 = policy.NewPUInfo(puID2, common.ContainerPU)
+	puInfo2 = policy.NewPUInfo(puID2, "/ns2", common.ContainerPU)
 
 	ip2 := policy.ExtendedMap{"bridge": puIP2}
 	puInfo2.Runtime.SetIPAddresses(ip2)
@@ -178,7 +178,7 @@ func TestEnforcerExternalNetworks(t *testing.T) {
 			}}
 
 			contextID := "123456"
-			puInfo := policy.NewPUInfo(contextID, common.LinuxProcessPU)
+			puInfo := policy.NewPUInfo(contextID, "/ns1", common.LinuxProcessPU)
 			context, err := pucontext.NewPU(contextID, puInfo, 10*time.Second)
 			So(err, ShouldBeNil)
 			enforcer.puFromContextID.AddOrUpdate(contextID, context)
@@ -249,7 +249,7 @@ func TestInvalidIPContext(t *testing.T) {
 
 		secret, err := secrets.NewCompactPKI([]byte(secrets.PrivateKeyPEM), []byte(secrets.PublicPEM), []byte(secrets.CAPEM), secrets.CreateTxtToken(), claimsheader.CompressionTypeNone)
 		So(err, ShouldBeNil)
-		puInfo := policy.NewPUInfo("SomeProcessingUnitId", common.LinuxProcessPU)
+		puInfo := policy.NewPUInfo("SomeProcessingUnitId", "/ns2", common.LinuxProcessPU)
 		collector := &collector.DefaultCollector{}
 
 		// mock the call
@@ -355,7 +355,7 @@ func TestInvalidTokenContext(t *testing.T) {
 
 		secret, err := secrets.NewCompactPKI([]byte(secrets.PrivateKeyPEM), []byte(secrets.PublicPEM), []byte(secrets.CAPEM), secrets.CreateTxtToken(), claimsheader.CompressionTypeNone)
 		So(err, ShouldBeNil)
-		puInfo := policy.NewPUInfo("SomeProcessingUnitId", common.LinuxProcessPU)
+		puInfo := policy.NewPUInfo("SomeProcessingUnitId", "/ns2", common.LinuxProcessPU)
 
 		PacketFlow := packetgen.NewTemplateFlow()
 		_, err = PacketFlow.GenerateTCPFlow(packetgen.PacketFlowTypeGoodFlowTemplate)
@@ -1260,7 +1260,7 @@ func TestCacheState(t *testing.T) {
 		enforcer.packetLogs = true
 		contextID := "123"
 
-		puInfo := policy.NewPUInfo(contextID, common.ContainerPU)
+		puInfo := policy.NewPUInfo(contextID, "/ns1", common.ContainerPU)
 
 		// Should fail: Not in cache
 		err = enforcer.Unenforce(contextID)
@@ -1319,7 +1319,7 @@ func TestDoCreatePU(t *testing.T) {
 		enforcer.packetLogs = true
 		enforcer.mode = constants.LocalServer
 		contextID := "124"
-		puInfo := policy.NewPUInfo(contextID, common.LinuxProcessPU)
+		puInfo := policy.NewPUInfo(contextID, "/ns1", common.LinuxProcessPU)
 
 		spec, _ := portspec.NewPortSpecFromString("80", nil)
 		puInfo.Runtime.SetOptions(policy.OptionsType{
@@ -1365,7 +1365,7 @@ func TestDoCreatePU(t *testing.T) {
 		enforcer.packetLogs = true
 		enforcer.mode = constants.LocalServer
 		contextID := "125"
-		puInfo := policy.NewPUInfo(contextID, common.LinuxProcessPU)
+		puInfo := policy.NewPUInfo(contextID, "/ns1", common.LinuxProcessPU)
 
 		Convey("When I create a new PU without ports or mark", func() {
 			err := enforcer.Enforce(contextID, puInfo)
@@ -1398,7 +1398,7 @@ func TestDoCreatePU(t *testing.T) {
 		enforcer.mode = constants.RemoteContainer
 
 		contextID := "126"
-		puInfo := policy.NewPUInfo(contextID, common.ContainerPU)
+		puInfo := policy.NewPUInfo(contextID, "/ns1", common.ContainerPU)
 
 		Convey("When I create a new PU without an IP", func() {
 			err := enforcer.Enforce(contextID, puInfo)
@@ -1430,7 +1430,7 @@ func TestContextFromIP(t *testing.T) {
 		enforcer := NewWithDefaults(testServerID, collector, nil, secret, constants.RemoteContainer, "/proc", []string{"0.0.0.0/0"})
 		enforcer.packetLogs = true
 
-		puInfo := policy.NewPUInfo("SomePU", common.ContainerPU)
+		puInfo := policy.NewPUInfo("SomePU", "/ns", common.ContainerPU)
 
 		context, err := pucontext.NewPU("SomePU", puInfo, 10*time.Second)
 		contextID := "AporetoContext"
@@ -3486,7 +3486,7 @@ func TestFlowReportingUptoValidSynAck(t *testing.T) {
 
 							if PacketFlow.GetNthPacket(i).GetTCPSyn() && PacketFlow.GetNthPacket(i).GetTCPAck() {
 								contextID := "123456"
-								puInfo := policy.NewPUInfo(contextID, common.LinuxProcessPU)
+								puInfo := policy.NewPUInfo(contextID, "/ns1", common.LinuxProcessPU)
 								context, err := pucontext.NewPU(contextID, puInfo, 10*time.Second)
 								So(err, ShouldBeNil)
 								enforcer.puFromContextID.AddOrUpdate(contextID, context)
@@ -4312,7 +4312,7 @@ func TestPacketsWithInvalidTags(t *testing.T) {
 			serverID := testServerID
 
 			// Create ProcessingUnit 1
-			puInfo1 := policy.NewPUInfo(puID1, common.ContainerPU)
+			puInfo1 := policy.NewPUInfo(puID1, "/ns1", common.ContainerPU)
 
 			ip1 := policy.ExtendedMap{}
 			ip1["bridge"] = puIP1
@@ -4323,7 +4323,7 @@ func TestPacketsWithInvalidTags(t *testing.T) {
 			puInfo1.Policy.AddReceiverRules(tagSelector)
 
 			// Create processing unit 2
-			puInfo2 := policy.NewPUInfo(puID2, common.ContainerPU)
+			puInfo2 := policy.NewPUInfo(puID2, "/ns2", common.ContainerPU)
 			ip2 := policy.ExtendedMap{"bridge": puIP2}
 			puInfo2.Runtime.SetIPAddresses(ip2)
 			ipl2 := policy.ExtendedMap{policy.DefaultNamespace: puIP2}
@@ -4444,7 +4444,7 @@ func TestForPacketsWithRandomFlags(t *testing.T) {
 						serverID := testServerID
 
 						// Create ProcessingUnit 1
-						puInfo1 = policy.NewPUInfo(puID1, common.ContainerPU)
+						puInfo1 = policy.NewPUInfo(puID1, "/ns1", common.ContainerPU)
 
 						ip1 := policy.ExtendedMap{}
 						ip1["bridge"] = puIP1
@@ -4455,7 +4455,7 @@ func TestForPacketsWithRandomFlags(t *testing.T) {
 						puInfo1.Policy.AddReceiverRules(tagSelector)
 
 						// Create processing unit 2
-						puInfo2 = policy.NewPUInfo(puID2, common.ContainerPU)
+						puInfo2 = policy.NewPUInfo(puID2, "/ns2", common.ContainerPU)
 						ip2 := policy.ExtendedMap{"bridge": puIP2}
 						puInfo2.Runtime.SetIPAddresses(ip2)
 						ipl2 := policy.ExtendedMap{policy.DefaultNamespace: puIP2}
@@ -4506,7 +4506,7 @@ func TestForPacketsWithRandomFlags(t *testing.T) {
 						serverID := testServerID
 
 						// Create ProcessingUnit 1
-						puInfo1 = policy.NewPUInfo(puID1, common.ContainerPU)
+						puInfo1 = policy.NewPUInfo(puID1, "/ns1", common.ContainerPU)
 
 						ip1 := policy.ExtendedMap{}
 						ip1["bridge"] = puIP1
@@ -4517,7 +4517,7 @@ func TestForPacketsWithRandomFlags(t *testing.T) {
 						puInfo1.Policy.AddReceiverRules(tagSelector)
 
 						// Create processing unit 2
-						puInfo2 = policy.NewPUInfo(puID2, common.ContainerPU)
+						puInfo2 = policy.NewPUInfo(puID2, "/ns2", common.ContainerPU)
 						ip2 := policy.ExtendedMap{"bridge": puIP2}
 						puInfo2.Runtime.SetIPAddresses(ip2)
 						ipl2 := policy.ExtendedMap{policy.DefaultNamespace: puIP2}
@@ -4650,7 +4650,7 @@ func TestDNS(t *testing.T) {
 		puID1 := "SomePU"
 		enforcer := NewWithDefaults(testServerID, collector, nil, secret, constants.RemoteContainer, "/proc", []string{"1.1.1.1/31"})
 		enforcer.packetLogs = true
-		puInfo := policy.NewPUInfo(puID1, common.ContainerPU)
+		puInfo := policy.NewPUInfo(puID1, "/ns1", common.ContainerPU)
 		puInfo.Policy.UpdateDNSNetworks([]policy.DNSRule{{
 			Name:     externalFQDN,
 			Port:     "80",
@@ -4731,7 +4731,7 @@ func TestDNSWithError(t *testing.T) {
 		puID1 := "SomePU"
 		enforcer := NewWithDefaults(testServerID, collector, nil, secret, constants.RemoteContainer, "/proc", []string{"1.1.1.1/31"})
 		enforcer.packetLogs = true
-		puInfo := policy.NewPUInfo(puID1, common.ContainerPU)
+		puInfo := policy.NewPUInfo(puID1, "/ns1", common.ContainerPU)
 		puInfo.Policy.UpdateDNSNetworks([]policy.DNSRule{{
 			Name:     externalFQDN,
 			Port:     "80",
@@ -4789,7 +4789,7 @@ func TestPUPortCreation(t *testing.T) {
 
 		enforcer.mode = constants.LocalServer
 		contextID := "1001"
-		puInfo := policy.NewPUInfo(contextID, common.LinuxProcessPU)
+		puInfo := policy.NewPUInfo(contextID, "/ns1", common.LinuxProcessPU)
 		puInfo.Runtime.SetOptions(policy.OptionsType{
 			CgroupMark: "100",
 		})

--- a/controller/internal/enforcer/nfqdatapath/nflog/nflog_common.go
+++ b/controller/internal/enforcer/nfqdatapath/nflog/nflog_common.go
@@ -12,4 +12,4 @@ type NFLogger interface {
 }
 
 // GetPUInfoFunc provides PU information given the id
-type GetPUInfoFunc func(id string) (string, *policy.TagStore)
+type GetPUInfoFunc func(id string) (string, string, *policy.TagStore)

--- a/controller/internal/enforcer/nfqdatapath/nflog/nflog_linux.go
+++ b/controller/internal/enforcer/nfqdatapath/nflog/nflog_linux.go
@@ -91,7 +91,7 @@ func (a *nfLog) recordFromNFLogBuffer(buf *nflog.NfPacket, puIsSource bool) (*co
 	contextID, policyID, extSrvID := parts[0], parts[1], parts[2]
 	encodedAction := string(buf.Prefix[len(buf.Prefix)-1])
 
-	puID, tags := a.getPUInfo(contextID)
+	puID, puNamespace, tags := a.getPUInfo(contextID)
 	if puID == "" {
 		return nil, fmt.Errorf("nflog: unable to find pu id associated given context id: %s", contextID)
 	}
@@ -130,6 +130,7 @@ func (a *nfLog) recordFromNFLogBuffer(buf *nflog.NfPacket, puIsSource bool) (*co
 		Tags:        tags,
 		Action:      action,
 		L4Protocol:  buf.Protocol,
+		Namespace:   puNamespace,
 		Count:       1,
 	}
 

--- a/controller/internal/enforcer/nfqdatapath/nfq_linux.go
+++ b/controller/internal/enforcer/nfqdatapath/nfq_linux.go
@@ -256,6 +256,7 @@ func (d *Datapath) collectUDPPacket(msg *debugpacketmessage) {
 
 		report.Claims = d.puFromIP.Identity().GetSlice()
 		report.PUID = d.puFromIP.ManagementID()
+		report.Namespace = d.puFromIP.ManagementNamespace()
 		report.Encrypt = false
 
 	} else {
@@ -266,6 +267,7 @@ func (d *Datapath) collectUDPPacket(msg *debugpacketmessage) {
 		report.Encrypt = msg.udpConn.ServiceConnection
 		report.Claims = msg.udpConn.Context.Identity().GetSlice()
 		report.PUID = msg.udpConn.Context.ManagementID()
+		report.Namespace = msg.udpConn.Context.ManagementNamespace()
 	}
 
 	if msg.network && !packettracing.IsNetworkPacketTraced(value.(*tracingCacheEntry).direction) {

--- a/controller/internal/enforcer/nfqdatapath/utils.go
+++ b/controller/internal/enforcer/nfqdatapath/utils.go
@@ -105,6 +105,7 @@ func (d *Datapath) reportExternalServiceFlowCommon(context *pucontext.PUContext,
 		Tags:        context.Annotations(),
 		PolicyID:    actual.PolicyID,
 		L4Protocol:  p.IPProto(),
+		Namespace:   context.ManagementNamespace(),
 		Count:       1,
 	}
 

--- a/controller/internal/enforcer/proxy/enforcerproxy_test.go
+++ b/controller/internal/enforcer/proxy/enforcerproxy_test.go
@@ -112,7 +112,7 @@ func createPUInfo() *policy.PUInfo {
 
 	runtime := policy.NewPURuntimeWithDefaults()
 	runtime.SetIPAddresses(ips)
-	plc := policy.NewPUPolicy("testServerID", policy.Police, rules, rules, nil, nil, nil, nil, nil, ips, 0, nil, nil, []string{})
+	plc := policy.NewPUPolicy("testServerID", "/ns1", policy.Police, rules, rules, nil, nil, nil, nil, nil, ips, 0, nil, nil, []string{})
 
 	return policy.PUInfoFromPolicyAndRuntime("testServerID", plc, runtime)
 

--- a/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
@@ -192,7 +192,9 @@ func Test_NegativeConfigureRulesV4(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		ipl := policy.ExtendedMap{}
-		policyrules := policy.NewPUPolicy("Context",
+		policyrules := policy.NewPUPolicy(
+			"Context",
+			"/ns1",
 			policy.Police,
 			nil,
 			nil,
@@ -207,7 +209,7 @@ func Test_NegativeConfigureRulesV4(t *testing.T) {
 			nil,
 			[]string{},
 		)
-		containerinfo := policy.NewPUInfo("Context", common.ContainerPU)
+		containerinfo := policy.NewPUInfo("Context", "/ns1", common.ContainerPU)
 		containerinfo.Policy = policyrules
 		containerinfo.Runtime = policy.NewPURuntimeWithDefaults()
 		containerinfo.Runtime.SetOptions(policy.OptionsType{
@@ -616,7 +618,9 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 					},
 				}
 				ipl := policy.ExtendedMap{}
-				policyrules := policy.NewPUPolicy("Context",
+				policyrules := policy.NewPUPolicy(
+					"Context",
+					"/ns1",
 					policy.Police,
 					appACLs,
 					netACLs,
@@ -631,7 +635,7 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 					nil,
 					[]string{},
 				)
-				puInfo := policy.NewPUInfo("Context", common.LinuxProcessPU)
+				puInfo := policy.NewPUInfo("Context", "/ns1", common.LinuxProcessPU)
 				puInfo.Policy = policyrules
 				puInfo.Runtime.SetOptions(policy.OptionsType{
 					CgroupMark: "10",
@@ -702,7 +706,9 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 						},
 					}
 					ipl := policy.ExtendedMap{}
-					policyrules := policy.NewPUPolicy("Context",
+					policyrules := policy.NewPUPolicy(
+						"Context",
+						"/ns1",
 						policy.Police,
 						appACLs,
 						netACLs,
@@ -717,7 +723,7 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 						nil,
 						[]string{},
 					)
-					puInfoUpdated := policy.NewPUInfo("Context", common.LinuxProcessPU)
+					puInfoUpdated := policy.NewPUInfo("Context", "/ns1", common.LinuxProcessPU)
 					puInfoUpdated.Policy = policyrules
 					puInfoUpdated.Runtime.SetOptions(policy.OptionsType{
 						CgroupMark: "10",
@@ -1011,7 +1017,9 @@ func Test_OperationWithContainersV4(t *testing.T) {
 					},
 				}
 				ipl := policy.ExtendedMap{}
-				policyrules := policy.NewPUPolicy("Context",
+				policyrules := policy.NewPUPolicy(
+					"Context",
+					"/ns1",
 					policy.Police,
 					appACLs,
 					netACLs,
@@ -1026,7 +1034,7 @@ func Test_OperationWithContainersV4(t *testing.T) {
 					nil,
 					[]string{},
 				)
-				puInfo := policy.NewPUInfo("Context", common.ContainerPU)
+				puInfo := policy.NewPUInfo("Context", "/ns1", common.ContainerPU)
 				puInfo.Policy = policyrules
 				puInfo.Runtime.SetOptions(policy.OptionsType{
 					CgroupMark: "10",

--- a/controller/internal/supervisor/iptablesctrl/iptablesV6_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptablesV6_test.go
@@ -70,7 +70,9 @@ func Test_NegativeConfigureRulesV6(t *testing.T) {
 		i.SetTargetNetworks(cfg) //nolint
 
 		ipl := policy.ExtendedMap{}
-		policyrules := policy.NewPUPolicy("Context",
+		policyrules := policy.NewPUPolicy(
+			"Context",
+			"/ns1",
 			policy.Police,
 			nil,
 			nil,
@@ -85,7 +87,7 @@ func Test_NegativeConfigureRulesV6(t *testing.T) {
 			nil,
 			[]string{},
 		)
-		containerinfo := policy.NewPUInfo("Context", common.ContainerPU)
+		containerinfo := policy.NewPUInfo("Context", "/ns1", common.ContainerPU)
 		containerinfo.Policy = policyrules
 		containerinfo.Runtime = policy.NewPURuntimeWithDefaults()
 		containerinfo.Runtime.SetOptions(policy.OptionsType{
@@ -511,7 +513,9 @@ func Test_OperationWithLinuxServicesV6(t *testing.T) {
 					},
 				}
 				ipl := policy.ExtendedMap{}
-				policyrules := policy.NewPUPolicy("Context",
+				policyrules := policy.NewPUPolicy(
+					"Context",
+					"/ns1",
 					policy.Police,
 					appACLs,
 					netACLs,
@@ -526,7 +530,7 @@ func Test_OperationWithLinuxServicesV6(t *testing.T) {
 					nil,
 					[]string{},
 				)
-				puInfo := policy.NewPUInfo("Context", common.LinuxProcessPU)
+				puInfo := policy.NewPUInfo("Context", "/ns1", common.LinuxProcessPU)
 				puInfo.Policy = policyrules
 				puInfo.Runtime.SetOptions(policy.OptionsType{
 					CgroupMark: "10",
@@ -596,7 +600,9 @@ func Test_OperationWithLinuxServicesV6(t *testing.T) {
 						},
 					}
 					ipl := policy.ExtendedMap{}
-					policyrules := policy.NewPUPolicy("Context",
+					policyrules := policy.NewPUPolicy(
+						"Context",
+						"/ns1",
 						policy.Police,
 						appACLs,
 						netACLs,
@@ -611,7 +617,7 @@ func Test_OperationWithLinuxServicesV6(t *testing.T) {
 						nil,
 						[]string{},
 					)
-					puInfoUpdated := policy.NewPUInfo("Context", common.LinuxProcessPU)
+					puInfoUpdated := policy.NewPUInfo("Context", "/ns1", common.LinuxProcessPU)
 					puInfoUpdated.Policy = policyrules
 					puInfoUpdated.Runtime.SetOptions(policy.OptionsType{
 						CgroupMark: "10",
@@ -907,7 +913,9 @@ func Test_OperationWithContainersV6(t *testing.T) {
 					},
 				}
 				ipl := policy.ExtendedMap{}
-				policyrules := policy.NewPUPolicy("Context",
+				policyrules := policy.NewPUPolicy(
+					"Context",
+					"/ns1",
 					policy.Police,
 					appACLs,
 					netACLs,
@@ -922,7 +930,7 @@ func Test_OperationWithContainersV6(t *testing.T) {
 					nil,
 					[]string{},
 				)
-				puInfo := policy.NewPUInfo("Context", common.ContainerPU)
+				puInfo := policy.NewPUInfo("Context", "/ns1", common.ContainerPU)
 				puInfo.Policy = policyrules
 				puInfo.Runtime.SetOptions(policy.OptionsType{
 					CgroupMark: "10",

--- a/controller/internal/supervisor/supervisor_test.go
+++ b/controller/internal/supervisor/supervisor_test.go
@@ -61,6 +61,7 @@ func createPUInfo() *policy.PUInfo {
 	runtime.SetIPAddresses(ips)
 	plc := policy.NewPUPolicy(
 		"context",
+		"/ns1",
 		policy.Police,
 		rules,
 		rules,

--- a/controller/pkg/pucontext/pucontext.go
+++ b/controller/pkg/pucontext/pucontext.go
@@ -33,30 +33,31 @@ var LookupHost = net.LookupHost
 
 // PUContext holds data indexed by the PU ID
 type PUContext struct {
-	id                string
-	username          string
-	autoport          bool
-	managementID      string
-	identity          *policy.TagStore
-	annotations       *policy.TagStore
-	txt               *policies
-	rcv               *policies
-	ApplicationACLs   *acls.ACLCache
-	networkACLs       *acls.ACLCache
-	externalIPCache   cache.DataStore
-	DNSACLs           cache.DataStore
-	mark              string
-	tcpPorts          []string
-	udpPorts          []string
-	puType            common.PUType
-	synToken          []byte
-	synServiceContext []byte
-	synExpiration     time.Time
-	jwt               string
-	jwtExpiration     time.Time
-	scopes            []string
-	Extension         interface{}
-	CancelFunc        context.CancelFunc
+	id                  string
+	username            string
+	autoport            bool
+	managementID        string
+	managementNamespace string
+	identity            *policy.TagStore
+	annotations         *policy.TagStore
+	txt                 *policies
+	rcv                 *policies
+	ApplicationACLs     *acls.ACLCache
+	networkACLs         *acls.ACLCache
+	externalIPCache     cache.DataStore
+	DNSACLs             cache.DataStore
+	mark                string
+	tcpPorts            []string
+	udpPorts            []string
+	puType              common.PUType
+	synToken            []byte
+	synServiceContext   []byte
+	synExpiration       time.Time
+	jwt                 string
+	jwtExpiration       time.Time
+	scopes              []string
+	Extension           interface{}
+	CancelFunc          context.CancelFunc
 	sync.RWMutex
 }
 
@@ -66,19 +67,20 @@ func NewPU(contextID string, puInfo *policy.PUInfo, timeout time.Duration) (*PUC
 	ctx, cancelFunc := context.WithCancel(ctx)
 
 	pu := &PUContext{
-		id:              contextID,
-		username:        puInfo.Runtime.Options().UserID,
-		autoport:        puInfo.Runtime.Options().AutoPort,
-		managementID:    puInfo.Policy.ManagementID(),
-		puType:          puInfo.Runtime.PUType(),
-		identity:        puInfo.Policy.Identity(),
-		annotations:     puInfo.Policy.Annotations(),
-		externalIPCache: cache.NewCacheWithExpiration("External IP Cache", timeout),
-		ApplicationACLs: acls.NewACLCache(),
-		networkACLs:     acls.NewACLCache(),
-		mark:            puInfo.Runtime.Options().CgroupMark,
-		scopes:          puInfo.Policy.Scopes(),
-		CancelFunc:      cancelFunc,
+		id:                  contextID,
+		username:            puInfo.Runtime.Options().UserID,
+		autoport:            puInfo.Runtime.Options().AutoPort,
+		managementID:        puInfo.Policy.ManagementID(),
+		managementNamespace: puInfo.Policy.ManagementNamespace(),
+		puType:              puInfo.Runtime.PUType(),
+		identity:            puInfo.Policy.Identity(),
+		annotations:         puInfo.Policy.Annotations(),
+		externalIPCache:     cache.NewCacheWithExpiration("External IP Cache", timeout),
+		ApplicationACLs:     acls.NewACLCache(),
+		networkACLs:         acls.NewACLCache(),
+		mark:                puInfo.Runtime.Options().CgroupMark,
+		scopes:              puInfo.Policy.Scopes(),
+		CancelFunc:          cancelFunc,
 	}
 
 	pu.CreateRcvRules(puInfo.Policy.ReceiverRules())
@@ -211,6 +213,11 @@ func (p *PUContext) Autoport() bool {
 // ManagementID returns the management ID
 func (p *PUContext) ManagementID() string {
 	return p.managementID
+}
+
+// ManagementNamespace returns the management namespace
+func (p *PUContext) ManagementNamespace() string {
+	return p.managementNamespace
 }
 
 // Type return the pu type

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -367,6 +367,7 @@ func (p *PUPolicy) ToPublicPolicy() *PUPolicyPublic {
 
 	return &PUPolicyPublic{
 		ManagementID:          p.managementID,
+		ManagementNamespace:   p.managementNamespace,
 		TriremeAction:         p.triremeAction,
 		ApplicationACLs:       p.applicationACLs.Copy(),
 		NetworkACLs:           p.networkACLs.Copy(),
@@ -390,6 +391,7 @@ func (p *PUPolicy) ToPublicPolicy() *PUPolicyPublic {
 // unit in an object that can be marshalled and transmitted over the RPC interface.
 type PUPolicyPublic struct {
 	ManagementID          string                  `json:"managementID,omitempty"`
+	ManagementNamespace   string                  `json:"managementNamespace,omitempty"`
 	TriremeAction         PUAction                `json:"triremeAction,omitempty"`
 	ApplicationACLs       IPRuleList              `json:"applicationACLs,omitempty"`
 	NetworkACLs           IPRuleList              `json:"networkACLs,omitempty"`
@@ -425,6 +427,7 @@ func (p *PUPolicyPublic) ToPrivatePolicy(convert bool) (*PUPolicy, error) {
 
 	return &PUPolicy{
 		managementID:          p.ManagementID,
+		managementNamespace:   p.ManagementNamespace,
 		triremeAction:         p.TriremeAction,
 		applicationACLs:       p.ApplicationACLs,
 		networkACLs:           p.NetworkACLs.Copy(),

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -14,6 +14,9 @@ type PUPolicy struct {
 	// ManagementID is provided for the policy implementations as a means of
 	// holding a policy identifier related to the implementation.
 	managementID string
+	// managementNamespace is provided for the policy implementations as a means of
+	// holding a policy sub identifier related to the implementation.
+	managementNamespace string
 	// triremeAction defines what level of policy should be applied to that container.
 	triremeAction PUAction
 	// dnsACLs is the list of DNS names and the associated ports that the container is
@@ -68,6 +71,7 @@ const (
 // netACLs are the ACLs for packet coming from the Network to the Application/PU.
 func NewPUPolicy(
 	id string,
+	namespace string,
 	action PUAction,
 	appACLs IPRuleList,
 	netACLs IPRuleList,
@@ -121,6 +125,7 @@ func NewPUPolicy(
 
 	return &PUPolicy{
 		managementID:          id,
+		managementNamespace:   namespace,
 		triremeAction:         action,
 		applicationACLs:       appACLs,
 		networkACLs:           netACLs,
@@ -139,7 +144,7 @@ func NewPUPolicy(
 
 // NewPUPolicyWithDefaults sets up a PU policy with defaults
 func NewPUPolicyWithDefaults() *PUPolicy {
-	return NewPUPolicy("", AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
+	return NewPUPolicy("", "", AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
 }
 
 // Clone returns a copy of the policy
@@ -149,6 +154,7 @@ func (p *PUPolicy) Clone() *PUPolicy {
 
 	np := NewPUPolicy(
 		p.managementID,
+		p.managementNamespace,
 		p.triremeAction,
 		p.applicationACLs.Copy(),
 		p.networkACLs.Copy(),
@@ -173,6 +179,14 @@ func (p *PUPolicy) ManagementID() string {
 	defer p.Unlock()
 
 	return p.managementID
+}
+
+// ManagementNamespace returns the management Namespace
+func (p *PUPolicy) ManagementNamespace() string {
+	p.Lock()
+	defer p.Unlock()
+
+	return p.managementNamespace
 }
 
 // TriremeAction returns the TriremeAction

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -11,7 +11,7 @@ func TestNewPolicy(t *testing.T) {
 	Convey("Given that I instantiate a new policy", t, func() {
 
 		Convey("When I provide only the mandatory fields", func() {
-			p := NewPUPolicy("id1", AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
+			p := NewPUPolicy("id1", "/abc", AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
 			Convey("I shpuld get an empty policy", func() {
 				So(p, ShouldNotBeNil)
 				So(p.applicationACLs, ShouldNotBeNil)
@@ -74,7 +74,8 @@ func TestNewPolicy(t *testing.T) {
 			ips := ExtendedMap{DefaultNamespace: "172.0.0.1"}
 
 			p := NewPUPolicy(
-				"id1",
+				"id",
+				"/abc",
 				AllowAll,
 				IPRuleList{appACL},
 				IPRuleList{netACL},
@@ -172,7 +173,8 @@ func TestFuncClone(t *testing.T) {
 		ips := ExtendedMap{DefaultNamespace: "172.0.0.1"}
 
 		d := NewPUPolicy(
-			"id1",
+			"id",
+			"/abc",
 			AllowAll,
 			IPRuleList{appACL},
 			IPRuleList{netACL},
@@ -256,6 +258,7 @@ func TestAllLockedSetGet(t *testing.T) {
 
 		p := NewPUPolicy(
 			"id1",
+			"/abc",
 			AllowAll,
 			IPRuleList{appACL},
 			IPRuleList{netACL},
@@ -274,6 +277,11 @@ func TestAllLockedSetGet(t *testing.T) {
 		Convey("I should be able to retrieve the management ID ", func() {
 			id := p.ManagementID()
 			So(id, ShouldResemble, "id1")
+		})
+
+		Convey("I should be able to retrieve the management namespace ", func() {
+			ns := p.ManagementNamespace()
+			So(ns, ShouldResemble, "/abc")
 		})
 
 		Convey("I should be able to retrieve the Action", func() {
@@ -358,8 +366,8 @@ func TestAllLockedSetGet(t *testing.T) {
 
 func TestPUInfo(t *testing.T) {
 	Convey("Given I try to initiate a new container policy", t, func() {
-		puInfor := NewPUInfo("123", common.ContainerPU)
-		policy := NewPUPolicy("123", AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
+		puInfor := NewPUInfo("123", "/abc", common.ContainerPU)
+		policy := NewPUPolicy("123", "/abc", AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
 		runtime := NewPURuntime("", 0, "", nil, nil, common.ContainerPU, nil)
 		Convey("Then I expect the struct to be populated", func() {
 			So(puInfor.ContextID, ShouldEqual, "123")

--- a/policy/puinfo.go
+++ b/policy/puinfo.go
@@ -14,8 +14,8 @@ type PUInfo struct {
 }
 
 // NewPUInfo instantiates a new ContainerPolicy
-func NewPUInfo(contextID string, puType common.PUType) *PUInfo {
-	policy := NewPUPolicy(contextID, AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
+func NewPUInfo(contextID, namespace string, puType common.PUType) *PUInfo {
+	policy := NewPUPolicy(contextID, namespace, AllowAll, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, []string{})
 	runtime := NewPURuntime("", 0, "", nil, nil, puType, nil)
 	return PUInfoFromPolicyAndRuntime(contextID, policy, runtime)
 }


### PR DESCRIPTION
--> Trireme supports one more sub identifier called `managementNamespace`, which can be used to group PU's.