### PR TITLE
Properly update the secrets of the authorizer

### DIFF
--- a/controller/internal/enforcer/apiauth/apiauth.go
+++ b/controller/internal/enforcer/apiauth/apiauth.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"go.aporeto.io/trireme-lib/collector"
@@ -31,6 +32,7 @@ type Processor struct {
 
 	issuer  string // the issuer ID .. need to get rid of that part with the new tokens
 	secrets secrets.Secrets
+	sync.Mutex
 }
 
 // New will create a new authorization processor.
@@ -50,6 +52,14 @@ func (p *Processor) retrieveNetworkContext(originalIP *net.TCPAddr) (*servicereg
 func (p *Processor) retrieveApplicationContext(address *net.TCPAddr) (*serviceregistry.ServiceContext, *serviceregistry.DependentServiceData, error) {
 
 	return p.registry.RetrieveServiceDataByIDAndNetwork(p.puContext, address.IP, address.Port, "")
+}
+
+// UpdateSecrets is called to update the authorizer secrets.
+func (p *Processor) UpdateSecrets(s secrets.Secrets) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.secrets = s
 }
 
 // ApplicationRequest processes an application side request and returns

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -329,15 +329,16 @@ func (p *Config) ShutDown() error {
 // UpdateSecrets updates the secrets
 func (p *Config) UpdateSecrets(cert *tls.Certificate, caPool *x509.CertPool, s secrets.Secrets, certPEM, keyPEM string) {
 	p.Lock()
-	defer p.Unlock()
-
 	p.cert = cert
 	p.ca = caPool
 	p.secrets = s
 	p.certPEM = certPEM
 	p.keyPEM = keyPEM
 	p.tlsClientConfig.RootCAs = caPool
+	p.Unlock()
+
 	p.metadata.UpdateSecrets([]byte(certPEM), []byte(keyPEM))
+	p.auth.UpdateSecrets(s)
 }
 
 // GetCertificateFunc implements the TLS interface for getting the certificate. This


### PR DESCRIPTION
Update the secrets of the API authorizer when they expire.
