### PR TITLE
Windows 314 fix

### DIFF
--- a/controller/internal/enforcer/applicationproxy/markedconn/origdest_windows.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/origdest_windows.go
@@ -44,7 +44,7 @@ func getOriginalDestPlatform(rawConn passFD, v4Proto bool) (net.IP, int, *Platfo
 			if netIP == nil {
 				err = fmt.Errorf("%s failed to get valid IP (%s)", frontman.GetDestInfoProc.Name, ipAddrStr)
 				// FrontmanGetDestInfo returned success, so clean up acquired resources
-				freeFunc(fd)
+				freeFunc(destHandle)
 			}
 		}
 	}

--- a/trireme-lib
+++ b/trireme-lib
@@ -1,1 +1,0 @@
-C:/Users/Aporeto/go/src/go.aporeto.io/


### PR DESCRIPTION
Fix minor bug discovered while writing unit tests - was passing a socket to our dll function which expects a different kind of handle.
Also, remove unneeded file accidentally committed.