### PR TITLE
Brianonn test mehul fix for iptables no bypass

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/iptables.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables.go
@@ -209,6 +209,10 @@ func (i *iptables) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to update synack networks: %s", err)
 	}
 
+	if err := i.impl.Commit(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -343,6 +343,8 @@ func (b *BatchProvider) Commit() error {
 	}
 
 	buf, err := b.createDataBuffer()
+	zap.L().Info("Commit operation :buffer = ", zap.String(buf.String()))
+
 	if err != nil {
 		zap.L().Error("Failed to create buffer ", zap.Error(err))
 		return fmt.Errorf("Failed to crete buffer %s", err)

--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -351,7 +351,7 @@ func (b *BatchProvider) Commit() error {
 	err = b.commitFunc(buf)
 
 	if err != nil {
-		zap.Error("commit returned error ", zap.Error(err))
+		zap.L().Error("commit returned error ", zap.Error(err))
 	}
 
 	return err

--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -435,6 +435,8 @@ func restoreHasWait(restoreCmd string) bool {
 		return false
 	}
 
+	restoreCmdVersion := match[1]
+
 	restoreVersion, err := version.NewVersion(match[1])
 	if err != nil {
 		return false
@@ -446,8 +448,10 @@ func restoreHasWait(restoreCmd string) bool {
 	}
 
 	if restoreVersion.LessThan(minimumVersion) {
-		zap.L().Info(fmt.Sprintf(" %s: does not support --wait. Must be v%s or higher", restoreCmd, minVersionString))
+		zap.L().Info(fmt.Sprintf(" %s (%s): does not support --wait. Must be v%s or higher", restoreCmd, restoreCmdVersion, minVersionString))
 		return false
+	} else {
+		zap.L().Info(fmt.Sprintf(" %s (%s): supports --wait. Will use %s --wait", restoreCmd, restoreCmdVersion, restoreCmd))
+		return true
 	}
-	return true
 }

--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -344,10 +344,17 @@ func (b *BatchProvider) Commit() error {
 
 	buf, err := b.createDataBuffer()
 	if err != nil {
+		zap.L().Error("Failed to create buffer ", zap.Error(err))
 		return fmt.Errorf("Failed to crete buffer %s", err)
 	}
 
-	return b.commitFunc(buf)
+	err = b.commitFunc(buf)
+
+	if err != nil {
+		zap.Error("commit returned error ", zap.Error(err))
+	}
+
+	return err
 }
 
 // RetrieveTable allows a caller to retrieve the final table. Mostly

--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -343,7 +343,7 @@ func (b *BatchProvider) Commit() error {
 	}
 
 	buf, err := b.createDataBuffer()
-	zap.L().Info("Commit operation :buffer = ", zap.String(buf.String()))
+	zap.L().Info("Commit operation :buffer = ", zap.String("buffer", buf.String()))
 
 	if err != nil {
 		zap.L().Error("Failed to create buffer ", zap.Error(err))

--- a/controller/pkg/aclprovider/iptablesprovider.go
+++ b/controller/pkg/aclprovider/iptablesprovider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -414,6 +415,11 @@ func (b *BatchProvider) quoteRulesSpec(rulesspec []string) {
 }
 
 func restoreHasWait(restoreCmd string) bool {
+	minVersionString := "1.6.2"
+	if _, err := os.Stat("/etc/redhat-release"); err == nil {
+		minVersionString = "1.6.0"
+	}
+
 	cmd := exec.Command(restoreCmd, "--version")
 	cmd.Stdin = bytes.NewReader([]byte{})
 	bytes, err := cmd.CombinedOutput()
@@ -434,13 +440,13 @@ func restoreHasWait(restoreCmd string) bool {
 		return false
 	}
 
-	minimumVersion, err := version.NewVersion("1.6.2")
+	minimumVersion, err := version.NewVersion(minVersionString)
 	if err != nil {
 		return false
 	}
 
 	if restoreVersion.LessThan(minimumVersion) {
-		zap.L().Info(fmt.Sprintf(" %s: does not support --wait. Must be v1.6.2 or higher", restoreCmd))
+		zap.L().Info(fmt.Sprintf(" %s: does not support --wait. Must be v%s or higher", restoreCmd, minVersionString))
 		return false
 	}
 	return true


### PR DESCRIPTION
same as branch  `brianonn-test-mehul-fix-for-iptables` but does not include the bypass fixes.  This is only for getting the VM into a broken state so that I can debug the root cause of the problem --- iptable-restore with empty buffer. 

