### PR TITLE
fix: support quoted iptable rules

### DIFF
--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -73,11 +73,11 @@ func NewGoIPTablesProviderV4(batchTables []string) (*BatchProvider, error) {
 	// We will only support the batch method if there is iptables-restore and iptables
 	// version 1.6.2 or better. Otherwise, we fall back to classic iptables instructions.
 	// This will allow us to support older kernel versions.
-	// if restoreHasWait(restoreCmdV4) {
-	// 	for _, t := range batchTables {
-	// 		batchTablesMap[t] = true
-	// 	}
-	// }
+	if restoreHasWait(restoreCmdV4) {
+		for _, t := range batchTables {
+			batchTablesMap[t] = true
+		}
+	}
 
 	b := &BatchProvider{
 		ipt:         ipt,

--- a/controller/pkg/aclprovider/iptablesprovider_test.go
+++ b/controller/pkg/aclprovider/iptablesprovider_test.go
@@ -12,7 +12,7 @@ const (
 	outputChain = "OUTPUT"
 )
 
-func NewTestProvider(batchTables []string) *BatchProvider {
+func NewTestProvider(batchTables []string, quote bool) *BatchProvider {
 	batchTablesMap := map[string]bool{}
 	for _, t := range batchTables {
 		batchTablesMap[t] = true
@@ -20,18 +20,19 @@ func NewTestProvider(batchTables []string) *BatchProvider {
 	return &BatchProvider{
 		rules:       map[string]map[string][]string{},
 		batchTables: batchTablesMap,
+		quote:       quote,
 	}
 }
 
 func TestAppend(t *testing.T) {
 	Convey("Given a valid batch provider", t, func() {
-		p := NewTestProvider([]string{mangle})
+		p := NewTestProvider([]string{mangle}, true)
 		Convey("When I append a first rule, it should create the table", func() {
 			err := p.Append(mangle, inputChain, "val1")
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
 		})
 
 		Convey("When I append two rules in the array, the values should be ordered ", func() {
@@ -42,8 +43,8 @@ func TestAppend(t *testing.T) {
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 2)
 			rules := p.rules[mangle][inputChain]
-			So(rules[0], ShouldResemble, "val1")
-			So(rules[1], ShouldResemble, "val2")
+			So(rules[0], ShouldResemble, "\"val1\"")
+			So(rules[1], ShouldResemble, "\"val2\"")
 		})
 
 		Convey("When I append two rules in different chains, there should be two chains", func() {
@@ -54,15 +55,97 @@ func TestAppend(t *testing.T) {
 			So(len(p.rules[mangle]), ShouldEqual, 2)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
 			So(len(p.rules[mangle][outputChain]), ShouldEqual, 1)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
-			So(p.rules[mangle][outputChain][0], ShouldResemble, "val2")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
+			So(p.rules[mangle][outputChain][0], ShouldResemble, "\"val2\"")
 		})
 	})
 }
 
 func TestInsert(t *testing.T) {
 	Convey("Given a valid batch provider", t, func() {
-		p := NewTestProvider([]string{mangle})
+		p := NewTestProvider([]string{mangle}, true)
+		Convey("When I insert a first rule, it should create the table", func() {
+			err := p.Insert(mangle, inputChain, 1, "val1")
+			So(err, ShouldBeNil)
+			So(len(p.rules[mangle]), ShouldEqual, 1)
+			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
+		})
+
+		Convey("When I insert two rules in the first position of the array, the values should be reverse ordered ", func() {
+			err := p.Insert(mangle, inputChain, 1, "val1")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, inputChain, 1, "val2")
+			So(err, ShouldBeNil)
+			So(len(p.rules[mangle]), ShouldEqual, 1)
+			So(len(p.rules[mangle][inputChain]), ShouldEqual, 2)
+			rules := p.rules[mangle][inputChain]
+			So(rules[1], ShouldResemble, "\"val1\"")
+			So(rules[0], ShouldResemble, "\"val2\"")
+		})
+
+		Convey("When I insert two rules in the first and last position of the array ", func() {
+			err := p.Insert(mangle, inputChain, 1, "val1")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, inputChain, 2, "val2")
+			So(err, ShouldBeNil)
+			So(len(p.rules[mangle]), ShouldEqual, 1)
+			So(len(p.rules[mangle][inputChain]), ShouldEqual, 2)
+			rules := p.rules[mangle][inputChain]
+			So(rules[0], ShouldResemble, "\"val1\"")
+			So(rules[1], ShouldResemble, "\"val2\"")
+		})
+
+		Convey("When I insert two rules in the first and a bad position in the array, the last one should be last ", func() {
+			err := p.Insert(mangle, inputChain, 1, "val1")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, inputChain, 6, "val2")
+			So(err, ShouldBeNil)
+			So(len(p.rules[mangle]), ShouldEqual, 1)
+			So(len(p.rules[mangle][inputChain]), ShouldEqual, 2)
+			rules := p.rules[mangle][inputChain]
+			So(rules[0], ShouldResemble, "\"val1\"")
+			So(rules[1], ShouldResemble, "\"val2\"")
+		})
+
+		Convey("When I insert a rule in the midle of the array, it should go in the right place ", func() {
+			err := p.Insert(mangle, inputChain, 1, "val3")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, inputChain, 1, "val2")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, inputChain, 1, "val1")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, inputChain, 2, "val1-2")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, inputChain, 4, "val2-3")
+			So(err, ShouldBeNil)
+			So(len(p.rules[mangle]), ShouldEqual, 1)
+			So(len(p.rules[mangle][inputChain]), ShouldEqual, 5)
+			rules := p.rules[mangle][inputChain]
+			So(rules[0], ShouldResemble, "\"val1\"")
+			So(rules[1], ShouldResemble, "\"val1-2\"")
+			So(rules[2], ShouldResemble, "\"val2\"")
+			So(rules[3], ShouldResemble, "\"val2-3\"")
+			So(rules[4], ShouldResemble, "\"val3\"")
+		})
+
+		Convey("When I Insert two rules in different chains, there should be two chains", func() {
+			err := p.Insert(mangle, inputChain, 1, "val1")
+			So(err, ShouldBeNil)
+			err = p.Insert(mangle, outputChain, 1, "val2")
+			So(err, ShouldBeNil)
+			So(len(p.rules[mangle]), ShouldEqual, 2)
+			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
+			So(len(p.rules[mangle][outputChain]), ShouldEqual, 1)
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
+			So(p.rules[mangle][outputChain][0], ShouldResemble, "\"val2\"")
+		})
+	})
+}
+
+func TestInsertWithQuoteFalse(t *testing.T) {
+	Convey("Given a valid batch provider", t, func() {
+		p := NewTestProvider([]string{mangle}, false)
 		Convey("When I insert a first rule, it should create the table", func() {
 			err := p.Insert(mangle, inputChain, 1, "val1")
 			So(err, ShouldBeNil)
@@ -144,13 +227,13 @@ func TestInsert(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	Convey("Given a valid batch provider", t, func() {
-		p := NewTestProvider([]string{mangle})
+		p := NewTestProvider([]string{mangle}, true)
 		Convey("When I have one rule, I should be able to delete it", func() {
 			err := p.Append(mangle, inputChain, "val1")
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
 			err = p.Delete(mangle, inputChain, "val1")
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
@@ -164,13 +247,13 @@ func TestDelete(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 2)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
-			So(p.rules[mangle][inputChain][1], ShouldResemble, "val2")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
+			So(p.rules[mangle][inputChain][1], ShouldResemble, "\"val2\"")
 			err = p.Delete(mangle, inputChain, "val2")
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
 		})
 
 		Convey("When I have two rules, I should be able to delete the first one", func() {
@@ -180,13 +263,13 @@ func TestDelete(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 2)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
-			So(p.rules[mangle][inputChain][1], ShouldResemble, "val2")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
+			So(p.rules[mangle][inputChain][1], ShouldResemble, "\"val2\"")
 			err = p.Delete(mangle, inputChain, "val1")
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val2")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val2\"")
 		})
 
 		Convey("When I have three rules, I should be able to delete the middle one", func() {
@@ -198,22 +281,22 @@ func TestDelete(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 3)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
-			So(p.rules[mangle][inputChain][1], ShouldResemble, "val2")
-			So(p.rules[mangle][inputChain][2], ShouldResemble, "val3")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
+			So(p.rules[mangle][inputChain][1], ShouldResemble, "\"val2\"")
+			So(p.rules[mangle][inputChain][2], ShouldResemble, "\"val3\"")
 			err = p.Delete(mangle, inputChain, "val2")
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 2)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
-			So(p.rules[mangle][inputChain][1], ShouldResemble, "val3")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
+			So(p.rules[mangle][inputChain][1], ShouldResemble, "\"val3\"")
 		})
 	})
 }
 
 func TestClearChain(t *testing.T) {
 	Convey("Given a valid batch provider", t, func() {
-		p := NewTestProvider([]string{mangle})
+		p := NewTestProvider([]string{mangle}, true)
 		Convey("If a clear an empty chain, I should get no error", func() {
 			err := p.ClearChain(mangle, inputChain)
 			So(err, ShouldBeNil)
@@ -224,7 +307,7 @@ func TestClearChain(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
 			So(len(p.rules[mangle][inputChain]), ShouldEqual, 1)
-			So(p.rules[mangle][inputChain][0], ShouldResemble, "val1")
+			So(p.rules[mangle][inputChain][0], ShouldResemble, "\"val1\"")
 			err = p.ClearChain(mangle, inputChain)
 			So(err, ShouldBeNil)
 			So(len(p.rules[mangle]), ShouldEqual, 1)
@@ -235,7 +318,7 @@ func TestClearChain(t *testing.T) {
 
 func TestDeleteChain(t *testing.T) {
 	Convey("Given a valid batch provider", t, func() {
-		p := NewTestProvider([]string{mangle})
+		p := NewTestProvider([]string{mangle}, true)
 		Convey("If a delete an empty chain, I should get no error", func() {
 			err := p.ClearChain(mangle, inputChain)
 			So(err, ShouldBeNil)


### PR DESCRIPTION
--> This is to support iptable rules with quotes which was not possible earlier with batch implementation.
--> This will be cherry-picked to 3.12.
--> Fixes this issue https://github.com/aporeto-inc/aporeto/issues/1874
