### PR TITLE
Clean caches on RST

### DIFF
--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -61,15 +61,17 @@ func (d *Datapath) processNetworkTCPPackets(p *packet.Packet) (conn *connection.
 
 	case packet.TCPSynAckMask:
 		conn, err = d.netSynAckRetrieveState(p)
-		switch err {
-		case pucontext.ToError(pucontext.ErrOutOfOrderSynAck):
-			// Drop this synack it is for a flow we know which is marked for deletion.
-			// We saw a FINACK and this synack has come without we seeing an appsyn for this flow again
-			//return conn, fmt.Errorf("%s %s:%d", err, p.SourceAddress().String(), int(p.SourcePort()))
-			return conn, pucontext.PuContextError(pucontext.ErrOutOfOrderSynAck, fmt.Sprintf("%s %s:%d", err, p.SourceAddress().String(), int(p.SourcePort())))
-		case pucontext.ToError(pucontext.ErrNonPUTraffic):
-			d.releaseUnmonitoredFlow(p)
-			return conn, nil
+		if err != nil {
+			switch err {
+			case pucontext.ToError(pucontext.ErrOutOfOrderSynAck):
+				// Drop this synack it is for a flow we know which is marked for deletion.
+				// We saw a FINACK and this synack has come without we seeing an appsyn for this flow again
+				//return conn, fmt.Errorf("%s %s:%d", err, p.SourceAddress().String(), int(p.SourcePort()))
+				return conn, pucontext.PuContextError(pucontext.ErrOutOfOrderSynAck, fmt.Sprintf("%s %s:%d", err, p.SourceAddress().String(), int(p.SourcePort())))
+			default:
+				d.releaseUnmonitoredFlow(p)
+				return conn, nil
+			}
 		}
 
 	default:
@@ -130,6 +132,17 @@ func (d *Datapath) processNetworkTCPPackets(p *packet.Packet) (conn *connection.
 			d.netReplyConnectionTracker.SetTimeOut(p.L4FlowHash(), conn.TimeOut) // nolint
 		}
 
+	}
+
+	if p.GetTCPFlags()&packet.TCPRstMask != 0 {
+		zap.L().Debug("Received early reset from network and cleaning up state", zap.String("Flow", p.L4FlowHash()))
+		// Seen a RST packet. Remove cache entries abbout this packet.
+		if err := d.netOrigConnectionTracker.Remove(p.L4FlowHash()); err != nil {
+			zap.L().Debug("Received early reset from network failed to clean net origin tracker", zap.String("Flow", p.L4FlowHash()))
+		}
+		if err := d.appReplyConnectionTracker.Remove(p.L4ReverseFlowHash()); err != nil {
+			zap.L().Debug("Received early reset from network failed to clean net pp reply tracker", zap.String("Flow", p.L4FlowHash()))
+		}
 	}
 
 	// Accept the packet
@@ -264,6 +277,17 @@ func (d *Datapath) processApplicationTCPPackets(p *packet.Packet) (conn *connect
 		}
 	}
 
+	if p.GetTCPFlags()&packet.TCPRstMask != 0 {
+		zap.L().Debug("Received early reset by application and cleaning up state", zap.String("Flow", p.L4FlowHash()))
+		// Seen a RST packet. Remove cache entries abbout this packet.
+		if err := d.sourcePortConnectionCache.Remove(p.SourcePortHash(packet.PacketTypeApplication)); err != nil {
+			zap.L().Debug("Received early reset by application and failed in source port cache", zap.String("Flow", p.L4FlowHash()))
+		}
+		if err := d.appOrigConnectionTracker.Remove(p.L4FlowHash()); err != nil {
+			zap.L().Debug("Received early reset by application and failed in app origin tracker", zap.String("Flow", p.L4FlowHash()))
+		}
+	}
+
 	// Accept the packet
 	p.UpdateTCPChecksum()
 	p.Print(packet.PacketStageOutgoing, d.PacketLogsEnabled())
@@ -369,12 +393,19 @@ func (d *Datapath) processApplicationSynAckPacket(tcpPacket *packet.Packet, cont
 			tcpPacket.DestPort(),
 			constants.DefaultExternalConnMark,
 		); err != nil {
-			zap.L().Error("Failed to update conntrack entry for flow at SynAck packet",
-				zap.String("context", string(conn.Auth.LocalContext)),
-				zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
-				zap.String("state", fmt.Sprintf("%d", conn.GetState())),
-				zap.Error(err),
-			)
+			if !netlink.IsNotExist(errors.Cause(err)) { // nolint
+				zap.L().Error("Failed to update conntrack entry for flow at SynAck packet",
+					zap.String("context", string(conn.Auth.LocalContext)),
+					zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
+					zap.String("state", fmt.Sprintf("%d", conn.GetState())),
+					zap.Error(err))
+			} else {
+				zap.L().Debug("Failed to update conntrack entry for flow at SynAck packet",
+					zap.String("context", string(conn.Auth.LocalContext)),
+					zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
+					zap.String("state", fmt.Sprintf("%d", conn.GetState())),
+					zap.Error(err))
+			}
 		}
 
 		return nil
