### PR TITLE
Fix Kubernetes Monitor Deletes

### DIFF
--- a/monitor/internal/pod/delete_controller_test.go
+++ b/monitor/internal/pod/delete_controller_test.go
@@ -120,15 +120,12 @@ func TestDeleteController(t *testing.T) {
 			}
 		}
 
-		dc := &DeleteController{
-			client:             nil,
-			handler:            nil,
-			deleteCh:           make(chan DeleteEvent),
-			reconcileCh:        make(chan struct{}),
-			tickerPeriod:       1 * time.Second,
-			itemProcessTimeout: 1 * time.Second,
-			reconcileFunc:      reconcileFunc,
-		}
+		dc := NewDeleteController(nil, nil)
+		dc.deleteCh = make(chan DeleteEvent)
+		dc.reconcileCh = make(chan struct{})
+		dc.tickerPeriod = 1 * time.Second
+		dc.itemProcessTimeout = 1 * time.Second
+		dc.reconcileFunc = reconcileFunc
 
 		Convey("it should be able to receive delete events, and access them during a reconcile", func() {
 			ev := DeleteEvent{


### PR DESCRIPTION
As @dstiliadis and I have debugged this morning, it looks like we can even miss a terminating event, which will mean that the pod will never register with the delete controller, and therefore we will never destroy the PU.

This change simply changes the logic of registering the deletes: whenever we reconcile past the retrieval of the pod object, we will register it with the delete controller, and let it handle it from there.