### PR TITLE
Fix init sequence where CNIs are not complete with IP address allocation

### DIFF
--- a/controller/internal/enforcer/applicationproxy/markedconn/markedconn.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/markedconn.go
@@ -280,7 +280,7 @@ func GetInterfaces() map[string]struct{} {
 
 	ifaces, err := netinterfaces.GetInterfacesInfo()
 	if err != nil {
-		zap.L().Debug("Unable to get interfaces info", zap.Error(err))
+		zap.L().Error("Unable to get interfaces info", zap.Error(err))
 	}
 
 	for _, iface := range ifaces {

--- a/monitor/internal/kubernetes/handler.go
+++ b/monitor/internal/kubernetes/handler.go
@@ -76,7 +76,7 @@ func (m *KubernetesMonitor) HandlePUEvent(ctx context.Context, puID string, even
 
 	// The event is then sent to the upstream policyResolver
 	if err := m.handlers.Policy.HandlePUEvent(ctx, puID, event, kubernetesRuntime); err != nil {
-		zap.L().Error("Unable to resolve policy for puid", zap.String("puID", puID))
+		zap.L().Error("Unable to resolve policy for puid", zap.String("puID", puID), zap.Error(err))
 		return fmt.Errorf("Unable to resolve policy for puid:%s", puID)
 	}
 


### PR DESCRIPTION
Fixes the initialization of the local interfaces and makes sure we recover from this even if the CNIs are not ready when we are ready. 