### PR TITLE
updated docker/distribution and go-ipset to use lowercase Sirupsen

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,7 +6,7 @@ required = ["github.com/docker/distribution"]
 
 [[constraint]]
   name = "github.com/docker/docker"
-  version = "v17.05.0-ce-rc3"
+  version = "v18.06.3-ce"
 
 [[constraint]]
   name = "github.com/docker/distribution"
@@ -66,7 +66,7 @@ required = ["github.com/docker/distribution"]
 
 [[constraint]]
   name = "github.com/aporeto-inc/oxy"
-  branch = "sirupsen"
+  branch = "master"
 
 [[constraint]]
   name = "go.aporeto.io/netlink-go"
@@ -75,10 +75,6 @@ required = ["github.com/docker/distribution"]
 [[constraint]]
   name = "go.aporeto.io/tg"
   branch = "master"
-
-[[constraint]]
-  name = "github.com/hashicorp/go-version"
-  version = "v1.0.0"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,7 +10,7 @@ required = ["github.com/docker/distribution"]
 
 [[constraint]]
   name = "github.com/docker/distribution"
-  revision = "v2.7.0""
+  revision = "v2.7.0"
 
 [[override]]
   name = "github.com/ti-mo/netfilter"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,7 @@
 required = ["github.com/docker/distribution"]
 
 [[constraint]]
-  branch = "master"
+  branch = "sirupsen"
   name = "github.com/aporeto-inc/go-ipset"
 
 [[constraint]]
@@ -10,7 +10,7 @@ required = ["github.com/docker/distribution"]
 
 [[constraint]]
   name = "github.com/docker/distribution"
-  revision = "b38e5838b7b2f2ad48e06ec4b500011976080621"
+  revision = "v2.7.0""
 
 [[override]]
   name = "github.com/ti-mo/netfilter"


### PR DESCRIPTION
#### Description
updates docker/distribution and go-ipset to use versions that use lowercase sirupsen
