### PR TITLE
fix: call setloglevel only on valid log input

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -156,8 +156,10 @@ func (t *trireme) UpdateConfiguration(cfg *runtime.Configuration) error {
 	}
 
 	for _, e := range t.enforcers {
-		if err := e.SetLogLevel(cfg.LogLevel); err != nil {
-			zap.L().Error("unable to set log level", zap.Error(err))
+		if cfg.LogLevel != "" {
+			if err := e.SetLogLevel(cfg.LogLevel); err != nil {
+				zap.L().Error("unable to set log level", zap.Error(err))
+			}
 		}
 
 		err := e.SetTargetNetworks(cfg)


### PR DESCRIPTION
--> Saves a rpc call.
--> Prevents reseting the packetLogs on every `UpdateConfiguration` call.