### PR TITLE
k8s Monitor: Add SandboxID fix. (#856)

### DIFF
--- a/monitor/extractors/interface.go
+++ b/monitor/extractors/interface.go
@@ -21,6 +21,9 @@ type EventMetadataExtractor func(*common.EventInfo) (*policy.PURuntime, error)
 // The 5th argument (bool) indicates if a network namespace should get extracted
 type PodMetadataExtractor func(context.Context, client.Client, *runtime.Scheme, *corev1.Pod, bool) (*policy.PURuntime, error)
 
+// PodSandboxExtractor is a function used to extract the SandboxID from a given pod.
+type PodSandboxExtractor func(context.Context, *corev1.Pod) (string, error)
+
 // PodNetclsProgrammer is a function used to program the net_cls cgroup of a pod for Trireme.
 // This has to be used when Trireme is used in conjunction with pods that are in HostNetwork=true mode.
 type PodNetclsProgrammer func(context.Context, *corev1.Pod, policy.RuntimeReader) error

--- a/monitor/internal/pod/config.go
+++ b/monitor/internal/pod/config.go
@@ -13,6 +13,7 @@ type Config struct { // nolint
 	MetadataExtractor extractors.PodMetadataExtractor
 	NetclsProgrammer  extractors.PodNetclsProgrammer
 	ResetNetcls       extractors.ResetNetclsKubepods
+	SandboxExtractor  extractors.PodSandboxExtractor
 }
 
 // DefaultConfig provides a default configuration
@@ -21,6 +22,7 @@ func DefaultConfig() *Config {
 		MetadataExtractor: nil,
 		NetclsProgrammer:  nil,
 		ResetNetcls:       nil,
+		SandboxExtractor:  nil,
 		EnableHostPods:    false,
 		Kubeconfig:        "",
 		Nodename:          "",

--- a/monitor/internal/pod/controller.go
+++ b/monitor/internal/pod/controller.go
@@ -41,7 +41,7 @@ var (
 )
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, handler *config.ProcessorConfig, metadataExtractor extractors.PodMetadataExtractor, netclsProgrammer extractors.PodNetclsProgrammer, nodeName string, enableHostPods bool, deleteCh chan<- DeleteEvent, deleteReconcileCh chan<- struct{}) *ReconcilePod {
+func newReconciler(mgr manager.Manager, handler *config.ProcessorConfig, metadataExtractor extractors.PodMetadataExtractor, netclsProgrammer extractors.PodNetclsProgrammer, sandboxExtractor extractors.PodSandboxExtractor, nodeName string, enableHostPods bool, deleteCh chan<- DeleteEvent, deleteReconcileCh chan<- struct{}) *ReconcilePod {
 	return &ReconcilePod{
 		client:            mgr.GetClient(),
 		scheme:            mgr.GetScheme(),
@@ -49,6 +49,7 @@ func newReconciler(mgr manager.Manager, handler *config.ProcessorConfig, metadat
 		handler:           handler,
 		metadataExtractor: metadataExtractor,
 		netclsProgrammer:  netclsProgrammer,
+		sandboxExtractor:  sandboxExtractor,
 		nodeName:          nodeName,
 		enableHostPods:    enableHostPods,
 		deleteCh:          deleteCh,
@@ -101,8 +102,9 @@ var _ reconcile.Reconciler = &ReconcilePod{}
 // them for real deletion in the Kubernetes API. Once an object is gone, we will
 // send down destroy events to trireme.
 type DeleteEvent struct {
-	NativeID string
-	Key      client.ObjectKey
+	PodUID        string
+	SandboxID     string
+	NamespaceName client.ObjectKey
 }
 
 // ReconcilePod reconciles a Pod object
@@ -115,6 +117,7 @@ type ReconcilePod struct {
 	handler           *config.ProcessorConfig
 	metadataExtractor extractors.PodMetadataExtractor
 	netclsProgrammer  extractors.PodNetclsProgrammer
+	sandboxExtractor  extractors.PodSandboxExtractor
 	nodeName          string
 	enableHostPods    bool
 	deleteCh          chan<- DeleteEvent
@@ -129,7 +132,8 @@ type ReconcilePod struct {
 func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.Background()
 	nn := request.NamespacedName.String()
-
+	var puID, sandboxID string
+	var err error
 	// Fetch the corresponding pod object.
 	pod := &corev1.Pod{}
 	if err := r.client.Get(ctx, request.NamespacedName, pod); err != nil {
@@ -141,8 +145,12 @@ func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, e
 		return reconcile.Result{}, err
 	}
 
-	puID := string(pod.GetUID())
-
+	sandboxID, err = r.sandboxExtractor(ctx, pod)
+	if err != nil {
+		// Do nothing if we can't find the sandboxID
+		zap.L().Debug("Pod reconcile: Cannot extract the SandboxID for ", zap.String("podname: ", nn))
+	}
+	puID = string(pod.GetUID())
 	// abort immediately if this is a HostNetwork pod, but we don't want to activate them
 	// NOTE: is already done in the mapper, however, this additional check does not hurt
 	if pod.Spec.HostNetwork && !r.enableHostPods {
@@ -154,8 +162,9 @@ func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, e
 	// if we reconcile though and the pod exists, we definitely know though
 	// that it must go away at some point, so always register it with the delete controller
 	r.deleteCh <- DeleteEvent{
-		NativeID: puID,
-		Key:      request.NamespacedName,
+		PodUID:        puID,
+		SandboxID:     sandboxID,
+		NamespaceName: request.NamespacedName,
 	}
 
 	// try to find out if any of the containers have been started yet
@@ -219,7 +228,10 @@ func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, e
 		if pod.DeletionTimestamp != nil {
 			return reconcile.Result{}, nil
 		}
-
+		// If the pod hasn't started or if there is no sandbox present, requeue.
+		if sandboxID == "" || !started {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		if started {
 			// if the metadata extractor is missing the PID or nspath, we need to try again
 			// we need it for starting the PU. However, only require this if we are not in host network mode.
@@ -293,6 +305,20 @@ func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, e
 		// every HandlePUEvent call gets done in this context
 		handlePUCtx, handlePUCancel := context.WithTimeout(ctx, r.handlePUEventTimeout)
 		defer handlePUCancel()
+
+		if err := r.handler.Policy.HandlePUEvent(
+			handlePUCtx,
+			puID,
+			common.EventUpdate,
+			puRuntime,
+		); err != nil {
+			zap.L().Error("failed to handle update event", zap.String("puID", puID), zap.String("namespacedName", nn), zap.Error(err))
+			r.recorder.Eventf(pod, "Warning", "PUUpdate", "failed to handle update event for PU '%s': %s", puID, err.Error())
+			// return reconcile.Result{}, err
+		} else {
+			r.recorder.Eventf(pod, "Normal", "PUUpdate", "PU '%s' updated successfully", puID)
+		}
+
 		if err := r.handler.Policy.HandlePUEvent(
 			handlePUCtx,
 			puID,

--- a/monitor/internal/pod/delete_controller.go
+++ b/monitor/internal/pod/delete_controller.go
@@ -6,15 +6,17 @@ import (
 
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
+	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/policy"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 // deleteControllerReconcileFunc is the reconciler function signature for the DeleteController
-type deleteControllerReconcileFunc func(context.Context, client.Client, *config.ProcessorConfig, time.Duration, *map[string]client.ObjectKey)
+type deleteControllerReconcileFunc func(context.Context, client.Client, *config.ProcessorConfig, time.Duration, map[string]DeleteObject, extractors.PodSandboxExtractor, chan event.GenericEvent)
 
 // DeleteController is responsible for cleaning up after Kubernetes because we
 // are missing our native ID on the last reconcile event where the pod has already
@@ -31,10 +33,19 @@ type DeleteController struct {
 	reconcileFunc      deleteControllerReconcileFunc
 	tickerPeriod       time.Duration
 	itemProcessTimeout time.Duration
+	sandboxExtractor   extractors.PodSandboxExtractor
+	eventsCh           chan event.GenericEvent
+}
+
+// DeleteObject is the obj used to store in the event map.
+type DeleteObject struct {
+	podUID    string
+	sandboxID string
+	podName   client.ObjectKey
 }
 
 // NewDeleteController creates a new DeleteController.
-func NewDeleteController(c client.Client, pc *config.ProcessorConfig) *DeleteController {
+func NewDeleteController(c client.Client, pc *config.ProcessorConfig, sandboxExtractor extractors.PodSandboxExtractor, eventsCh chan event.GenericEvent) *DeleteController {
 	return &DeleteController{
 		client:             c,
 		handler:            pc,
@@ -43,6 +54,8 @@ func NewDeleteController(c client.Client, pc *config.ProcessorConfig) *DeleteCon
 		reconcileFunc:      deleteControllerReconcile,
 		tickerPeriod:       5 * time.Second,
 		itemProcessTimeout: 30 * time.Second,
+		sandboxExtractor:   sandboxExtractor,
+		eventsCh:           eventsCh,
 	}
 }
 
@@ -60,17 +73,21 @@ func (c *DeleteController) GetReconcileCh() chan<- struct{} {
 func (c *DeleteController) Start(z <-chan struct{}) error {
 	backgroundCtx := context.Background()
 	t := time.NewTicker(c.tickerPeriod)
-	m := make(map[string]client.ObjectKey)
+	m := make(map[string]DeleteObject)
 
 	// the poor man's controller loop
 	for {
 		select {
 		case ev := <-c.deleteCh:
-			m[ev.NativeID] = ev.Key
+			obj := DeleteObject{podUID: ev.PodUID, sandboxID: ev.SandboxID, podName: ev.NamespaceName}
+			// here don't update the map, insert only if not present.
+			if _, ok := m[ev.PodUID]; !ok {
+				m[ev.PodUID] = obj
+			}
 		case <-c.reconcileCh:
-			c.reconcileFunc(backgroundCtx, c.client, c.handler, c.itemProcessTimeout, &m)
+			c.reconcileFunc(backgroundCtx, c.client, c.handler, c.itemProcessTimeout, m, c.sandboxExtractor, c.eventsCh)
 		case <-t.C:
-			c.reconcileFunc(backgroundCtx, c.client, c.handler, c.itemProcessTimeout, &m)
+			c.reconcileFunc(backgroundCtx, c.client, c.handler, c.itemProcessTimeout, m, c.sandboxExtractor, c.eventsCh)
 		case <-z:
 			t.Stop()
 			return nil
@@ -79,13 +96,20 @@ func (c *DeleteController) Start(z <-chan struct{}) error {
 }
 
 // deleteControllerReconcile is the real reconciler implementation for the DeleteController
-func deleteControllerReconcile(backgroundCtx context.Context, c client.Client, pc *config.ProcessorConfig, itemProcessTimeout time.Duration, m *map[string]client.ObjectKey) {
-	for nativeID, req := range *m {
-		deleteControllerProcessItem(backgroundCtx, c, pc, itemProcessTimeout, m, nativeID, req)
+func deleteControllerReconcile(backgroundCtx context.Context, c client.Client, pc *config.ProcessorConfig, itemProcessTimeout time.Duration, m map[string]DeleteObject, sandboxExtractor extractors.PodSandboxExtractor, eventCh chan event.GenericEvent) {
+	for podUID, req := range m {
+		deleteControllerProcessItem(backgroundCtx, c, pc, itemProcessTimeout, m, podUID, req.podName, sandboxExtractor, eventCh)
 	}
 }
 
-func deleteControllerProcessItem(backgroundCtx context.Context, c client.Client, pc *config.ProcessorConfig, itemProcessTimeout time.Duration, m *map[string]client.ObjectKey, nativeID string, req client.ObjectKey) {
+func deleteControllerProcessItem(backgroundCtx context.Context, c client.Client, pc *config.ProcessorConfig, itemProcessTimeout time.Duration, m map[string]DeleteObject, podUID string, req client.ObjectKey, sandboxExtractor extractors.PodSandboxExtractor, eventCh chan event.GenericEvent) {
+	//var err error
+	var ok bool
+	var delObj DeleteObject
+	if delObj, ok = m[podUID]; !ok {
+		zap.L().Warn("DeleteController: nativeID not found in delete controller map", zap.String("nativeID", podUID))
+		return
+	}
 	ctx, cancel := context.WithTimeout(backgroundCtx, itemProcessTimeout)
 	defer cancel()
 	pod := &corev1.Pod{}
@@ -95,38 +119,100 @@ func deleteControllerProcessItem(backgroundCtx context.Context, c client.Client,
 			// so just send a destroy event
 			if err := pc.Policy.HandlePUEvent(
 				ctx,
-				nativeID,
+				podUID,
 				common.EventDestroy,
 				policy.NewPURuntimeWithDefaults(),
 			); err != nil {
 				// we don't really care, we just warn
-				zap.L().Warn("failed to handle destroy event", zap.String("puID", nativeID), zap.String("namespacedName", req.String()), zap.Error(err))
+				zap.L().Warn("DeleteController: Failed to handle destroy event", zap.String("puID", podUID), zap.String("namespacedName", req.String()), zap.Error(err))
 			}
 			// we only fire events away, we don't really care about the error anyway
 			// it is up to the policy engine to make sense of that
-			delete(*m, nativeID)
+			delete(m, podUID)
 		} else {
 			// we don't really care, we just warn
-			zap.L().Warn("failed to get pod from Kubernetes API", zap.String("puID", nativeID), zap.String("namespacedName", req.String()), zap.Error(err))
+			zap.L().Warn("DeleteController: Failed to get pod from Kubernetes API", zap.String("puID", podUID), zap.String("namespacedName", req.String()), zap.Error(err))
 		}
 		return
 	}
 
 	// the edge case: a pod with the same namespaced name came up and we have missed a delete event
 	// this means that this pod belongs to a different PU and must live, therefore we try to delete the old one
-	if nativeID != string(pod.GetUID()) {
-		zap.L().Error("Pod does not have expected native ID, we must have missed an event and the same pod was recreated. Trying to destroy PU", zap.String("puID", nativeID), zap.String("namespacedName", req.String()), zap.String("podUID", string(pod.GetUID())))
+
+	// the following code also takes care of any restarts in the Pod, the restarts can be caused by either
+	// the sandbox getting killed or all the containers restarting due a crash or kill.
+
+	// Now destroy the PU only if the following
+	// 1. Simple case if the pod UID don't match then go ahead and destroy the PU.
+	// 2. When the pod UID match then do the following:
+	//		2.a Get the current SandboxID from the pod.
+	// 		2.b Get the sandboxID from the map.
+	// 		2.c If the sandBoxID differ then send the destroy event for the old(map) sandBoxID.
+
+	// 1st case, simple if the pod UID don't match then just call the destroy PU event and delete the map entry with the old key.
+	if string(pod.UID) != delObj.podUID {
+
+		zap.L().Warn("DeleteController: Pod does not have expected native ID, we must have missed an event and the same pod was recreated. Trying to destroy PU", zap.String("puID", podUID), zap.String("namespacedName", req.String()), zap.String("podUID", string(pod.GetUID())))
 		if err := pc.Policy.HandlePUEvent(
 			ctx,
-			nativeID,
+			podUID,
 			common.EventDestroy,
 			policy.NewPURuntimeWithDefaults(),
 		); err != nil {
 			// we don't really care, we just warn
-			zap.L().Warn("failed to handle destroy event", zap.String("puID", nativeID), zap.String("namespacedName", req.String()), zap.Error(err))
+			zap.L().Warn("DeleteController: Failed to handle destroy event", zap.String("puID", podUID), zap.String("namespacedName", req.String()), zap.Error(err))
 		}
 		// we only fire events away, we don't really care about the error anyway
 		// it is up to the policy engine to make sense of that
-		delete(*m, nativeID)
+		delete(m, podUID)
+		return
+	}
+
+	// now the 2nd case, when pod UID match
+	if string(pod.UID) == delObj.podUID {
+		zap.L().Debug("DeleteController: the pod UID Match happened, delete the", zap.String("podName:", req.String()), zap.String("podUID", string(pod.UID)))
+		// 2a get the current sandboxID
+		if sandboxExtractor == nil {
+			return
+		}
+		currentSandboxID, err := sandboxExtractor(ctx, pod)
+		if err != nil {
+			zap.L().Debug("DeleteController: cannot extract the SandboxID, return", zap.String("namespacedName", req.String()), zap.String("podUID", string(pod.GetUID())))
+			return
+		}
+		// update the map with the sandboxID
+		// here we update the map only if the sandboxID has not been extracted.
+		// The extraction of the sandboxID if  missed by the main controller then we will update the map below.
+		if delObj.sandboxID == "" {
+			delObj = DeleteObject{podUID: podUID, sandboxID: currentSandboxID, podName: req}
+			m[podUID] = delObj
+		}
+		// 2b get the pod/old sandboxID
+		oldSandboxID := delObj.sandboxID
+
+		zap.L().Debug("DeleteController:", zap.String(" the sandboxID, curr:", currentSandboxID), zap.String(" old sandboxID: ", oldSandboxID))
+		// 2c compare the oldSandboxID and currentSandboxID, if they differ then destroy the PU
+		if oldSandboxID != currentSandboxID {
+			zap.L().Debug("DeleteController: Pod SandboxID differ. Trying to destroy PU", zap.String("namespacedName", req.String()), zap.String("currentSandboxID", currentSandboxID), zap.String("oldSandboxID", oldSandboxID))
+			if err := pc.Policy.HandlePUEvent(
+				ctx,
+				podUID,
+				common.EventDestroy,
+				policy.NewPURuntimeWithDefaults(),
+			); err != nil {
+				// we don't really care, we just warn
+				zap.L().Warn("DeleteController: Failed to handle destroy event", zap.String("puID", podUID), zap.String("namespacedName", req.String()), zap.Error(err))
+			}
+			// we only fire events away, we don't really care about the error anyway
+			// it is up to the policy engine to make sense of that
+			delete(m, podUID)
+			zap.L().Debug("DeleteController: PU destroyed, now send event for the pod-controller to reconcile", zap.String(" podName: ", req.String()))
+			// below we send event to the main pod-controller to reconcile again and to create a PU if it is not created yet.
+			eventCh <- event.GenericEvent{
+				Object: pod,
+				Meta:   pod.GetObjectMeta(),
+			}
+			return
+		}
 	}
 }

--- a/monitor/internal/pod/delete_controller_test.go
+++ b/monitor/internal/pod/delete_controller_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/monitor/config"
+	"go.aporeto.io/trireme-lib/monitor/extractors"
 	"go.aporeto.io/trireme-lib/policy/mockpolicy"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 func TestDeleteControllerFunctionality(t *testing.T) {
@@ -32,7 +34,7 @@ func TestDeleteControllerFunctionality(t *testing.T) {
 			},
 		}
 		c := fakeclient.NewFakeClient(pod1)
-
+		eventsCh := make(chan event.GenericEvent)
 		handler := mockpolicy.NewMockResolver(ctrl)
 
 		pc := &config.ProcessorConfig{
@@ -46,63 +48,71 @@ func TestDeleteControllerFunctionality(t *testing.T) {
 
 		Convey("then no destroy events should be sent if there is nothing in the state right now", func() {
 			handler.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), common.EventDestroy, gomock.Any()).Return(nil).Times(0)
-			m := make(map[string]client.ObjectKey)
-			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, &m)
+			m := make(map[string]DeleteObject)
+			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, m, nil, eventsCh)
 			So(m, ShouldBeEmpty)
 		})
 
 		Convey("then *no* destroy events should be sent if the pod with the same namespaced name and UID still exists in the Kubernetes API", func() {
 			handler.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), common.EventDestroy, gomock.Any()).Return(nil).Times(0)
-			m := make(map[string]client.ObjectKey)
-			m["aaaa"] = client.ObjectKey{
+			m := make(map[string]DeleteObject)
+			nn := client.ObjectKey{
 				Name:      "pod1",
 				Namespace: "default",
 			}
-			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, &m)
+			m["aaaa"] = DeleteObject{podUID: "aaaa", sandboxID: "", podName: nn}
+			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, m, nil, eventsCh)
 			So(m, ShouldHaveLength, 1)
 		})
 
 		Convey("then a destroy event should be sent if the pod with the same namespaced name but *different* UID exists in the Kubernetes API", func() {
 			handler.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), common.EventDestroy, gomock.Any()).Return(nil).Times(1)
-			m := make(map[string]client.ObjectKey)
-			m["bbbb"] = client.ObjectKey{
+			m := make(map[string]DeleteObject)
+			nn := client.ObjectKey{
 				Name:      "pod1",
 				Namespace: "default",
 			}
-			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, &m)
+			m["bbbb"] = DeleteObject{podUID: "", sandboxID: "", podName: nn}
+			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, m, nil, eventsCh)
 			So(m, ShouldBeEmpty)
 		})
 
 		Convey("then a destroy event should be sent if the pod does not exist in the Kubernetes API", func() {
 			handler.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), common.EventDestroy, gomock.Any()).Return(nil).Times(1)
-			m := make(map[string]client.ObjectKey)
-			m["aaaa"] = client.ObjectKey{
+			m := make(map[string]DeleteObject)
+
+			nn := client.ObjectKey{
 				Name:      "pod2",
 				Namespace: "default",
 			}
-			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, &m)
+			m["aaaa"] = DeleteObject{podUID: "", sandboxID: "", podName: nn}
+			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, m, nil, eventsCh)
 			So(m, ShouldBeEmpty)
 		})
 
 		Convey("then a destroy event should be sent if the pod with the same namespaced name but *different* UID exists in the Kubernetes API, and it should still be removed from the map if it fails", func() {
 			handler.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), common.EventDestroy, gomock.Any()).Return(failure).Times(1)
-			m := make(map[string]client.ObjectKey)
-			m["bbbb"] = client.ObjectKey{
+			m := make(map[string]DeleteObject)
+
+			nn := client.ObjectKey{
 				Name:      "pod1",
 				Namespace: "default",
 			}
-			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, &m)
+			m["bbbb"] = DeleteObject{podUID: "", sandboxID: "", podName: nn}
+			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, m, nil, eventsCh)
 			So(m, ShouldBeEmpty)
 		})
 
 		Convey("then a destroy event should be sent if the pod does not exist in the Kubernetes API, and it should still be removed from the map if it fails", func() {
 			handler.EXPECT().HandlePUEvent(gomock.Any(), gomock.Any(), common.EventDestroy, gomock.Any()).Return(failure).Times(1)
-			m := make(map[string]client.ObjectKey)
-			m["aaaa"] = client.ObjectKey{
+			m := make(map[string]DeleteObject)
+
+			nn := client.ObjectKey{
 				Name:      "pod2",
 				Namespace: "default",
 			}
-			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, &m)
+			m["aaaa"] = DeleteObject{podUID: "", sandboxID: "", podName: nn}
+			deleteControllerReconcile(ctx, c, pc, itemProcessTimeout, m, nil, eventsCh)
 			So(m, ShouldBeEmpty)
 		})
 	})
@@ -112,15 +122,16 @@ func TestDeleteController(t *testing.T) {
 	Convey("Given a delete controller", t, func() {
 		z := make(chan struct{})
 
-		testMap := make(map[string]client.ObjectKey)
+		testMap := make(map[string]DeleteObject)
+		eventsCh := make(chan event.GenericEvent)
 		//nolint:unparam
-		reconcileFunc := func(ctx context.Context, c client.Client, pc *config.ProcessorConfig, t time.Duration, m *map[string]client.ObjectKey) {
-			for k, v := range *m {
+		reconcileFunc := func(ctx context.Context, c client.Client, pc *config.ProcessorConfig, t time.Duration, m map[string]DeleteObject, s extractors.PodSandboxExtractor, eventsCh chan event.GenericEvent) {
+			for k, v := range m {
 				testMap[k] = v
 			}
 		}
 
-		dc := NewDeleteController(nil, nil)
+		dc := NewDeleteController(nil, nil, nil, eventsCh)
 		dc.deleteCh = make(chan DeleteEvent)
 		dc.reconcileCh = make(chan struct{})
 		dc.tickerPeriod = 1 * time.Second
@@ -129,13 +140,20 @@ func TestDeleteController(t *testing.T) {
 
 		Convey("it should be able to receive delete events, and access them during a reconcile", func() {
 			ev := DeleteEvent{
-				NativeID: "aaaa",
-				Key: client.ObjectKey{
+				PodUID: "aaaa",
+				NamespaceName: client.ObjectKey{
 					Name:      "pod1",
 					Namespace: "default",
 				},
 			}
-
+			exp := DeleteObject{
+				podUID:    "aaaa",
+				sandboxID: "",
+				podName: client.ObjectKey{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+			}
 			go func() {
 				dc.GetDeleteCh() <- ev
 				dc.GetReconcileCh() <- struct{}{}
@@ -144,19 +162,26 @@ func TestDeleteController(t *testing.T) {
 
 			err := dc.Start(z)
 			So(err, ShouldBeNil)
-			So(testMap, ShouldContainKey, ev.NativeID)
-			So(testMap[ev.NativeID], ShouldResemble, ev.Key)
+			So(testMap, ShouldContainKey, ev.PodUID)
+			So(testMap[ev.PodUID], ShouldResemble, exp)
 		})
 
 		Convey("it should be able to receive delete events, and access them during a reconcile that was triggered through the ticker", func() {
 			ev := DeleteEvent{
-				NativeID: "aaaa",
-				Key: client.ObjectKey{
+				PodUID: "aaaa",
+				NamespaceName: client.ObjectKey{
 					Name:      "pod1",
 					Namespace: "default",
 				},
 			}
-
+			exp := DeleteObject{
+				podUID:    "aaaa",
+				sandboxID: "",
+				podName: client.ObjectKey{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+			}
 			go func() {
 				dc.GetDeleteCh() <- ev
 				// sleeping for twice the ticker period should always trigger the reconcile
@@ -166,12 +191,12 @@ func TestDeleteController(t *testing.T) {
 
 			err := dc.Start(z)
 			So(err, ShouldBeNil)
-			So(testMap, ShouldContainKey, ev.NativeID)
-			So(testMap[ev.NativeID], ShouldResemble, ev.Key)
+			So(testMap, ShouldContainKey, ev.PodUID)
+			So(testMap[ev.PodUID], ShouldResemble, exp)
 		})
 
 		Reset(func() {
-			testMap = make(map[string]client.ObjectKey)
+			testMap = make(map[string]DeleteObject)
 			dc = &DeleteController{
 				client:             nil,
 				handler:            nil,

--- a/monitor/internal/pod/monitor.go
+++ b/monitor/internal/pod/monitor.go
@@ -28,6 +28,7 @@ type PodMonitor struct {
 	metadataExtractor extractors.PodMetadataExtractor
 	netclsProgrammer  extractors.PodNetclsProgrammer
 	resetNetcls       extractors.ResetNetclsKubepods
+	sandboxExtractor  extractors.PodSandboxExtractor
 	enableHostPods    bool
 	kubeCfg           *rest.Config
 	kubeClient        client.Client
@@ -87,13 +88,16 @@ func (m *PodMonitor) SetupConfig(registerer registerer.Registerer, cfg interface
 	if kubernetesconfig.ResetNetcls == nil {
 		return fmt.Errorf("missing reset net_cls implementation")
 	}
-
+	if kubernetesconfig.SandboxExtractor == nil {
+		return fmt.Errorf("missing SandboxExtractor implementation")
+	}
 	// Setting up Kubernetes
 	m.kubeCfg = kubeCfg
 	m.localNode = kubernetesconfig.Nodename
 	m.enableHostPods = kubernetesconfig.EnableHostPods
 	m.metadataExtractor = kubernetesconfig.MetadataExtractor
 	m.netclsProgrammer = kubernetesconfig.NetclsProgrammer
+	m.sandboxExtractor = kubernetesconfig.SandboxExtractor
 	m.resetNetcls = kubernetesconfig.ResetNetcls
 
 	return nil
@@ -127,13 +131,13 @@ func (m *PodMonitor) Run(ctx context.Context) error {
 	}
 
 	// Create the delete event controller first
-	dc := NewDeleteController(mgr.GetClient(), m.handlers)
+	dc := NewDeleteController(mgr.GetClient(), m.handlers, m.sandboxExtractor, m.eventsCh)
 	if err := mgr.Add(dc); err != nil {
 		return fmt.Errorf("pod: %s", err.Error())
 	}
 
 	// Create the main controller for the monitor
-	r := newReconciler(mgr, m.handlers, m.metadataExtractor, m.netclsProgrammer, m.localNode, m.enableHostPods, dc.GetDeleteCh(), dc.GetReconcileCh())
+	r := newReconciler(mgr, m.handlers, m.metadataExtractor, m.netclsProgrammer, m.sandboxExtractor, m.localNode, m.enableHostPods, dc.GetDeleteCh(), dc.GetReconcileCh())
 	if err := addController(mgr, r, m.eventsCh); err != nil {
 		return fmt.Errorf("pod: %s", err.Error())
 	}

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -267,6 +267,13 @@ func SubOptionMonitorPodMetadataExtractor(extractor extractors.PodMetadataExtrac
 	}
 }
 
+// SubOptionMonitorSandboxExtractor provides a way to specify metadata extractor for Kubernetes
+func SubOptionMonitorSandboxExtractor(extractor extractors.PodSandboxExtractor) PodMonitorOption {
+	return func(cfg *podmonitor.Config) {
+		cfg.SandboxExtractor = extractor
+	}
+}
+
 // SubOptionMonitorPodNetclsProgrammer provides a way to program the net_cls cgroup for host network pods in Kubernetes
 func SubOptionMonitorPodNetclsProgrammer(netclsprogrammer extractors.PodNetclsProgrammer) PodMonitorOption {
 	return func(cfg *podmonitor.Config) {

--- a/utils/cgnetcls/mockcgnetcls/mockcgnetcls.go
+++ b/utils/cgnetcls/mockcgnetcls/mockcgnetcls.go
@@ -65,6 +65,20 @@ func (mr *MockCgroupnetclsMockRecorder) AssignMark(cgroupname, mark interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignMark", reflect.TypeOf((*MockCgroupnetcls)(nil).AssignMark), cgroupname, mark)
 }
 
+// AssignRootMark mocks base method
+// nolint
+func (m *MockCgroupnetcls) AssignRootMark(mark uint64) error {
+	ret := m.ctrl.Call(m, "AssignRootMark", mark)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AssignRootMark indicates an expected call of AssignRootMark
+// nolint
+func (mr *MockCgroupnetclsMockRecorder) AssignRootMark(mark interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignRootMark", reflect.TypeOf((*MockCgroupnetcls)(nil).AssignRootMark), mark)
+}
+
 // AddProcess mocks base method
 // nolint
 func (m *MockCgroupnetcls) AddProcess(cgroupname string, pid int) error {


### PR DESCRIPTION
* k8s Monitor: Add SandboxID fix.

* Fix panic, add the sandboxExtractor func in reconciler.

* Add SandboxID as the puID.

* Remove the run phase for sandbox-extractor.

* Add pod UID in delete controller.

* Add changes to the delete controller.

Change the logic to handle the sandbox delete events.

* Add PU update and fix review comments.

* Replace native with puID.

* Fix review comments.

* Fix Unit Test.

* Add unit test fixes.

* Fix linter.

* Add proper debugs.

* Fix debug issue.

#### Description
*Changes proposed in this pull request.*

#### Test plan
*Outline the test plan used to test this change before merging it.*

> Fixes #.
