### PR TITLE
clear ipset destroy list after all the unused ipsets have been destroyed

### DIFF
--- a/controller/pkg/ipsetmanager/ipsets.go
+++ b/controller/pkg/ipsetmanager/ipsets.go
@@ -289,8 +289,9 @@ func (m *managerType) DestroyUnusedIPsets() {
 			if err := ipsetHandler.Destroy(); err != nil {
 				zap.L().Warn("Failed to destroy ipset", zap.String("ipset", ipsetName), zap.Error(err))
 			}
-
 		}
+
+		ipHandler.toDestroy = nil
 	}
 
 	destroy(m.ipv4Handler)


### PR DESCRIPTION
There is a list we maintain that is used to destroy ipsets when it is safe to destroy them. There was a bug where this list wasnt being cleared. Although it wasnt affecting any communication because ipsets themselves have reference in the iptables. This PR fixes that bug. 



