### PR TITLE
Making Resync a blocked operation for the PodMonitor (master)

### DIFF
--- a/monitor/internal/pod/controller.go
+++ b/monitor/internal/pod/controller.go
@@ -43,7 +43,7 @@ var (
 )
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, handler *config.ProcessorConfig, metadataExtractor extractors.PodMetadataExtractor, netclsProgrammer extractors.PodNetclsProgrammer, sandboxExtractor extractors.PodSandboxExtractor, nodeName string, enableHostPods bool, deleteCh chan<- DeleteEvent, deleteReconcileCh chan<- struct{}) *ReconcilePod {
+func newReconciler(mgr manager.Manager, handler *config.ProcessorConfig, metadataExtractor extractors.PodMetadataExtractor, netclsProgrammer extractors.PodNetclsProgrammer, sandboxExtractor extractors.PodSandboxExtractor, nodeName string, enableHostPods bool, deleteCh chan<- DeleteEvent, deleteReconcileCh chan<- struct{}, resyncInfo *ResyncInfoChan) *ReconcilePod {
 	return &ReconcilePod{
 		client:            mgr.GetClient(),
 		scheme:            mgr.GetScheme(),
@@ -56,6 +56,7 @@ func newReconciler(mgr manager.Manager, handler *config.ProcessorConfig, metadat
 		enableHostPods:    enableHostPods,
 		deleteCh:          deleteCh,
 		deleteReconcileCh: deleteReconcileCh,
+		resyncInfo:        resyncInfo,
 
 		// TODO: should move into configuration
 		handlePUEventTimeout:   60 * time.Second,
@@ -123,16 +124,30 @@ type ReconcilePod struct {
 	enableHostPods    bool
 	deleteCh          chan<- DeleteEvent
 	deleteReconcileCh chan<- struct{}
+	resyncInfo        *ResyncInfoChan
 
 	metadataExtractTimeout time.Duration
 	handlePUEventTimeout   time.Duration
 	netclsProgramTimeout   time.Duration
 }
 
+func (r *ReconcilePod) resyncHelper(nn string) {
+	if r.resyncInfo != nil {
+		r.resyncInfo.SendInfo(nn)
+	}
+}
+
 // Reconcile reads that state of the cluster for a pod object
 func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.Background()
 	nn := request.NamespacedName.String()
+
+	// we do this very early on:
+	// whatever happened to the processing of this pod event, we are telling the Resync handler
+	// that we have seen it. Even if we have not sent an event to the policy engine,
+	// it means that most likely we are okay for an existing PU to be deleted first
+	defer r.resyncHelper(nn)
+
 	var puID, sandboxID string
 	var err error
 	// Fetch the corresponding pod object.

--- a/monitor/internal/pod/controller_test.go
+++ b/monitor/internal/pod/controller_test.go
@@ -242,6 +242,7 @@ func TestController(t *testing.T) {
 			enableHostPods:    true,
 			deleteCh:          deleteCh,
 			deleteReconcileCh: deleteReconcileCh,
+			resyncInfo:        NewResyncInfoChan(),
 
 			// taken from original file
 			handlePUEventTimeout:   5 * time.Second,

--- a/monitor/internal/pod/monitor.go
+++ b/monitor/internal/pod/monitor.go
@@ -37,12 +37,14 @@ type PodMonitor struct {
 	kubeCfg                   *rest.Config
 	kubeClient                client.Client
 	eventsCh                  chan event.GenericEvent
+	resyncInfo                *ResyncInfoChan
 }
 
 // New returns a new kubernetes monitor.
 func New() *PodMonitor {
 	podMonitor := &PodMonitor{
-		eventsCh: make(chan event.GenericEvent),
+		eventsCh:   make(chan event.GenericEvent),
+		resyncInfo: NewResyncInfoChan(),
 	}
 
 	return podMonitor
@@ -123,7 +125,7 @@ func (m *PodMonitor) Run(ctx context.Context) error {
 	}
 
 	// ensure to run the reset net_cls
-	// NOTE: we also call this during resync, however, that is not called at startup
+	// NOTE: we also call this during resync, however, that is not called at startup (we call ResyncWithAllPods instead before we return)
 	if m.resetNetcls == nil {
 		return errors.New("pod: missing net_cls reset implementation")
 	}
@@ -146,7 +148,7 @@ func (m *PodMonitor) Run(ctx context.Context) error {
 	}
 
 	// Create the main controller for the monitor
-	r := newReconciler(mgr, m.handlers, m.metadataExtractor, m.netclsProgrammer, m.sandboxExtractor, m.localNode, m.enableHostPods, dc.GetDeleteCh(), dc.GetReconcileCh())
+	r := newReconciler(mgr, m.handlers, m.metadataExtractor, m.netclsProgrammer, m.sandboxExtractor, m.localNode, m.enableHostPods, dc.GetDeleteCh(), dc.GetReconcileCh(), m.resyncInfo)
 	if err := addController(mgr, r, m.workers, m.eventsCh); err != nil {
 		return fmt.Errorf("pod: %s", err.Error())
 	}
@@ -183,6 +185,14 @@ func (m *PodMonitor) Run(ctx context.Context) error {
 		return errors.New("pod: controller did not start within 5s")
 	case <-controllerStarted:
 		m.kubeClient = mgr.GetClient()
+
+		// call ResyncWithAllPods before we return from here
+		// this will block until every pod at this point in time has been seeing at least one `Reconcile` call
+		// we do this so that we build up our internal PU cache in the policy engine,
+		// so that when we remove stale pods on startup, we don't remove them and create them again
+		if err := ResyncWithAllPods(ctx, m.kubeClient, m.resyncInfo, m.eventsCh); err != nil {
+			// not important enough to fail
+		}
 		return nil
 	}
 }
@@ -206,7 +216,7 @@ func (m *PodMonitor) Resync(ctx context.Context) error {
 		return errors.New("pod: client has not been initialized yet")
 	}
 
-	return ResyncWithAllPods(ctx, m.kubeClient, m.eventsCh)
+	return ResyncWithAllPods(ctx, m.kubeClient, m.resyncInfo, m.eventsCh)
 }
 
 type runnable struct {

--- a/monitor/internal/pod/monitor.go
+++ b/monitor/internal/pod/monitor.go
@@ -18,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"go.uber.org/zap"
 )
 
 // PodMonitor implements a monitor that sends pod events upstream
@@ -191,7 +193,7 @@ func (m *PodMonitor) Run(ctx context.Context) error {
 		// we do this so that we build up our internal PU cache in the policy engine,
 		// so that when we remove stale pods on startup, we don't remove them and create them again
 		if err := ResyncWithAllPods(ctx, m.kubeClient, m.resyncInfo, m.eventsCh); err != nil {
-			// not important enough to fail
+			zap.L().Warn("Pod resync failed", zap.Error(err))
 		}
 		return nil
 	}

--- a/monitor/internal/pod/resync.go
+++ b/monitor/internal/pod/resync.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -14,8 +15,9 @@ import (
 )
 
 // ResyncWithAllPods is called from the implemented resync, it will list all pods
-// and fire them down the event source (the generic event channel)
-func ResyncWithAllPods(ctx context.Context, c client.Client, evCh chan<- event.GenericEvent) error {
+// and fire them down the event source (the generic event channel).
+// It will block until every pod at the time of calling has been calling `Reconcile` at least once.
+func ResyncWithAllPods(ctx context.Context, c client.Client, i *ResyncInfoChan, evCh chan<- event.GenericEvent) error {
 	if c == nil {
 		return errors.New("pod: no client available")
 	}
@@ -24,11 +26,29 @@ func ResyncWithAllPods(ctx context.Context, c client.Client, evCh chan<- event.G
 		return errors.New("pod: no event source available")
 	}
 
+	if i == nil {
+		return errors.New("pod: no resync info channel available")
+	}
+
 	list := &corev1.PodList{}
 	if err := c.List(ctx, &client.ListOptions{}, list); err != nil {
 		return fmt.Errorf("pod: %s", err.Error())
 	}
 
+	// build a map of pods that we will expect to turn true
+	m := make(map[string]bool)
+	for _, pod := range list.Items {
+		podName := pod.GetName()
+		podNamespace := pod.GetNamespace()
+		if podName != "" && podNamespace != "" {
+			m[fmt.Sprintf("%s/%s", podNamespace, podName)] = false
+		}
+	}
+
+	// Request that the controller reports to us from now on
+	i.EnableNeedsInfo()
+
+	// fire away events to the controller
 	for _, pod := range list.Items {
 		p := pod.DeepCopy()
 		evCh <- event.GenericEvent{
@@ -37,5 +57,75 @@ func ResyncWithAllPods(ctx context.Context, c client.Client, evCh chan<- event.G
 		}
 	}
 
+	// now wait for all pods to have reported back
+waitLoop:
+	for {
+		info := <-*i.GetInfoCh()
+		if _, ok := m[info]; ok {
+			m[info] = true
+		}
+
+		// now check if we can abort already
+		for _, v := range m {
+			if !v {
+				continue waitLoop
+			}
+		}
+		break waitLoop
+	}
+	i.DisableNeedsInfo()
+
 	return nil
+}
+
+// ResyncInfoChan is used to report back from the controller on which pods it has processed.
+// It allows the Resync of the monitor to block and wait until a list has been processed.
+type ResyncInfoChan struct {
+	m  sync.RWMutex
+	b  bool
+	ch chan string
+}
+
+// NewResyncInfoChan creates a new ResyncInfoChan
+func NewResyncInfoChan() *ResyncInfoChan {
+	return &ResyncInfoChan{
+		ch: make(chan string, 100),
+	}
+}
+
+// EnableNeedsInfo enables the need for sending info
+func (r *ResyncInfoChan) EnableNeedsInfo() {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.b = true
+}
+
+// DisableNeedsInfo disables the need for sending info
+func (r *ResyncInfoChan) DisableNeedsInfo() {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.b = false
+}
+
+// NeedsInfo returns if there is a need for sending info
+func (r *ResyncInfoChan) NeedsInfo() bool {
+	r.m.RLock()
+	defer r.m.RUnlock()
+	return r.b
+}
+
+// SendInfo will make the info available through an internal channel
+func (r *ResyncInfoChan) SendInfo(info string) {
+	r.m.RLock()
+	defer r.m.RUnlock()
+	if r.b {
+		r.ch <- info
+	}
+}
+
+// GetInfoCh returns the channel
+func (r *ResyncInfoChan) GetInfoCh() *chan string {
+	r.m.RLock()
+	defer r.m.RUnlock()
+	return &r.ch
 }

--- a/monitor/internal/pod/resync.go
+++ b/monitor/internal/pod/resync.go
@@ -12,12 +12,15 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"go.uber.org/zap"
 )
 
 // ResyncWithAllPods is called from the implemented resync, it will list all pods
 // and fire them down the event source (the generic event channel).
 // It will block until every pod at the time of calling has been calling `Reconcile` at least once.
 func ResyncWithAllPods(ctx context.Context, c client.Client, i *ResyncInfoChan, evCh chan<- event.GenericEvent) error {
+	zap.L().Debug("Pod resync: starting to resync all pods")
 	if c == nil {
 		return errors.New("pod: no client available")
 	}
@@ -44,6 +47,7 @@ func ResyncWithAllPods(ctx context.Context, c client.Client, i *ResyncInfoChan, 
 			m[fmt.Sprintf("%s/%s", podNamespace, podName)] = false
 		}
 	}
+	zap.L().Debug("Pod resync: pods that need to be resynced", zap.Any("pods", m))
 
 	// Request that the controller reports to us from now on
 	i.EnableNeedsInfo()
@@ -62,7 +66,10 @@ waitLoop:
 	for {
 		info := <-*i.GetInfoCh()
 		if _, ok := m[info]; ok {
+			zap.L().Debug("Pod resync: pod that is part of the resync", zap.String("pod", info))
 			m[info] = true
+		} else {
+			zap.L().Debug("Pod resync: *not* a pod that is part of the resync", zap.String("pod", info))
 		}
 
 		// now check if we can abort already
@@ -74,6 +81,7 @@ waitLoop:
 		break waitLoop
 	}
 	i.DisableNeedsInfo()
+	zap.L().Debug("Pod resync: finished resyncing all pods")
 
 	return nil
 }

--- a/monitor/internal/pod/resync_test.go
+++ b/monitor/internal/pod/resync_test.go
@@ -17,6 +17,7 @@ func TestResyncWithAllPods(t *testing.T) {
 	Convey("Given a client, two pods and an event channel", t, func() {
 		ctx := context.TODO()
 		evCh := make(chan event.GenericEvent, 100)
+		resyncInfo := NewResyncInfoChan()
 		pod1 := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod1",
@@ -32,19 +33,22 @@ func TestResyncWithAllPods(t *testing.T) {
 		c := fakeclient.NewFakeClient(pod1, pod2)
 
 		Convey("resync should fail if there is no client", func() {
-			err := ResyncWithAllPods(ctx, nil, evCh)
+			err := ResyncWithAllPods(ctx, nil, resyncInfo, evCh)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "pod: no client available")
 		})
 
 		Convey("resync should fail if there is no event channel", func() {
-			err := ResyncWithAllPods(ctx, c, nil)
+			err := ResyncWithAllPods(ctx, c, resyncInfo, nil)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "pod: no event source available")
 		})
 
 		Convey("resync should successfully send messages with all pods", func() {
-			err := ResyncWithAllPods(ctx, c, evCh)
+			resyncInfo.EnableNeedsInfo()
+			resyncInfo.SendInfo("default/pod1")
+			resyncInfo.SendInfo("default/pod2")
+			err := ResyncWithAllPods(ctx, c, resyncInfo, evCh)
 			So(err, ShouldBeNil)
 			allPods := []string{"pod1", "pod2"}
 			collectedPods := []string{}


### PR DESCRIPTION
This will make `Resync()` a blocked operation for the `PodMonitor` as discussed with @sibicramesh earlier today. It also calls Resync during `Run()` so that it is guaranteed to have run and reconciled every pod once first before returning.

This is required for the 3.13 enforcer which removes stale PUs on startup and would otherwise potentially delete and create them again on a restart.