@@ -460,12 +491,19 @@ func (d *Datapath) processApplicationAckPacket(tcpPacket *packet.Packet, context
 					tcpPacket.DestPort(),
 					constants.DefaultConnMark,
 				); err != nil {
-					zap.L().Error("Failed to update conntrack entry for flow at Ack packet",
-						zap.String("context", string(conn.Auth.LocalContext)),
-						zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
-						zap.String("state", fmt.Sprintf("%d", conn.GetState())),
-						zap.Error(err),
-					)
+					if !netlink.IsNotExist(errors.Cause(err)) {
+						zap.L().Error("Failed to update conntrack entry for flow at Ack packet",
+							zap.String("context", string(conn.Auth.LocalContext)),
+							zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
+							zap.String("state", fmt.Sprintf("%d", conn.GetState())),
+							zap.Error(err))
+					} else {
+						zap.L().Debug("Failed to update conntrack entry for flow at Ack packet",
+							zap.String("context", string(conn.Auth.LocalContext)),
+							zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
+							zap.String("state", fmt.Sprintf("%d", conn.GetState())),
+							zap.Error(err))
+					}
 				}
 				return nil
 			}
@@ -823,7 +861,7 @@ func (d *Datapath) processNetworkAckPacket(context *pucontext.PUContext, conn *c
 			tcpPacket.SourcePort(),
 			tcpPacket.DestPort(),
 			constants.DefaultExternalConnMark,
-		); err != nil && !netlink.IsNotExist(errors.Cause(err)) {
+		); err != nil {
 			zap.L().Error("Failed to update conntrack entry for flow at network Ack packet",
 				zap.String("context", string(conn.Auth.LocalContext)),
 				zap.String("app-conn", tcpPacket.L4ReverseFlowHash()),
@@ -1142,7 +1180,11 @@ func (d *Datapath) releaseUnmonitoredFlow(tcpPacket *packet.Packet) {
 		tcpPacket.SourcePort(),
 		tcpPacket.DestPort(),
 		constants.DefaultExternalConnMark,
-	); err != nil && !netlink.IsNotExist(errors.Cause(err)) {
-		zap.L().Error("Failed to update conntrack table", zap.Error(err))
+	); err != nil {
+		if !netlink.IsNotExist(errors.Cause(err)) {
+			zap.L().Error("Failed to update conntrack table", zap.Error(err))
+		} else {
+			zap.L().Debug("Failed to update conntrack table", zap.Error(err))
+		}
 	}
 }

--- a/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
+++ b/controller/internal/enforcer/nfqdatapath/datapath_tcp.go
@@ -135,8 +135,8 @@ func (d *Datapath) processNetworkTCPPackets(p *packet.Packet) (conn *connection.
 	}
 
 	if p.GetTCPFlags()&packet.TCPRstMask != 0 {
+		// Seen a RST packet. Remove cache entries related to this connection
 		zap.L().Debug("Received early reset from network and cleaning up state", zap.String("Flow", p.L4FlowHash()))
-		// Seen a RST packet. Remove cache entries abbout this packet.
 		if err := d.netOrigConnectionTracker.Remove(p.L4FlowHash()); err != nil {
 			zap.L().Debug("Received early reset from network failed to clean net origin tracker", zap.String("Flow", p.L4FlowHash()))
 		}
@@ -278,8 +278,8 @@ func (d *Datapath) processApplicationTCPPackets(p *packet.Packet) (conn *connect
 	}
 
 	if p.GetTCPFlags()&packet.TCPRstMask != 0 {
+		// Seen a RST packet. Remove cache entries related to this connection
 		zap.L().Debug("Received early reset by application and cleaning up state", zap.String("Flow", p.L4FlowHash()))
-		// Seen a RST packet. Remove cache entries abbout this packet.
 		if err := d.sourcePortConnectionCache.Remove(p.SourcePortHash(packet.PacketTypeApplication)); err != nil {
 			zap.L().Debug("Received early reset by application and failed in source port cache", zap.String("Flow", p.L4FlowHash()))
 		}


### PR DESCRIPTION
This PR cleans up the caches on early RST packets. In some installations we are noticing that a Syn/SynAck sequence is followed by an immediate RST. When this happens the kernel re-uses immediately the source port and this creates state issues in the connection management (unlike normal cases where the ports are rotated over a large number of connections).

If one of the initial negotiation packets is RST there is no reason to keep state. We let the packet go and immediately clean up the cache. 

The problem was first identified as part of the OpenShift router that seems to be doing keep-alive by initiating a Syn/SynAck sequence followed by an immediate RST. This leads the kernel in immediately re-using the source port and this confuses the state machines in the case where host containers are protected. 