### PR TITLE
with aporeto iptables we do not need to check for ip6tables

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/ipv6.go
+++ b/controller/internal/supervisor/iptablesctrl/ipv6.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aporeto-inc/go-ipset/ipset"
 	provider "go.aporeto.io/trireme-lib/controller/pkg/aclprovider"
 	"go.aporeto.io/trireme-lib/controller/pkg/ipsetmanager"
+	"go.uber.org/zap"
 )
 
 const (
@@ -103,6 +104,7 @@ func (i *ipv6) NewChain(table, chain string) error {
 		return nil
 	}
 
+	zap.L().Debug("new chain")
 	return i.ipt.NewChain(table, chain)
 }
 
@@ -111,6 +113,7 @@ func (i *ipv6) Commit() error {
 		return nil
 	}
 
+	zap.L().Debug("ipv6 commit")
 	return i.ipt.Commit()
 }
 

--- a/controller/internal/supervisor/iptablesctrl/ipv6_nonwindows.go
+++ b/controller/internal/supervisor/iptablesctrl/ipv6_nonwindows.go
@@ -11,10 +11,7 @@ import (
 func GetIPv6Impl(ipv6Enabled bool) (IPImpl, error) {
 	ipt, err := provider.NewGoIPTablesProviderV6([]string{"mangle"})
 	if err == nil {
-		// test if the system supports ip6tables
-		if _, err = ipt.ListChains("mangle"); err == nil {
-			return &ipv6{ipt: ipt, ipv6Enabled: ipv6Enabled}, nil
-		}
+		return &ipv6{ipt: ipt, ipv6Enabled: ipv6Enabled}, nil
 	}
 
 	return &ipv6{ipt: nil, ipv6Enabled: false}, nil


### PR DESCRIPTION
#### Description
*Changes proposed in this pull request.*

#### Test plan
*Outline the test plan used to test this change before merging it.*

> Fixes #.
