### PR TITLE
removed redundant return

### DIFF
--- a/controller/internal/processmon/processmon_test.go
+++ b/controller/internal/processmon/processmon_test.go
@@ -74,7 +74,6 @@ forLoop:
 		}
 	}
 	close(errChannel)
-	return
 }
 
 func TestCmdHelper(t *testing.T) {


### PR DESCRIPTION
removes a redundant return that passed **go:1.13** and was caught by **go:1.14** and **go:master** 

