### PR TITLE
Follow-up from #943

### DIFF
--- a/controller/internal/enforcer/applicationproxy/http/http.go
+++ b/controller/internal/enforcer/applicationproxy/http/http.go
@@ -185,16 +185,16 @@ func (p *Config) newBaseTLSClientConfig() *tls.Config {
 func (p *Config) GetClientCertificateFunc(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 	p.RLock()
 	defer p.RUnlock()
-	if p.cert != nil {
+	if p.cert != nil && len(p.cert.Certificate) > 0 {
 		cert, err := x509.ParseCertificate(p.cert.Certificate[0])
 		if err != nil {
-			zap.L().Error("http: Cannot build the cert chain")
+			zap.L().Error("http: client-certs: cannot build the cert chain: failed to parse cert[0]", zap.Error(err))
 		}
 		if cert != nil {
 			by, _ := x509CertToPem(cert)
 			pemCert, err := buildCertChain(by, p.secrets.PublicSecrets().CertAuthority())
 			if err != nil {
-				zap.L().Error("http: Cannot build the cert chain")
+				zap.L().Error("http: client-certs: cannot build the cert chain", zap.Error(err))
 			}
 			var certChain tls.Certificate
 			var certDERBlock *pem.Block
@@ -466,7 +466,7 @@ func (p *Config) GetCertificateFunc(clientHello *tls.ClientHelloInfo) (*tls.Cert
 }
 
 func buildCertChain(certPEM, caPEM []byte) ([]byte, error) {
-	zap.L().Debug("http:  BEFORE in buildCertChain certPEM: ", zap.String("certPEM:", string(certPEM)), zap.String("caPEM: ", string(caPEM)))
+	zap.L().Debug("http: buildCertChain() call", zap.String("certPEM", string(certPEM)), zap.String("caPEM", string(caPEM)))
 	certChain := []*x509.Certificate{}
 	clientPEMBlock := certPEM
 
@@ -498,9 +498,9 @@ func buildCertChain(certPEM, caPEM []byte) ([]byte, error) {
 			return nil, fmt.Errorf("invalid pem block type: %s", certDERBlock.Type)
 		}
 	}
-	by, _ := x509CertChainToPem(certChain)
-	zap.L().Debug("http: After building the cert chain: ", zap.String("certChain: ", string(by)))
-	return x509CertChainToPem(certChain)
+	certChainBytes, err := x509CertChainToPem(certChain)
+	zap.L().Debug("http: buildCertChain() return", zap.String("certChainBytes", string(certChainBytes)), zap.Error(err))
+	return certChainBytes, err
 }
 
 // x509CertChainToPem converts chain of x509 certs to byte.

--- a/controller/internal/enforcer/envoyauthorizer/envoyauthorizerenforcer.go
+++ b/controller/internal/enforcer/envoyauthorizer/envoyauthorizerenforcer.go
@@ -143,6 +143,8 @@ func (e *Enforcer) Enforce(contextID string, puInfo *policy.PUInfo) error {
 		sdsServer, err := envoyproxy.NewSdsServer(contextID, puInfo, caPool, e.secrets)
 		if err != nil {
 			zap.L().Error("Cannot create and run SdsServer", zap.Error(err))
+			ingressServer.Stop()
+			egressServer.Stop()
 			return err
 		}
 		// Add the EnvoyServers to our cache


### PR DESCRIPTION
Follow-up from #943 . Adding better logging for http client certs and adding stops in envoy.

There could be a lot more done in both packages that are touched here. However, especially the http package stands out: logging is not very clear, UT missing (in the works though for envoy by Abhi), a lot of variable/pointer checks missing, unclear return values and missing errors - should at least have a comment if they are intended, ignoring golang best practices and not very elegant code. One can see that this was written down in a hurry, and fixed in a hurry by us recently as well :) This package deserves some love.

Anyway, I leave it up to @brianonn and @abhijitherekar to add more to this PR if you think that is necessary.

@brianonn I ignored the `Gopkg.toml` comment from #943 as I don't think we need to change anything. Please comment here if you think otherwise.