### PR TITLE
new: nflog rule for each extension

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -305,11 +305,9 @@ func (i *iptables) programExtensionsRules(contextID string, rule *aclIPset, chai
 	rulesspec := []string{
 		"-p", proto,
 		"-m", "set", "--match-set", rule.ipset, ipMatchDirection,
-		"--match", "multiport", "--dports", strings.Join(rule.ports, ","),
 	}
 
 	for _, ext := range rule.extensions {
-
 		if rule.policy.Action&policy.Log > 0 {
 			if err := i.programNflogExtensionRule(contextID, rule, rulesspec, ext, chain, nfLogGroup); err != nil {
 				return fmt.Errorf("unable to program nflog extension: %v", err)

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -330,6 +330,8 @@ func (i *iptables) programExtensionsRules(contextID string, rule *aclIPset, chai
 	return nil
 }
 
+// WARNING: The extension should always contain the action at the end else,
+// the function returns error
 func (i *iptables) programNflogExtensionRule(contextID string, rule *aclIPset, rulesspec []string, ext string, chain, proto, nfLogGroup string) error {
 
 	parts := strings.SplitN(ext, " -j ", 2)

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -340,14 +340,14 @@ func (i *iptables) programNflogExtensionRule(contextID string, rule *aclIPset, r
 	}
 	filter, ruleAction := parts[0], parts[1]
 
-	action := "3"
-	if ruleAction == "DROP" {
-		action = "6"
-	}
-
 	filterArgs, err := shellwords.Parse(filter)
 	if err != nil {
 		return fmt.Errorf("unable to parse extension %s: %v", ext, err)
+	}
+
+	action := "3"
+	if ruleAction == "DROP" {
+		action = "6"
 	}
 
 	defaultNflogSuffix := []string{"-m", "state", "--state", "NEW",

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -331,7 +331,7 @@ func (i *iptables) programExtensionsRules(contextID string, rule *aclIPset, chai
 }
 
 // WARNING: The extension should always contain the action at the end else,
-// the function returns error
+// the function returns error.
 func (i *iptables) programNflogExtensionRule(contextID string, rule *aclIPset, rulesspec []string, ext string, chain, proto, nfLogGroup string) error {
 
 	parts := strings.SplitN(ext, " -j ", 2)

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -338,7 +338,11 @@ func (i *iptables) programNflogExtensionRule(contextID string, rule *aclIPset, r
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid extension format: %s", ext)
 	}
-	filter, ruleAction := parts[0], parts[1]
+	filter, target := parts[0], parts[1]
+
+	if filter == "" || target == "" {
+		return fmt.Errorf("filter or target is empty: %s", ext)
+	}
 
 	filterArgs, err := shellwords.Parse(filter)
 	if err != nil {
@@ -346,7 +350,7 @@ func (i *iptables) programNflogExtensionRule(contextID string, rule *aclIPset, r
 	}
 
 	action := "3"
-	if ruleAction == "DROP" {
+	if target == "DROP" {
 		action = "6"
 	}
 

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -311,7 +311,7 @@ func (i *iptables) programExtensionsRules(contextID string, rule *aclIPset, chai
 	for _, ext := range rule.extensions {
 
 		if rule.policy.Action&policy.Log > 0 {
-			if err := i.programNflogExtensionRule(contextID, rule, rulesspec, ext, chain, proto, nfLogGroup); err != nil {
+			if err := i.programNflogExtensionRule(contextID, rule, rulesspec, ext, chain, nfLogGroup); err != nil {
 				return fmt.Errorf("unable to program nflog extension: %v", err)
 			}
 		}
@@ -332,7 +332,7 @@ func (i *iptables) programExtensionsRules(contextID string, rule *aclIPset, chai
 
 // WARNING: The extension should always contain the action at the end else,
 // the function returns error.
-func (i *iptables) programNflogExtensionRule(contextID string, rule *aclIPset, rulesspec []string, ext string, chain, proto, nfLogGroup string) error {
+func (i *iptables) programNflogExtensionRule(contextID string, rule *aclIPset, rulesspec []string, ext string, chain, nfLogGroup string) error {
 
 	parts := strings.SplitN(ext, " -j ", 2)
 	if len(parts) != 2 {

--- a/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
@@ -1110,7 +1110,7 @@ func Test_ExtensionsV4(t *testing.T) {
 							ServiceID: "s2",
 							PolicyID:  "2",
 						},
-						Extensions: []string{"-m bpf --bytecode \"20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535\" -j DROP"},
+						Extensions: []string{"--match multiport --dports 443 -m bpf --bytecode \"20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535\" -j DROP"},
 					},
 					policy.IPRule{
 						Addresses: []string{"50.0.0.0/24"},
@@ -1463,7 +1463,7 @@ func Test_ExtensionsV4(t *testing.T) {
 							ServiceID: "s2",
 							PolicyID:  "2",
 						},
-						Extensions: []string{"-m bpf --bytecode \"20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535\" -j DROP"},
+						Extensions: []string{"--match multiport --dports 443  -m bpf --bytecode \"20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535\" -j DROP"},
 					},
 					policy.IPRule{
 						Addresses: []string{"50.0.0.0/24"},

--- a/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
@@ -398,6 +398,263 @@ var (
 		},
 	}
 
+	expectedMangleAfterPUInsertWithLogV4 = map[string][]string{
+		"INPUT": {
+			"-m set ! --match-set TRI-v4-Excluded src -j TRI-Net",
+		},
+		"OUTPUT": {
+			"-m set ! --match-set TRI-v4-Excluded dst -j TRI-App",
+		},
+		"TRI-App": {
+			"-j TRI-Prx-App",
+			"-m mark --mark 1073741922 -j ACCEPT",
+			"-m connmark --mark 61166 -j ACCEPT",
+			"-j TRI-UID-App",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP dst -m tcp --tcp-flags SYN,ACK SYN,ACK -j MARK --set-mark 99",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP dst -m tcp --tcp-flags SYN,ACK SYN,ACK -j NFQUEUE --queue-balance 8:11 --queue-bypass",
+			"-j TRI-Pid-App",
+			"-j TRI-Svc-App",
+			"-j TRI-Hst-App",
+		},
+		"TRI-Net": {
+			"-j TRI-Prx-Net",
+			"-p udp -m set --match-set TRI-v4-TargetUDP src -m string --string n30njxq7bmiwr6dtxq --algo bm --to 65535 -j NFQUEUE --queue-bypass --queue-balance 24:27",
+			"-m connmark --mark 61166 -j ACCEPT",
+			"-j TRI-UID-Net",
+			"-m set --match-set TRI-v4-TargetTCP src -p tcp -m tcp --tcp-flags SYN,ACK SYN,ACK -j NFQUEUE --queue-balance 24:27 --queue-bypass",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-option 34 --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 16:19 --queue-bypass",
+			"-j TRI-Pid-Net",
+			"-j TRI-Svc-Net",
+			"-j TRI-Hst-Net",
+		},
+		"TRI-Pid-App": {
+			"-m cgroup --cgroup 10 -m comment --comment PU-Chain -j MARK --set-mark 10",
+			"-m mark --mark 10 -m comment --comment PU-Chain -j TRI-App-pu1N7uS6--0",
+		},
+		"TRI-Pid-Net": {
+			"-p tcp -m multiport --destination-ports 9000 -m comment --comment PU-Chain -j TRI-Net-pu1N7uS6--0", "-p udp -m multiport --destination-ports 5000 -m comment --comment PU-Chain -j TRI-Net-pu1N7uS6--0",
+		},
+		"TRI-Prx-App": {
+			"-m mark --mark 0x40 -j ACCEPT",
+			"-p tcp -m tcp --sport 0 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-srv src -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-dst dst,dst -m mark ! --mark 0x40 -j ACCEPT",
+		},
+		"TRI-Prx-Net": {
+			"-m mark --mark 0x40 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-dst src,src -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-srv src -m addrtype --src-type LOCAL -j ACCEPT",
+			"-p tcp -m tcp --dport 0 -j ACCEPT",
+		},
+		"TRI-Hst-App": {},
+		"TRI-Hst-Net": {},
+		"TRI-Svc-App": {},
+		"TRI-Svc-Net": {},
+		"TRI-UID-App": {},
+		"TRI-UID-Net": {},
+
+		"TRI-Net-pu1N7uS6--0": {
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV src -m state --state ESTABLISHED -j ACCEPT",
+			"-p TCP -m set --match-set TRI-v4-ext-w5frVpu19gtV src -m state --state NEW -m set ! --match-set TRI-v4-TargetTCP src --match multiport --dports 80 -j DROP",
+			"-p UDP -m set --match-set TRI-v4-ext-IuSLspu19gtV src --match multiport --dports 443 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 16:19",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-flags SYN,ACK ACK -j NFQUEUE --queue-balance 20:23",
+			"-p udp -m set --match-set TRI-v4-TargetUDP src --match limit --limit 1000/s -j NFQUEUE --queue-balance 16:19",
+			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-s 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:6",
+			"-s 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:10",
+			"-s 0.0.0.0/0 -j DROP",
+		},
+
+		"TRI-App-pu1N7uS6--0": {
+			"-p TCP -m set --match-set TRI-v4-ext-uNdc0pu19gtV dst -m state --state NEW -m set ! --match-set TRI-v4-TargetTCP dst --match multiport --dports 80 -j DROP",
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -m state --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:2:s2:3",
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -j ACCEPT",
+			"-p icmp -m set --match-set TRI-v4-ext-w5frVpu19gtV dst -j ACCEPT",
+			"-p UDP -m set --match-set TRI-v4-ext-IuSLspu19gtV dst -m state --state ESTABLISHED -j ACCEPT",
+			"-p tcp -m tcp --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 0:3",
+			"-p tcp -m tcp --tcp-flags SYN,ACK ACK -j NFQUEUE --queue-balance 4:7",
+			"-p udp -m set --match-set TRI-v4-TargetUDP dst -j NFQUEUE --queue-balance 0:3",
+			"-p udp -m set --match-set TRI-v4-TargetUDP dst -m state --state ESTABLISHED -m comment --comment UDP-Established-Connections -j ACCEPT",
+			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-d 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:6",
+			"-d 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:10",
+			"-d 0.0.0.0/0 -j DROP",
+		},
+	}
+
+	expectedMangleAfterPUInsertWithExtensionsV4 = map[string][]string{
+		"INPUT": {
+			"-m set ! --match-set TRI-v4-Excluded src -j TRI-Net",
+		},
+		"OUTPUT": {
+			"-m set ! --match-set TRI-v4-Excluded dst -j TRI-App",
+		},
+		"TRI-App": {
+			"-j TRI-Prx-App",
+			"-m mark --mark 1073741922 -j ACCEPT",
+			"-m connmark --mark 61166 -j ACCEPT",
+			"-j TRI-UID-App",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP dst -m tcp --tcp-flags SYN,ACK SYN,ACK -j MARK --set-mark 99",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP dst -m tcp --tcp-flags SYN,ACK SYN,ACK -j NFQUEUE --queue-balance 8:11 --queue-bypass",
+			"-j TRI-Pid-App",
+			"-j TRI-Svc-App",
+			"-j TRI-Hst-App",
+		},
+		"TRI-Net": {
+			"-j TRI-Prx-Net",
+			"-p udp -m set --match-set TRI-v4-TargetUDP src -m string --string n30njxq7bmiwr6dtxq --algo bm --to 65535 -j NFQUEUE --queue-bypass --queue-balance 24:27",
+			"-m connmark --mark 61166 -j ACCEPT",
+			"-j TRI-UID-Net",
+			"-m set --match-set TRI-v4-TargetTCP src -p tcp -m tcp --tcp-flags SYN,ACK SYN,ACK -j NFQUEUE --queue-balance 24:27 --queue-bypass",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-option 34 --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 16:19 --queue-bypass",
+			"-j TRI-Pid-Net",
+			"-j TRI-Svc-Net",
+			"-j TRI-Hst-Net",
+		},
+		"TRI-Pid-App": {
+			"-m cgroup --cgroup 10 -m comment --comment PU-Chain -j MARK --set-mark 10",
+			"-m mark --mark 10 -m comment --comment PU-Chain -j TRI-App-pu1N7uS6--0",
+		},
+		"TRI-Pid-Net": {
+			"-p tcp -m multiport --destination-ports 9000 -m comment --comment PU-Chain -j TRI-Net-pu1N7uS6--0", "-p udp -m multiport --destination-ports 5000 -m comment --comment PU-Chain -j TRI-Net-pu1N7uS6--0",
+		},
+		"TRI-Prx-App": {
+			"-m mark --mark 0x40 -j ACCEPT",
+			"-p tcp -m tcp --sport 0 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-srv src -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-dst dst,dst -m mark ! --mark 0x40 -j ACCEPT",
+		},
+		"TRI-Prx-Net": {
+			"-m mark --mark 0x40 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-dst src,src -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-srv src -m addrtype --src-type LOCAL -j ACCEPT",
+			"-p tcp -m tcp --dport 0 -j ACCEPT",
+		},
+		"TRI-Hst-App": {},
+		"TRI-Hst-Net": {},
+		"TRI-Svc-App": {},
+		"TRI-Svc-Net": {},
+		"TRI-UID-App": {},
+		"TRI-UID-Net": {},
+
+		"TRI-Net-pu1N7uS6--0": {
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV src -m state --state ESTABLISHED -j ACCEPT",
+			"-p TCP -m set --match-set TRI-v4-ext-w5frVpu19gtV src -m state --state NEW -m set ! --match-set TRI-v4-TargetTCP src --match multiport --dports 80 -j DROP",
+			"-p UDP -m set --match-set TRI-v4-ext-IuSLspu19gtV src --match multiport --dports 443 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 16:19",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-flags SYN,ACK ACK -j NFQUEUE --queue-balance 20:23",
+			"-p udp -m set --match-set TRI-v4-TargetUDP src --match limit --limit 1000/s -j NFQUEUE --queue-balance 16:19",
+			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-s 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:6",
+			"-s 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:10",
+			"-s 0.0.0.0/0 -j DROP",
+		},
+
+		"TRI-App-pu1N7uS6--0": {
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -m bpf --bytecode 20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535 -j DROP",
+			"-p TCP -m set --match-set TRI-v4-ext-uNdc0pu19gtV dst -m state --state NEW -m set ! --match-set TRI-v4-TargetTCP dst --match multiport --dports 80 -j DROP",
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -j ACCEPT",
+			"-p icmp -m set --match-set TRI-v4-ext-w5frVpu19gtV dst -j ACCEPT",
+			"-p UDP -m set --match-set TRI-v4-ext-IuSLspu19gtV dst -m state --state ESTABLISHED -j ACCEPT",
+			"-p tcp -m tcp --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 0:3",
+			"-p tcp -m tcp --tcp-flags SYN,ACK ACK -j NFQUEUE --queue-balance 4:7",
+			"-p udp -m set --match-set TRI-v4-TargetUDP dst -j NFQUEUE --queue-balance 0:3",
+			"-p udp -m set --match-set TRI-v4-TargetUDP dst -m state --state ESTABLISHED -m comment --comment UDP-Established-Connections -j ACCEPT",
+			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-d 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:6",
+			"-d 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:10",
+			"-d 0.0.0.0/0 -j DROP",
+		},
+	}
+
+	expectedMangleAfterPUInsertWithExtensionsAndLogV4 = map[string][]string{
+		"INPUT": {
+			"-m set ! --match-set TRI-v4-Excluded src -j TRI-Net",
+		},
+		"OUTPUT": {
+			"-m set ! --match-set TRI-v4-Excluded dst -j TRI-App",
+		},
+		"TRI-App": {
+			"-j TRI-Prx-App",
+			"-m mark --mark 1073741922 -j ACCEPT",
+			"-m connmark --mark 61166 -j ACCEPT",
+			"-j TRI-UID-App",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP dst -m tcp --tcp-flags SYN,ACK SYN,ACK -j MARK --set-mark 99",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP dst -m tcp --tcp-flags SYN,ACK SYN,ACK -j NFQUEUE --queue-balance 8:11 --queue-bypass",
+			"-j TRI-Pid-App",
+			"-j TRI-Svc-App",
+			"-j TRI-Hst-App",
+		},
+		"TRI-Net": {
+			"-j TRI-Prx-Net",
+			"-p udp -m set --match-set TRI-v4-TargetUDP src -m string --string n30njxq7bmiwr6dtxq --algo bm --to 65535 -j NFQUEUE --queue-bypass --queue-balance 24:27",
+			"-m connmark --mark 61166 -j ACCEPT",
+			"-j TRI-UID-Net",
+			"-m set --match-set TRI-v4-TargetTCP src -p tcp -m tcp --tcp-flags SYN,ACK SYN,ACK -j NFQUEUE --queue-balance 24:27 --queue-bypass",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-option 34 --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 16:19 --queue-bypass",
+			"-j TRI-Pid-Net",
+			"-j TRI-Svc-Net",
+			"-j TRI-Hst-Net",
+		},
+		"TRI-Pid-App": {
+			"-m cgroup --cgroup 10 -m comment --comment PU-Chain -j MARK --set-mark 10",
+			"-m mark --mark 10 -m comment --comment PU-Chain -j TRI-App-pu1N7uS6--0",
+		},
+		"TRI-Pid-Net": {
+			"-p tcp -m multiport --destination-ports 9000 -m comment --comment PU-Chain -j TRI-Net-pu1N7uS6--0", "-p udp -m multiport --destination-ports 5000 -m comment --comment PU-Chain -j TRI-Net-pu1N7uS6--0",
+		},
+		"TRI-Prx-App": {
+			"-m mark --mark 0x40 -j ACCEPT",
+			"-p tcp -m tcp --sport 0 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-srv src -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-dst dst,dst -m mark ! --mark 0x40 -j ACCEPT",
+		},
+		"TRI-Prx-Net": {
+			"-m mark --mark 0x40 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-dst src,src -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-Proxy-pu19gtV-srv src -m addrtype --src-type LOCAL -j ACCEPT",
+			"-p tcp -m tcp --dport 0 -j ACCEPT",
+		},
+		"TRI-Hst-App": {},
+		"TRI-Hst-Net": {},
+		"TRI-Svc-App": {},
+		"TRI-Svc-Net": {},
+		"TRI-UID-App": {},
+		"TRI-UID-Net": {},
+
+		"TRI-Net-pu1N7uS6--0": {
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV src -m state --state ESTABLISHED -j ACCEPT",
+			"-p TCP -m set --match-set TRI-v4-ext-w5frVpu19gtV src -m state --state NEW -m set ! --match-set TRI-v4-TargetTCP src --match multiport --dports 80 -j DROP",
+			"-p UDP -m set --match-set TRI-v4-ext-IuSLspu19gtV src --match multiport --dports 443 -j ACCEPT",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 16:19",
+			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-flags SYN,ACK ACK -j NFQUEUE --queue-balance 20:23",
+			"-p udp -m set --match-set TRI-v4-TargetUDP src --match limit --limit 1000/s -j NFQUEUE --queue-balance 16:19",
+			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-s 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:6",
+			"-s 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:10",
+			"-s 0.0.0.0/0 -j DROP",
+		},
+
+		"TRI-App-pu1N7uS6--0": {
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -m bpf --bytecode 20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535 -m state --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:2:s2:6",
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -m bpf --bytecode 20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535 -j DROP",
+			"-p TCP -m set --match-set TRI-v4-ext-uNdc0pu19gtV dst -m state --state NEW -m set ! --match-set TRI-v4-TargetTCP dst --match multiport --dports 80 -j DROP",
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -m state --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:2:s2:3",
+			"-p UDP -m set --match-set TRI-v4-ext-6zlJIpu19gtV dst --match multiport --dports 443 -j ACCEPT",
+			"-p icmp -m set --match-set TRI-v4-ext-w5frVpu19gtV dst -j ACCEPT",
+			"-p UDP -m set --match-set TRI-v4-ext-IuSLspu19gtV dst -m state --state ESTABLISHED -j ACCEPT",
+			"-p tcp -m tcp --tcp-flags SYN,ACK SYN -j NFQUEUE --queue-balance 0:3",
+			"-p tcp -m tcp --tcp-flags SYN,ACK ACK -j NFQUEUE --queue-balance 4:7",
+			"-p udp -m set --match-set TRI-v4-TargetUDP dst -j NFQUEUE --queue-balance 0:3",
+			"-p udp -m set --match-set TRI-v4-TargetUDP dst -m state --state ESTABLISHED -m comment --comment UDP-Established-Connections -j ACCEPT",
+			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-d 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:6",
+			"-d 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:10",
+			"-d 0.0.0.0/0 -j DROP",
+		},
+	}
+
 	expectedNATAfterPUInsertV4 = map[string][]string{
 		"PREROUTING": {
 			"-p tcp -m addrtype --dst-type LOCAL -m set ! --match-set TRI-v4-Excluded src -j TRI-Redir-Net",
@@ -772,6 +1029,537 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 						})
 					})
 				})
+			})
+		})
+	})
+}
+
+func Test_ExtensionsV4(t *testing.T) {
+	Convey("Given an iptables controller with a memory backend with extensions in policy and log disabled", t, func() {
+		cfg := &runtime.Configuration{
+			TCPTargetNetworks: []string{"0.0.0.0/0"},
+			UDPTargetNetworks: []string{"10.0.0.0/8"},
+			ExcludedNetworks:  []string{"127.0.0.1"},
+		}
+
+		commitFunc := func(buf *bytes.Buffer) error {
+			return nil
+		}
+
+		iptv4 := provider.NewCustomBatchProvider(&baseIpt{}, commitFunc, []string{"nat", "mangle"})
+		So(iptv4, ShouldNotBeNil)
+
+		iptv6 := provider.NewCustomBatchProvider(&baseIpt{}, commitFunc, []string{"nat", "mangle"})
+		So(iptv6, ShouldNotBeNil)
+
+		ipsv4 := &memoryIPSetProvider{sets: map[string]*memoryIPSet{}}
+		ipsv6 := &memoryIPSetProvider{sets: map[string]*memoryIPSet{}}
+
+		i, err := createTestInstance(ipsv4, ipsv6, iptv4, iptv6, constants.LocalServer)
+		So(err, ShouldBeNil)
+		So(i, ShouldNotBeNil)
+
+		Convey("When I start the controller, I should get the right global chains and ipsets and proper extensions should be configured", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := i.Run(ctx)
+			i.SetTargetNetworks(cfg) //nolint
+			So(err, ShouldBeNil)
+
+			for set, targets := range ipsv4.sets {
+				So(expectedGlobalIPSetsV4, ShouldContainKey, set)
+				for target := range targets.set {
+					So(expectedGlobalIPSetsV4[set], ShouldContain, target)
+				}
+			}
+
+			t := i.iptv4.impl.RetrieveTable()
+			So(t, ShouldNotBeNil)
+			So(len(t), ShouldEqual, 2)
+			So(t["mangle"], ShouldNotBeNil)
+			So(t["nat"], ShouldNotBeNil)
+
+			for chain, rules := range t["mangle"] {
+				So(expectedGlobalMangleChainsV4, ShouldContainKey, chain)
+				So(rules, ShouldResemble, expectedGlobalMangleChainsV4[chain])
+			}
+
+			for chain, rules := range t["nat"] {
+				So(expectedGlobalNATChainsV4, ShouldContainKey, chain)
+				So(rules, ShouldResemble, expectedGlobalNATChainsV4[chain])
+			}
+
+			Convey("When I configure a new set of rules, the ACLs must be correct", func() {
+				appACLs := policy.IPRuleList{
+					policy.IPRule{
+						Addresses: []string{"30.0.0.0/24"},
+						Ports:     []string{"80"},
+						Protocols: []string{"TCP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject,
+							ServiceID: "s1",
+							PolicyID:  "1",
+						},
+					},
+					policy.IPRule{
+						Addresses: []string{"30.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"UDP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept,
+							ServiceID: "s2",
+							PolicyID:  "2",
+						},
+						Extensions: []string{"-m bpf --bytecode \"20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535\" -j DROP"},
+					},
+					policy.IPRule{
+						Addresses: []string{"50.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"icmp"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept,
+							ServiceID: "s3",
+							PolicyID:  "3",
+						},
+					},
+				}
+				netACLs := policy.IPRuleList{
+					policy.IPRule{
+						Addresses: []string{"40.0.0.0/24"},
+						Ports:     []string{"80"},
+						Protocols: []string{"TCP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject,
+							ServiceID: "s3",
+							PolicyID:  "1",
+						},
+					},
+					policy.IPRule{
+						Addresses: []string{"40.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"UDP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept,
+							ServiceID: "s4",
+							PolicyID:  "2",
+						},
+					},
+				}
+				ipl := policy.ExtendedMap{}
+				policyrules := policy.NewPUPolicy(
+					"Context",
+					"/ns1",
+					policy.Police,
+					appACLs,
+					netACLs,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					ipl,
+					0,
+					nil,
+					nil,
+					[]string{},
+				)
+				puInfo := policy.NewPUInfo("Context", "/ns1", common.LinuxProcessPU)
+				puInfo.Policy = policyrules
+				puInfo.Runtime.SetOptions(policy.OptionsType{
+					CgroupMark: "10",
+				})
+
+				udpPortSpec, err := portspec.NewPortSpecFromString("5000", nil)
+				So(err, ShouldBeNil)
+				tcpPortSpec, err := portspec.NewPortSpecFromString("9000", nil)
+				So(err, ShouldBeNil)
+
+				puInfo.Runtime.SetServices([]common.Service{
+					{
+						Ports:    udpPortSpec,
+						Protocol: 17,
+					},
+					{
+						Ports:    tcpPortSpec,
+						Protocol: 6,
+					},
+				})
+
+				err = i.iptv4.ConfigureRules(0, "pu1", puInfo)
+				So(err, ShouldBeNil)
+				err = i.AddPortToPortSet("pu1", "8080")
+				So(err, ShouldBeNil)
+				t := i.iptv4.impl.RetrieveTable()
+
+				for chain, rules := range t["mangle"] {
+					So(expectedMangleAfterPUInsertWithExtensionsV4, ShouldContainKey, chain)
+					So(rules, ShouldResemble, expectedMangleAfterPUInsertWithExtensionsV4[chain])
+				}
+
+				for chain, rules := range t["nat"] {
+					So(expectedNATAfterPUInsertV4, ShouldContainKey, chain)
+					So(rules, ShouldResemble, expectedNATAfterPUInsertV4[chain])
+				}
+
+				for set, targets := range ipsv4.sets {
+					So(expectedIPSetsAfterPUInsertV4, ShouldContainKey, set)
+					for target := range targets.set {
+						So(expectedIPSetsAfterPUInsertV4[set], ShouldContain, target)
+					}
+				}
+			})
+		})
+	})
+
+	Convey("Given an iptables controller with a memory backend with bad extensions in policy and log enabled", t, func() {
+		cfg := &runtime.Configuration{
+			TCPTargetNetworks: []string{"0.0.0.0/0"},
+			UDPTargetNetworks: []string{"10.0.0.0/8"},
+			ExcludedNetworks:  []string{"127.0.0.1"},
+		}
+
+		commitFunc := func(buf *bytes.Buffer) error {
+			return nil
+		}
+
+		iptv4 := provider.NewCustomBatchProvider(&baseIpt{}, commitFunc, []string{"nat", "mangle"})
+		So(iptv4, ShouldNotBeNil)
+
+		iptv6 := provider.NewCustomBatchProvider(&baseIpt{}, commitFunc, []string{"nat", "mangle"})
+		So(iptv6, ShouldNotBeNil)
+
+		ipsv4 := &memoryIPSetProvider{sets: map[string]*memoryIPSet{}}
+		ipsv6 := &memoryIPSetProvider{sets: map[string]*memoryIPSet{}}
+
+		i, err := createTestInstance(ipsv4, ipsv6, iptv4, iptv6, constants.LocalServer)
+		So(err, ShouldBeNil)
+		So(i, ShouldNotBeNil)
+
+		Convey("When I start the controller, I should get the right global chains and ipsets and proper drop extension should be configured", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := i.Run(ctx)
+			i.SetTargetNetworks(cfg) //nolint
+			So(err, ShouldBeNil)
+
+			for set, targets := range ipsv4.sets {
+				So(expectedGlobalIPSetsV4, ShouldContainKey, set)
+				for target := range targets.set {
+					So(expectedGlobalIPSetsV4[set], ShouldContain, target)
+				}
+			}
+
+			t := i.iptv4.impl.RetrieveTable()
+			So(t, ShouldNotBeNil)
+			So(len(t), ShouldEqual, 2)
+			So(t["mangle"], ShouldNotBeNil)
+			So(t["nat"], ShouldNotBeNil)
+
+			for chain, rules := range t["mangle"] {
+				So(expectedGlobalMangleChainsV4, ShouldContainKey, chain)
+				So(rules, ShouldResemble, expectedGlobalMangleChainsV4[chain])
+			}
+
+			for chain, rules := range t["nat"] {
+				So(expectedGlobalNATChainsV4, ShouldContainKey, chain)
+				So(rules, ShouldResemble, expectedGlobalNATChainsV4[chain])
+			}
+
+			Convey("When I configure a new set of rules, the ACLs must be correct", func() {
+				appACLs := policy.IPRuleList{
+					policy.IPRule{
+						Addresses: []string{"30.0.0.0/24"},
+						Ports:     []string{"80"},
+						Protocols: []string{"TCP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject,
+							ServiceID: "s1",
+							PolicyID:  "1",
+						},
+					},
+					policy.IPRule{
+						Addresses: []string{"30.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"UDP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept | policy.Log,
+							ServiceID: "s2",
+							PolicyID:  "2",
+						},
+						Extensions: []string{" -j DROP"},
+					},
+					policy.IPRule{
+						Addresses: []string{"50.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"icmp"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept,
+							ServiceID: "s3",
+							PolicyID:  "3",
+						},
+					},
+				}
+				netACLs := policy.IPRuleList{
+					policy.IPRule{
+						Addresses: []string{"40.0.0.0/24"},
+						Ports:     []string{"80"},
+						Protocols: []string{"TCP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject,
+							ServiceID: "s3",
+							PolicyID:  "1",
+						},
+					},
+					policy.IPRule{
+						Addresses: []string{"40.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"UDP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept,
+							ServiceID: "s4",
+							PolicyID:  "2",
+						},
+					},
+				}
+				ipl := policy.ExtendedMap{}
+				policyrules := policy.NewPUPolicy(
+					"Context",
+					"/ns1",
+					policy.Police,
+					appACLs,
+					netACLs,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					ipl,
+					0,
+					nil,
+					nil,
+					[]string{},
+				)
+				puInfo := policy.NewPUInfo("Context", "/ns1", common.LinuxProcessPU)
+				puInfo.Policy = policyrules
+				puInfo.Runtime.SetOptions(policy.OptionsType{
+					CgroupMark: "10",
+				})
+
+				udpPortSpec, err := portspec.NewPortSpecFromString("5000", nil)
+				So(err, ShouldBeNil)
+				tcpPortSpec, err := portspec.NewPortSpecFromString("9000", nil)
+				So(err, ShouldBeNil)
+
+				puInfo.Runtime.SetServices([]common.Service{
+					{
+						Ports:    udpPortSpec,
+						Protocol: 17,
+					},
+					{
+						Ports:    tcpPortSpec,
+						Protocol: 6,
+					},
+				})
+
+				err = i.iptv4.ConfigureRules(0, "pu1", puInfo)
+				So(err, ShouldBeNil)
+				err = i.AddPortToPortSet("pu1", "8080")
+				So(err, ShouldBeNil)
+				t := i.iptv4.impl.RetrieveTable()
+
+				for chain, rules := range t["mangle"] {
+					So(expectedMangleAfterPUInsertWithLogV4, ShouldContainKey, chain)
+					So(rules, ShouldResemble, expectedMangleAfterPUInsertWithLogV4[chain])
+				}
+
+				for chain, rules := range t["nat"] {
+					So(expectedNATAfterPUInsertV4, ShouldContainKey, chain)
+					So(rules, ShouldResemble, expectedNATAfterPUInsertV4[chain])
+				}
+
+				for set, targets := range ipsv4.sets {
+					So(expectedIPSetsAfterPUInsertV4, ShouldContainKey, set)
+					for target := range targets.set {
+						So(expectedIPSetsAfterPUInsertV4[set], ShouldContain, target)
+					}
+				}
+			})
+		})
+	})
+
+	Convey("Given an iptables controller with a memory backend with extensions in policy and log enabled", t, func() {
+		cfg := &runtime.Configuration{
+			TCPTargetNetworks: []string{"0.0.0.0/0"},
+			UDPTargetNetworks: []string{"10.0.0.0/8"},
+			ExcludedNetworks:  []string{"127.0.0.1"},
+		}
+
+		commitFunc := func(buf *bytes.Buffer) error {
+			return nil
+		}
+
+		iptv4 := provider.NewCustomBatchProvider(&baseIpt{}, commitFunc, []string{"nat", "mangle"})
+		So(iptv4, ShouldNotBeNil)
+
+		iptv6 := provider.NewCustomBatchProvider(&baseIpt{}, commitFunc, []string{"nat", "mangle"})
+		So(iptv6, ShouldNotBeNil)
+
+		ipsv4 := &memoryIPSetProvider{sets: map[string]*memoryIPSet{}}
+		ipsv6 := &memoryIPSetProvider{sets: map[string]*memoryIPSet{}}
+
+		i, err := createTestInstance(ipsv4, ipsv6, iptv4, iptv6, constants.LocalServer)
+		So(err, ShouldBeNil)
+		So(i, ShouldNotBeNil)
+
+		Convey("When I start the controller, I should get the right global chains and ipsets and proper drop extension should be configured", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := i.Run(ctx)
+			i.SetTargetNetworks(cfg) //nolint
+			So(err, ShouldBeNil)
+
+			for set, targets := range ipsv4.sets {
+				So(expectedGlobalIPSetsV4, ShouldContainKey, set)
+				for target := range targets.set {
+					So(expectedGlobalIPSetsV4[set], ShouldContain, target)
+				}
+			}
+
+			t := i.iptv4.impl.RetrieveTable()
+			So(t, ShouldNotBeNil)
+			So(len(t), ShouldEqual, 2)
+			So(t["mangle"], ShouldNotBeNil)
+			So(t["nat"], ShouldNotBeNil)
+
+			for chain, rules := range t["mangle"] {
+				So(expectedGlobalMangleChainsV4, ShouldContainKey, chain)
+				So(rules, ShouldResemble, expectedGlobalMangleChainsV4[chain])
+			}
+
+			for chain, rules := range t["nat"] {
+				So(expectedGlobalNATChainsV4, ShouldContainKey, chain)
+				So(rules, ShouldResemble, expectedGlobalNATChainsV4[chain])
+			}
+
+			Convey("When I configure a new set of rules, the ACLs must be correct", func() {
+				appACLs := policy.IPRuleList{
+					policy.IPRule{
+						Addresses: []string{"30.0.0.0/24"},
+						Ports:     []string{"80"},
+						Protocols: []string{"TCP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject,
+							ServiceID: "s1",
+							PolicyID:  "1",
+						},
+					},
+					policy.IPRule{
+						Addresses: []string{"30.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"UDP"},
+						Policy: &policy.FlowPolicy{
+							// Log enabled.
+							Action:    policy.Accept | policy.Log,
+							ServiceID: "s2",
+							PolicyID:  "2",
+						},
+						Extensions: []string{"-m bpf --bytecode \"20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535\" -j DROP"},
+					},
+					policy.IPRule{
+						Addresses: []string{"50.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"icmp"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept,
+							ServiceID: "s3",
+							PolicyID:  "3",
+						},
+					},
+				}
+				netACLs := policy.IPRuleList{
+					policy.IPRule{
+						Addresses: []string{"40.0.0.0/24"},
+						Ports:     []string{"80"},
+						Protocols: []string{"TCP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject,
+							ServiceID: "s3",
+							PolicyID:  "1",
+						},
+					},
+					policy.IPRule{
+						Addresses: []string{"40.0.0.0/24"},
+						Ports:     []string{"443"},
+						Protocols: []string{"UDP"},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept,
+							ServiceID: "s4",
+							PolicyID:  "2",
+						},
+					},
+				}
+				ipl := policy.ExtendedMap{}
+				policyrules := policy.NewPUPolicy(
+					"Context",
+					"/ns1",
+					policy.Police,
+					appACLs,
+					netACLs,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					ipl,
+					0,
+					nil,
+					nil,
+					[]string{},
+				)
+				puInfo := policy.NewPUInfo("Context", "/ns1", common.LinuxProcessPU)
+				puInfo.Policy = policyrules
+				puInfo.Runtime.SetOptions(policy.OptionsType{
+					CgroupMark: "10",
+				})
+
+				udpPortSpec, err := portspec.NewPortSpecFromString("5000", nil)
+				So(err, ShouldBeNil)
+				tcpPortSpec, err := portspec.NewPortSpecFromString("9000", nil)
+				So(err, ShouldBeNil)
+
+				puInfo.Runtime.SetServices([]common.Service{
+					{
+						Ports:    udpPortSpec,
+						Protocol: 17,
+					},
+					{
+						Ports:    tcpPortSpec,
+						Protocol: 6,
+					},
+				})
+
+				err = i.iptv4.ConfigureRules(0, "pu1", puInfo)
+				So(err, ShouldBeNil)
+				err = i.AddPortToPortSet("pu1", "8080")
+				So(err, ShouldBeNil)
+				t := i.iptv4.impl.RetrieveTable()
+
+				for chain, rules := range t["mangle"] {
+					So(expectedMangleAfterPUInsertWithExtensionsAndLogV4, ShouldContainKey, chain)
+					So(rules, ShouldResemble, expectedMangleAfterPUInsertWithExtensionsAndLogV4[chain])
+				}
+
+				for chain, rules := range t["nat"] {
+					So(expectedNATAfterPUInsertV4, ShouldContainKey, chain)
+					So(rules, ShouldResemble, expectedNATAfterPUInsertV4[chain])
+				}
+
+				for set, targets := range ipsv4.sets {
+					So(expectedIPSetsAfterPUInsertV4, ShouldContainKey, set)
+					for target := range targets.set {
+						So(expectedIPSetsAfterPUInsertV4[set], ShouldContain, target)
+					}
+				}
 			})
 		})
 	})

--- a/policy/types.go
+++ b/policy/types.go
@@ -186,6 +186,17 @@ func (f *FlowPolicy) LogPrefix(contextID string) string {
 	return hash + ":" + f.PolicyID + ":" + f.ServiceID + ":" + f.EncodedActionString()
 }
 
+// LogPrefixAction is the prefix used in nf-log action with the given action.
+func (f *FlowPolicy) LogPrefixAction(contextID string, action string) string {
+
+	hash, err := Fnv32Hash(contextID)
+	if err != nil {
+		zap.L().Warn("unable to generate log prefix hash", zap.Error(err))
+	}
+
+	return hash + ":" + f.PolicyID + ":" + f.ServiceID + ":" + action
+}
+
 // DefaultLogPrefix return the prefix used in nf-log action for default rule.
 func DefaultLogPrefix(contextID string) string {
 

--- a/policy/types.go
+++ b/policy/types.go
@@ -187,11 +187,16 @@ func (f *FlowPolicy) LogPrefix(contextID string) string {
 }
 
 // LogPrefixAction is the prefix used in nf-log action with the given action.
+// NOTE: If 0 or empty action is passed, the default is reject (6).
 func (f *FlowPolicy) LogPrefixAction(contextID string, action string) string {
 
 	hash, err := Fnv32Hash(contextID)
 	if err != nil {
 		zap.L().Warn("unable to generate log prefix hash", zap.Error(err))
+	}
+
+	if len(action) == 0 || action == "0" {
+		action = "6"
 	}
 
 	return hash + ":" + f.PolicyID + ":" + f.ServiceID + ":" + action

--- a/policy/types_test.go
+++ b/policy/types_test.go
@@ -64,6 +64,44 @@ func TestLogPrefix(t *testing.T) {
 	})
 }
 
+func TestLogPrefixAction(t *testing.T) {
+	Convey("When I request log prefix action 6", t, func() {
+		f := &FlowPolicy{
+			Action:        Accept,
+			ObserveAction: ObserveNone,
+			PolicyID:      "deadbeef",
+			ServiceID:     "beaddead",
+		}
+		Convey("I should have the correct log prefix", func() {
+			So(f.LogPrefixAction("somecontextID", "6"), ShouldEqual, "3985287229:deadbeef:beaddead:6")
+		})
+	})
+
+	Convey("When I request log prefix action 0", t, func() {
+		f := &FlowPolicy{
+			Action:        Accept,
+			ObserveAction: ObserveNone,
+			PolicyID:      "deadbeef",
+			ServiceID:     "beaddead",
+		}
+		Convey("I should have the correct log prefix", func() {
+			So(f.LogPrefixAction("somecontextID", "0"), ShouldEqual, "3985287229:deadbeef:beaddead:6")
+		})
+	})
+
+	Convey("When I request log prefix action empty", t, func() {
+		f := &FlowPolicy{
+			Action:        Accept,
+			ObserveAction: ObserveNone,
+			PolicyID:      "deadbeef",
+			ServiceID:     "beaddead",
+		}
+		Convey("I should have the correct log prefix", func() {
+			So(f.LogPrefixAction("somecontextID", ""), ShouldEqual, "3985287229:deadbeef:beaddead:6")
+		})
+	})
+}
+
 func TestFnv32(t *testing.T) {
 
 	Convey("When I request log prefix with no data", t, func() {


### PR DESCRIPTION
>> WARNING: Make sure the rule contains the action at the end. 
For example:
This will work
iptables -A INPUT -p tcp --dport 20 -j DROP
This will NOT work
iptables -A INPUT -j DROP -p tcp --dport 20 

--> Provides visibility to the extension rules when the log option in in policy is enabled.
--> Extensions like this,
```console
"-m u32 ! --u32 \"6&0xFF=1\" -j DROP",
"--match multiport --dports 53 -m bpf --bytecode \"20,0 0 0 0,177 0 0 0,12 0 0 0,7 0 0 0,72 0 0 4,53 0 13 29,135 0 0 0,4 0 0 8,7 0 0 0,72 0 0 2,84 0 0 64655,21 0 7 0,72 0 0 4,21 0 5 1,64 0 0 6,21 0 3 0,72 0 0 10,37 1 0 1,6 0 0 0,6 0 0 65535\" -j DROP"
```
will program iptable rules like this on top of pu chain,
```console
Chain TRI-App-3079t_0RXU-0 (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 NFLOG      icmp --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-1NBdR3079zqUx dst u32 ! "0x6&0xff=0x1" state NEW nflog-prefix  "11963819:5d2510195ed69729b398dc8e:5d4b60655ed69791ec9c8df1:6" nflog-group 10
    0     0 DROP       icmp --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-1NBdR3079zqUx dst u32 ! "0x6&0xff=0x1"
    0     0 NFLOG      udp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-MvAKq3079zqUx dst multiport dports 53bpf [unsupported revision]  state NEW nflog-prefix  "11963819:5d2510195ed69729b398dc8e:5d3fec3fc7820f30f6cbdaf7:6" nflog-group 10
    0     0 DROP       udp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-MvAKq3079zqUx dst multiport dports 53bpf [unsupported revision]
...
```

>> NOTE: The protocol is from iprule, because otherwise the report endpoint will point to a different policy. Ports are optional because, protcols like icmp doesn't work on ports.