### PR TITLE
Fixes the iptables-restore cleanups

### DIFF
--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -249,7 +249,29 @@ func (b *BatchProvider) ListChains(table string) ([]string, error) {
 	b.Lock()
 	defer b.Unlock()
 
-	return b.ipt.ListChains(table)
+	chains, err := b.ipt.ListChains(table)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if _, ok := b.batchTables[table]; !ok || b.rules[table] == nil {
+		return chains, nil
+	}
+
+	for _, chain := range chains {
+		if _, ok := b.rules[table][chain]; !ok {
+			b.rules[table][chain] = []string{}
+		}
+	}
+
+	allChains := make([]string, len(b.rules[table]))
+	i := 0
+	for chain := range b.rules[table] {
+		allChains[i] = chain
+		i++
+	}
+
+	return allChains, nil
 }
 
 // ClearChain will clear the chains.


### PR DESCRIPTION
Fix the iptalbles-restore cleanups for Linux services. It essentially removes the spurious errors. The problem is that with Linux services we do not want to commit anything to iptables until there is a real service involved. This is handled correctly by making the list commands merge the current state of iptables with the buffer that is maintained in the system.,