### PR TITLE
fix: include src and dst ips in flowhash computation

### DIFF
--- a/collector/default.go
+++ b/collector/default.go
@@ -43,6 +43,8 @@ func StatsFlowHash(r *FlowRecord) string {
 	hash := xxhash.New()
 	hash.Write([]byte(r.Source.ID))      // nolint errcheck
 	hash.Write([]byte(r.Destination.ID)) // nolint errcheck
+	hash.Write([]byte(r.Source.IP))      // nolint errcheck
+	hash.Write([]byte(r.Destination.IP)) // nolint errcheck
 	port := make([]byte, 2)
 	binary.BigEndian.PutUint16(port, r.Destination.Port)
 	hash.Write(port)                              // nolint errcheck


### PR DESCRIPTION
This fixes the case when two or more flows for the same two pus with different ips are seen back to back and it is reported as being the same flow with just counters being increased. We now include the ips while computing the hash which solves it.