### PR TITLE
Client tls proxy

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -170,8 +170,11 @@ func (p *Config) newBaseTLSClientConfig() *tls.Config {
 	}
 }
 
+// GetClientCertificateFunc returns the certificate that will be used by the Proxy as a client during the TLS
 func (p *Config) GetClientCertificateFunc() func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 	return func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		p.RLock()
+		defer p.RUnlock()
 		if p.cert != nil {
 			return p.cert, nil
 		}

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -126,7 +126,10 @@ func (p *Config) clientTLSConfiguration(conn net.Conn, originalConfig *tls.Confi
 		if portContext.Service.UserAuthorizationType == policy.UserAuthorizationMutualTLS || portContext.Service.UserAuthorizationType == policy.UserAuthorizationJWT {
 			clientCAs := p.ca
 			if portContext.ClientTrustedRoots != nil {
-				clientCAs = portContext.ClientTrustedRoots
+				if !clientCAs.AppendCertsFromPEM(portContext.Service.MutualTLSTrustedRoots) {
+					return nil, fmt.Errorf("Unable to process client CAs")
+				}
+				//clientCAs = portContext.ClientTrustedRoots
 			}
 			config := p.newBaseTLSConfig()
 			config.ClientAuth = tls.VerifyClientCertIfGiven

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -304,7 +304,7 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		MaxIdleConnsPerHost: 2000,
 	}
 
-	// Create the proxies dowards the network and the application.
+	// Create the proxies downwards the network and the application.
 	var err error
 	p.fwdTLS, err = forward.New(
 		forward.RoundTripper(encryptedTransport),

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -145,7 +145,7 @@ func (p *Config) newBaseTLSConfig() *tls.Config {
 		NextProtos:               []string{"h2"},
 		PreferServerCipherSuites: true,
 		SessionTicketsDisabled:   true,
-		ClientAuth:               tls.RequestClientCert,
+		ClientAuth:               tls.VerifyClientCertIfGiven,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
@@ -158,6 +158,7 @@ func (p *Config) newBaseTLSConfig() *tls.Config {
 
 // newBaseTLSClientConfig creates the new basic TLS configuration for the client.
 func (p *Config) newBaseTLSClientConfig() *tls.Config {
+	fmt.Println("creating a new base TLS client config")
 	return &tls.Config{
 		GetCertificate:           p.GetCertificateFunc(),
 		NextProtos:               []string{"h2"},
@@ -175,6 +176,7 @@ func (p *Config) GetClientCertificateFunc() func(*tls.CertificateRequestInfo) (*
 	return func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		p.RLock()
 		defer p.RUnlock()
+		fmt.Println("\n\n in GetClientCertificateFunc")
 		if p.cert != nil {
 			return p.cert, nil
 		}
@@ -192,7 +194,7 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 	if p.server != nil {
 		return fmt.Errorf("Server already running")
 	}
-
+	fmt.Println("\n\n Starting the RunNetworkServer")
 	// If its an encrypted, wrap the listener in a TLS context. This is activated
 	// for the listener from the network, but not for the listener from a PU.
 	if encrypted {
@@ -290,6 +292,7 @@ func (p *Config) RunNetworkServer(ctx context.Context, l net.Listener, encrypted
 		DialContext:         networkDialerWithContext,
 		MaxIdleConnsPerHost: 2000,
 		MaxIdleConns:        2000,
+		ForceAttemptHTTP2: true,
 	}
 
 	// Create an unencrypted transport for talking to the application. If encryption
@@ -404,7 +407,7 @@ func (p *Config) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certifica
 func (p *Config) processAppRequest(w http.ResponseWriter, r *http.Request) {
 
 	zap.L().Debug("Processing Application Request", zap.String("URI", r.RequestURI), zap.String("Host", r.Host))
-
+	//fmt.Println("\n\n IN processAppRequest with requestURI and host: ", r.Re)
 	originalDestination := r.Context().Value(http.LocalAddrContextKey).(*net.TCPAddr)
 
 	// Authorize the request by calling the authorizer library.

--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -125,13 +125,14 @@ func (p *Config) clientTLSConfiguration(conn net.Conn, originalConfig *tls.Confi
 		}
 		if portContext.Service.UserAuthorizationType == policy.UserAuthorizationMutualTLS || portContext.Service.UserAuthorizationType == policy.UserAuthorizationJWT {
 			clientCAs := p.ca
+			// now append the User given CA certPool
 			if portContext.ClientTrustedRoots != nil {
+				// append only when the certpool is given
 				if len(portContext.Service.MutualTLSTrustedRoots) > 0 {
 					if !clientCAs.AppendCertsFromPEM(portContext.Service.MutualTLSTrustedRoots) {
 						return nil, fmt.Errorf("Unable to process client CAs")
 					}
 				}
-				//clientCAs = portContext.ClientTrustedRoots
 			}
 			config := p.newBaseTLSConfig()
 			config.ClientAuth = tls.VerifyClientCertIfGiven

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -77,7 +77,7 @@ func (p *Processor) UpdateServiceAPIs(apis *urisearch.APICache) error {
 
 // DecodeUserClaims decodes the user claims with the user authorization method.
 func (p *Processor) DecodeUserClaims(ctx context.Context, name, userToken string, certs []*x509.Certificate) ([]string, bool, string, error) {
-	fmt.Println("\n In decode use claims with auth type: ", p.userAuthorizationType, " len of certs: ", len(certs))
+
 	switch p.userAuthorizationType {
 	case policy.UserAuthorizationMutualTLS, policy.UserAuthorizationJWT:
 		// First parse any incoming certificates and retrieve attributes from them.

--- a/controller/pkg/auth/auth.go
+++ b/controller/pkg/auth/auth.go
@@ -77,7 +77,7 @@ func (p *Processor) UpdateServiceAPIs(apis *urisearch.APICache) error {
 
 // DecodeUserClaims decodes the user claims with the user authorization method.
 func (p *Processor) DecodeUserClaims(ctx context.Context, name, userToken string, certs []*x509.Certificate) ([]string, bool, string, error) {
-
+	fmt.Println("\n In decode use claims with auth type: ", p.userAuthorizationType, " len of certs: ", len(certs))
 	switch p.userAuthorizationType {
 	case policy.UserAuthorizationMutualTLS, policy.UserAuthorizationJWT:
 		// First parse any incoming certificates and retrieve attributes from them.


### PR DESCRIPTION
#### Description
The L7 app proxy is not sending the client certificate for PU-to-PU workflow. This breaks:

1. mtls between PU to PU on L7.
2. Aporeto to Envoy PU http flow.

Fixes: https://github.com/aporeto-inc/aporeto/issues/2370
#### Test plan
*Outline the test plan used to test this change before merging it.*

> Fixes #.
