### PR TITLE
fix: make any work a2

### DIFF
--- a/controller/constants/constants.go
+++ b/controller/constants/constants.go
@@ -117,6 +117,7 @@ const (
 	UDPProtoNum    = "17"
 	TCPProtoString = "TCP"
 	UDPProtoString = "UDP"
+	AllProtoString = "ALL"
 )
 
 // sockets

--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -128,7 +128,7 @@ func (i *iptables) proxyRules(cfg *ACLInfo) [][]string {
 }
 
 // trapRules provides the packet capture rules that are defined for each processing unit.
-func (i *iptables) trapRules(cfg *ACLInfo, isHostPU bool) [][]string {
+func (i *iptables) trapRules(cfg *ACLInfo, isHostPU bool, appAnyRules, netAnyRules [][]string) [][]string {
 
 	tmpl := template.Must(template.New(packetCaptureTemplate).Funcs(template.FuncMap{
 		"needDnsRules": func() bool {
@@ -140,6 +140,15 @@ func (i *iptables) trapRules(cfg *ACLInfo, isHostPU bool) [][]string {
 		"needICMP": func() bool {
 			return cfg.needICMPRules
 		},
+		"appAnyRules": func() [][]string {
+			return appAnyRules
+		},
+		"netAnyRules": func() [][]string {
+			return netAnyRules
+		},
+		"joinRule": func(rule []string) string {
+			return strings.Join(rule, " ")
+		},
 	}).Parse(packetCaptureTemplate))
 
 	rules, err := extractRulesFromTemplate(tmpl, cfg)
@@ -148,6 +157,66 @@ func (i *iptables) trapRules(cfg *ACLInfo, isHostPU bool) [][]string {
 	}
 
 	return rules
+}
+
+// getProtocolAnyRules returns app any acls and net any acls.
+func (i *iptables) getProtocolAnyRules(cfg *ACLInfo, appRules, netRules []aclIPset) ([][]string, [][]string, error) {
+
+	appAnyRules, _ := extractRules(appRules)
+	netAnyRules, _ := extractRules(netRules)
+
+	sortedAppAnyRulesBuckets := i.sortACLsInBuckets(cfg, cfg.AppChain, cfg.NetChain, appAnyRules, true)
+	sortedNetAnyRulesBuckets := i.sortACLsInBuckets(cfg, cfg.NetChain, cfg.AppChain, netAnyRules, false)
+
+	sortedAppAnyRules, err := extractACLsFromTemplate(sortedAppAnyRulesBuckets)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to sort app any rules in buckets: %v", err)
+	}
+
+	sortedNetAnyRules, err := extractACLsFromTemplate(sortedNetAnyRulesBuckets)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to sort net any rules in buckets: %v", err)
+	}
+
+	return sortedAppAnyRules, sortedNetAnyRules, nil
+}
+
+func extractACLsFromTemplate(rulesBucket *rulesInfo) ([][]string, error) {
+
+	tmpl := template.Must(template.New(acls).Funcs(template.FuncMap{
+		"joinRule": func(rule []string) string {
+			return strings.Join(rule, " ")
+		},
+	}).Parse(acls))
+
+	aclRules, err := extractRulesFromTemplate(tmpl, *rulesBucket)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract rules from template: %s", err)
+	}
+
+	return aclRules, nil
+}
+
+// extractRules extracts protocol any rules from the set and returns
+// protocol any rules and all other rules without any.
+func extractRules(rules []aclIPset) ([]aclIPset, []aclIPset) {
+
+	anyRules := []aclIPset{}
+	otherRules := []aclIPset{}
+
+	for _, rule := range rules {
+		for _, proto := range rule.protocols {
+
+			if proto != constants.AllProtoString {
+				otherRules = append(otherRules, rule)
+				continue
+			}
+
+			anyRules = append(anyRules, rule)
+		}
+	}
+
+	return anyRules, otherRules
 }
 
 // addContainerChain adds a chain for the specific container and redirects traffic there
@@ -226,9 +295,9 @@ func (i *iptables) addChainRules(cfg *ACLInfo) error {
 }
 
 // addPacketTrap adds the necessary iptables rules to capture control packets to user space
