### PR TITLE
If ingore stopped containers is set, always destroy it (#871)

### DIFF
--- a/monitor/internal/docker/monitor.go
+++ b/monitor/internal/docker/monitor.go
@@ -613,9 +613,10 @@ func (d *DockerMonitor) handleDieEvent(ctx context.Context, event *events.Messag
 	runtime := policy.NewPURuntimeWithDefaults()
 	runtime.SetOptions(runtime.Options())
 
-	if err := d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventStop, runtime); err != nil {
+	if err := d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventStop, runtime); err != nil && !d.terminateStoppedContainers {
 		return err
 	}
+
 	if d.terminateStoppedContainers {
 		return d.config.Policy.HandlePUEvent(ctx, puID, tevents.EventDestroy, runtime)
 	}


### PR DESCRIPTION
Move bug fix from master. For ignore-stopped-containers proceed with destroy event even in the presence of errors. 