### PR TITLE
Ipv6 error trace

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/ipv6.go
+++ b/controller/internal/supervisor/iptablesctrl/ipv6.go
@@ -35,7 +35,7 @@ func init() {
 func GetIPv6Impl() (IPImpl, error) {
 	ipt, err := provider.NewGoIPTablesProviderV6([]string{"mangle"})
 	if err != nil {
-		zap.L().Error("Unable to initialize ipv6 iptables :%s", zap.Error(err))
+		zap.L().Trace("Unable to initialize ipv6 iptables :%s", zap.Error(err))
 	}
 
 	return &ipv6{ipt: ipt, ipv6Disabled: ipv6Disabled}, nil


### PR DESCRIPTION
Move Ipv6 error log message to trace for now. 