### PR TITLE
fix: panic when the token is malformed

### DIFF
--- a/controller/pkg/tokens/binaryjwt.go
+++ b/controller/pkg/tokens/binaryjwt.go
@@ -516,7 +516,7 @@ func unpackToken(isAck bool, data []byte) ([]byte, []byte, []byte, []byte, error
 	sigPosition := int(binary.BigEndian.Uint16(data[lengthPosition : lengthPosition+2]))
 
 	// The token must be long enough to have at least 1 byte of signature.
-	if len(data) < sigPosition+1 {
+	if len(data) < sigPosition+1 || sigPosition == 0 {
 		return nil, nil, nil, nil, fmt.Errorf("no signature in the token")
 	}
 

--- a/controller/pkg/tokens/binaryjwt_test.go
+++ b/controller/pkg/tokens/binaryjwt_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/gob"
+	"fmt"
 	"math/big"
 	"strconv"
 	"testing"
@@ -114,6 +115,25 @@ func Test_EncodeDecode(t *testing.T) {
 				So(outClaims.T.Tags, ShouldContain, "AporetoContextID=pu1")
 			})
 
+		})
+
+		Convey("When I encode and decode a bad Syn Packet", func() {
+
+			token := make([]byte, 400)
+			token = append(token, []byte("abcdefghijklmnopqrstuvwxyz")...)
+
+			Convey("When I decode the token, it should be give the original claims", func() {
+				_, _, _, err := b.Decode(false, token, nil)
+				So(err, ShouldResemble, fmt.Errorf("unable to unpack token: no signature in the token"))
+			})
+		})
+
+		Convey("When I encode and decode a nil Syn Packet", func() {
+
+			Convey("When I decode the token, it should be give the original claims", func() {
+				_, _, _, err := b.Decode(false, nil, nil)
+				So(err, ShouldResemble, fmt.Errorf("unable to unpack token: not enough data"))
+			})
 		})
 	})
 }


### PR DESCRIPTION
**NOTE: This fix only avoids the crash. This doesn't explain why the token was messed up in the first place.**

The issue here is the signature position in the token is missing and the check for that was absent. We then proceed to extract the signature from this position in this case will be `0`. So is this panic
```panic
panic: runtime error: slice bounds out of range [22:0]
```
Added unit tests to avoid regression.

Full stack here 
[enforcerd.log](https://github.com/aporeto-inc/trireme-lib/files/4125107/enforcerd.log)