-func (i *iptables) addPacketTrap(cfg *ACLInfo, isHostPU bool) error {
+func (i *iptables) addPacketTrap(cfg *ACLInfo, isHostPU bool, appAnyRules, netAnyRules [][]string) error {
 
-	return i.processRulesFromList(i.trapRules(cfg, isHostPU), "Append")
+	return i.processRulesFromList(i.trapRules(cfg, isHostPU, appAnyRules, netAnyRules), "Append")
 }
 
 func (i *iptables) generateACLRules(cfg *ACLInfo, rule *aclIPset, chain string, reverseChain string, nfLogGroup, proto, ipMatchDirection string, reverseDirection string) ([][]string, [][]string) {
@@ -274,8 +343,12 @@ func (i *iptables) generateACLRules(cfg *ACLInfo, rule *aclIPset, chain string, 
 	}
 
 	if rule.policy.Action&policy.Log > 0 || observeContinue {
-		nflog := []string{"-m", "state", "--state", "NEW",
-			"-j", "NFLOG", "--nflog-group", nfLogGroup, "--nflog-prefix", rule.policy.LogPrefix(contextID)}
+		state := []string{}
+		if proto == constants.TCPProtoNum || proto == constants.UDPProtoNum || proto == constants.TCPProtoString || proto == constants.UDPProtoString {
+			state = []string{"-m", "state", "--state", "NEW"}
+		}
+
+		nflog := append(state, []string{"-j", "NFLOG", "--nflog-group", nfLogGroup, "--nflog-prefix", rule.policy.LogPrefix(contextID)}...)
 		nfLogRule := append(baseRule(proto), nflog...)
 
 		iptRules = append(iptRules, nfLogRule)
@@ -439,15 +512,11 @@ func (i *iptables) sortACLsInBuckets(cfg *ACLInfo, chain string, reverseChain st
 // by an application. The allow rules are inserted with highest priority.
 func (i *iptables) addExternalACLs(cfg *ACLInfo, chain string, reverseChain string, rules []aclIPset, isAppAcls bool) error {
 
+	_, rules = extractRules(rules)
+
 	rulesBucket := i.sortACLsInBuckets(cfg, chain, reverseChain, rules, isAppAcls)
 
-	tmpl := template.Must(template.New(acls).Funcs(template.FuncMap{
-		"joinRule": func(rule []string) string {
-			return strings.Join(rule, " ")
-		},
-	}).Parse(acls))
-
-	aclRules, err := extractRulesFromTemplate(tmpl, *rulesBucket)
+	aclRules, err := extractACLsFromTemplate(rulesBucket)
 	if err != nil {
 		return fmt.Errorf("unable to extract rules from template: %s", err)
 	}

--- a/controller/internal/supervisor/iptablesctrl/iptables.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables.go
@@ -761,7 +761,12 @@ func (i *iptables) installRules(cfg *ACLInfo, containerInfo *policy.PUInfo) erro
 		return err
 	}
 
-	return i.addPacketTrap(cfg, isHostPU)
+	appAnyRules, netAnyRules, err := i.getProtocolAnyRules(cfg, appACLIPset, netACLIPset)
+	if err != nil {
+		return err
+	}
+
+	return i.addPacketTrap(cfg, isHostPU, appAnyRules, netAnyRules)
 }
 
 // puPortSetName returns the name of the pu portset.

--- a/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptablesV4_test.go
@@ -383,6 +383,10 @@ var (
 			"-p tcp -m set --match-set TRI-v4-TargetTCP src -m tcp --tcp-flags SYN,ACK ACK -j NFQUEUE --queue-balance 20:23",
 			"-p udp -m set --match-set TRI-v4-TargetUDP src --match limit --limit 1000/s -j NFQUEUE --queue-balance 16:19",
 			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV src -j NFLOG --nflog-group 11 --nflog-prefix 913787369:123a:a3:6",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV src -j DROP",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV src -j NFLOG --nflog-group 11 --nflog-prefix 913787369:123a:a3:3",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV src -j ACCEPT",
 			"-s 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:6",
 			"-s 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 11 --nflog-prefix 913787369:default:default:10",
 			"-s 0.0.0.0/0 -j DROP",
@@ -398,6 +402,10 @@ var (
 			"-p udp -m set --match-set TRI-v4-TargetUDP dst -j NFQUEUE --queue-balance 0:3",
 			"-p udp -m set --match-set TRI-v4-TargetUDP dst -m state --state ESTABLISHED -m comment --comment UDP-Established-Connections -j ACCEPT",
 			"-p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV dst -j NFLOG --nflog-group 10 --nflog-prefix 913787369:123a:a3:6",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV dst -j DROP",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV dst -j NFLOG --nflog-group 10 --nflog-prefix 913787369:123a:a3:3",
+			"-p ALL -m set --match-set TRI-v4-ext-_qhcdpu19gtV dst -j ACCEPT",
 			"-d 0.0.0.0/0 -m state --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:6",
 			"-d 0.0.0.0/0 -m state ! --state NEW -j NFLOG --nflog-group 10 --nflog-prefix 913787369:default:default:10",
 			"-d 0.0.0.0/0 -j DROP",
@@ -698,6 +706,7 @@ var (
 		"TRI-v4-ext-uNdc0pu19gtV":            {"30.0.0.0/24"},
 		"TRI-v4-ext-w5frVpu19gtV":            {"40.0.0.0/24"},
 		"TRI-v4-ext-IuSLspu19gtV":            {"40.0.0.0/24"},
+		"TRI-v4-ext-_qhcdpu19gtV":            {"60.0.0.0/24"},
 		"TRI-v4-Proxy-pu19gtV-dst":           {},
 		"TRI-v4-Proxy-pu19gtV-srv":           {},
 	}
@@ -842,6 +851,16 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 			Convey("When I configure a new set of rules, the ACLs must be correct", func() {
 				appACLs := policy.IPRuleList{
 					policy.IPRule{
+						Addresses: []string{"60.0.0.0/24"},
+						Ports:     nil,
+						Protocols: []string{constants.AllProtoString},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept | policy.Log,
+							ServiceID: "a3",
+							PolicyID:  "123a",
+						},
+					},
+					policy.IPRule{
 						Addresses: []string{"30.0.0.0/24"},
 						Ports:     []string{"80"},
 						Protocols: []string{"TCP"},
@@ -871,8 +890,28 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 							PolicyID:  "3",
 						},
 					},
+					policy.IPRule{
+						Addresses: []string{"60.0.0.0/24"},
+						Ports:     nil,
+						Protocols: []string{constants.AllProtoString},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject | policy.Log,
+							ServiceID: "a3",
+							PolicyID:  "123a",
+						},
+					},
 				}
 				netACLs := policy.IPRuleList{
+					policy.IPRule{
+						Addresses: []string{"60.0.0.0/24"},
+						Ports:     nil,
+						Protocols: []string{constants.AllProtoString},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Accept | policy.Log,
+							ServiceID: "a3",
+							PolicyID:  "123a",
+						},
+					},
 					policy.IPRule{
 						Addresses: []string{"40.0.0.0/24"},
 						Ports:     []string{"80"},
@@ -891,6 +930,16 @@ func Test_OperationWithLinuxServicesV4(t *testing.T) {
 							Action:    policy.Accept,
 							ServiceID: "s4",
 							PolicyID:  "2",
+						},
+					},
+					policy.IPRule{
+						Addresses: []string{"60.0.0.0/24"},
+						Ports:     nil,
+						Protocols: []string{constants.AllProtoString},
+						Policy: &policy.FlowPolicy{
+							Action:    policy.Reject | policy.Log,
+							ServiceID: "a3",
+							PolicyID:  "123a",
 						},
 					},
 				}

--- a/controller/internal/supervisor/iptablesctrl/rules.go
+++ b/controller/internal/supervisor/iptablesctrl/rules.go
@@ -137,6 +137,9 @@ var packetCaptureTemplate = `
 {{.MangleTable}} {{.AppChain}} -p udp -m set --match-set {{.TargetUDPNetSet}} dst -j NFQUEUE --queue-balance {{.QueueBalanceAppSyn}}
 {{.MangleTable}} {{.AppChain}} -p udp -m set --match-set {{.TargetUDPNetSet}} dst -m state --state ESTABLISHED -m comment --comment UDP-Established-Connections -j ACCEPT
 {{.MangleTable}} {{.AppChain}} -p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT
+{{range appAnyRules}}
+{{joinRule .}}
+{{end}}
 {{.MangleTable}} {{.AppChain}} -d {{.DefaultIP}} -m state --state NEW -j NFLOG  --nflog-group 10 --nflog-prefix {{.NFLOGPrefix}}
 {{.MangleTable}} {{.AppChain}} -d {{.DefaultIP}} -m state ! --state NEW -j NFLOG --nflog-group 10 --nflog-prefix {{.DefaultNFLOGDropPrefix}}
 {{.MangleTable}} {{.AppChain}} -d {{.DefaultIP}} -j DROP
@@ -154,6 +157,9 @@ var packetCaptureTemplate = `
 {{end}}
 {{.MangleTable}} {{.NetChain}} -p udp -m set --match-set {{.TargetUDPNetSet}} src --match limit --limit 1000/s -j NFQUEUE --queue-balance {{.QueueBalanceNetSyn}}
 {{.MangleTable}} {{.NetChain}} -p tcp -m state --state ESTABLISHED -m comment --comment TCP-Established-Connections -j ACCEPT
+{{range netAnyRules}}
+{{joinRule .}}
+{{end}}
 {{.MangleTable}} {{.NetChain}} -s {{.DefaultIP}} -m state --state NEW -j NFLOG --nflog-group 11 --nflog-prefix {{.NFLOGPrefix}}
 {{.MangleTable}} {{.NetChain}} -s {{.DefaultIP}} -m state ! --state NEW -j NFLOG --nflog-group 11 --nflog-prefix {{.DefaultNFLOGDropPrefix}}
 {{.MangleTable}} {{.NetChain}} -s {{.DefaultIP}} -j DROP


### PR DESCRIPTION
Ordered `any` (same as other protocols)

```
RejectObserveContinue
RejectNotObserved
RejectObserveApply
AcceptObserveContinue
AcceptNotObserved
AcceptObserveApply
ReverseRules
```

Rules with `any`

**Network rules**

```console
Chain TRI-Net-2772-SD50s-0 (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 NFLOG      tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe src state NEW ! match-set TRI-v4-TargetTCP src multiport dports 1:65535 state NEW nflog-prefix  "646052532:5d6985695ed697eff189f53c:5d8fb717c7820f9140b0cc4e:3" nflog-group 11
    0     0 ACCEPT     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe src state NEW ! match-set TRI-v4-TargetTCP src multiport dports 1:65535
    0     0 NFQUEUE    tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-TargetTCP src tcp flags:0x12/0x02 NFQUEUE balance 16:19
    0     0 NFQUEUE    tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-TargetTCP src tcp flags:0x12/0x10 NFQUEUE balance 20:23
    0     0 NFQUEUE    udp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-TargetUDP src limit: avg 1000/sec burst 5 NFQUEUE balance 16:19
    0     0 ACCEPT     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            state ESTABLISHED /* TCP-Established-Connections */
    0     0 NFLOG      all  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe src nflog-prefix  "646052532:5d6985695ed697eff189f53c:5d8fb717c7820f9140b0cc4e:3" nflog-group 11
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe src
    0     0 NFLOG      all  --  *      *       0.0.0.0/0            0.0.0.0/0            state NEW nflog-prefix  "646052532:default:default:6" nflog-group 11
    0     0 NFLOG      all  --  *      *       0.0.0.0/0            0.0.0.0/0            ! state NEW nflog-prefix  "646052532:default:default:10" nflog-group 11
    0     0 DROP       all  --  *      *       0.0.0.0/0            0.0.0.0/0
```

**App rules**

```console
Chain TRI-App-2772-SD50s-0 (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 NFLOG      tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe dst state NEW ! match-set TRI-v4-TargetTCP dst multiport dports 1:65535 state NEW nflog-prefix  "646052532:5d6985695ed697eff189f53c:5d8fb717c7820f9140b0cc4e:3" nflog-group 10
    0     0 ACCEPT     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe dst state NEW ! match-set TRI-v4-TargetTCP dst multiport dports 1:65535
    0     0 NFQUEUE    tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp flags:0x12/0x02 NFQUEUE balance 0:3
    0     0 NFQUEUE    tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp flags:0x12/0x10 NFQUEUE balance 4:7
    0     0 NFQUEUE    udp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-TargetUDP dst NFQUEUE balance 0:3
    0     0 ACCEPT     udp  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-TargetUDP dst state ESTABLISHED /* UDP-Established-Connections */
    0     0 ACCEPT     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            state ESTABLISHED /* TCP-Established-Connections */
    0     0 NFLOG      all  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe dst nflog-prefix  "646052532:5d6985695ed697eff189f53c:5d8fb717c7820f9140b0cc4e:3" nflog-group 10
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            match-set TRI-v4-ext-h1Cv82772z4Fe dst
    0     0 NFLOG      all  --  *      *       0.0.0.0/0            0.0.0.0/0            state NEW nflog-prefix  "646052532:default:default:6" nflog-group 10
    0     0 NFLOG      all  --  *      *       0.0.0.0/0            0.0.0.0/0            ! state NEW nflog-prefix  "646052532:default:default:10" nflog-group 10
    0     0 DROP       all  --  *      *       0.0.0.0/0            0.0.0.0/0
```