### PR TITLE
Disable ip_early_demux in container namespace

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath.go
@@ -198,10 +198,10 @@ func New(
 			zap.L().Fatal("Failed to set conntrack options", zap.Error(err))
 		}
 
-		if mode == constants.LocalServer && !buildflags.IsLegacyKernel() {
+		if !buildflags.IsLegacyKernel() {
 			cmd = exec.Command(sysctlCmd, "-w", "net.ipv4.ip_early_demux=0")
 			if err := cmd.Run(); err != nil {
-				zap.L().Fatal("Failed to set early demux options", zap.Error(err))
+				zap.L().Info("IP early demux cannot be disabled in this context. Continuing.", zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
Disables ip_early_demux in the container namespaces as well. This affects newer kernels with performance issues.
