### PR TITLE
If ingore stopped containers is set, always destroy it

### DIFF
--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -613,9 +613,10 @@ func (d *DockerMonitor) handleDieEvent(ctx context.Context, event *events.Messag
 	runtime := policy.NewPURuntimeWithDefaults()
 	runtime.SetOptions(runtime.Options())
 
-	if err := d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventStop, runtime); err != nil {
+	if err := d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventStop, runtime); err != nil && !d.terminateStoppedContainers {
 		return err
 	}
+
 	if d.terminateStoppedContainers {
 		return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventDestroy, runtime)
 	}


### PR DESCRIPTION
Fixes the destroy of containers if ignore stopped containers is set and the container stop fails for some reason. It continues with the destroy operation.