### PR TITLE
Moved frontman APIs to utils and add functions to get frontman rules …

### DIFF
--- a/controller/internal/enforcer/applicationproxy/markedconn/mark_windows.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/mark_windows.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"syscall"
 
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/applicationproxy/markedconn/markedconn_windows_test.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/markedconn_windows_test.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 
 	"github.com/magiconair/properties/assert"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 )
 
 type abi struct {

--- a/controller/internal/enforcer/applicationproxy/markedconn/markedconn_windows_test.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/markedconn_windows_test.go
@@ -139,6 +139,14 @@ func (a *abi) DeleteFilterCriteria(driverHandle, filterName, criteriaName uintpt
 	return 1, nil
 }
 
+func (a *abi) ListIpsetsDetail(driverHandle, format, ipsetNames, ipsetNamesSize, bytesReturned uintptr) (uintptr, error) {
+	return 1, nil
+}
+
+func (a *abi) GetCriteriaList(driverHandle, format, criteriaList, criteriaListSize, bytesReturned uintptr) (uintptr, error) {
+	return 1, nil
+}
+
 type testPassFD struct {
 }
 

--- a/controller/internal/enforcer/applicationproxy/markedconn/origdest_windows.go
+++ b/controller/internal/enforcer/applicationproxy/markedconn/origdest_windows.go
@@ -7,7 +7,7 @@ import (
 	"net"
 
 	"go.aporeto.io/trireme-lib/controller/internal/windows"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/nfqdatapath/afinetrawsocket/afinetrawsocket_windows.go
+++ b/controller/internal/enforcer/nfqdatapath/afinetrawsocket/afinetrawsocket_windows.go
@@ -5,8 +5,8 @@ package afinetrawsocket
 import (
 	"errors"
 
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 )
 
 type rawsocket struct {

--- a/controller/internal/enforcer/nfqdatapath/nflog/nflog_windows.go
+++ b/controller/internal/enforcer/nfqdatapath/nflog/nflog_windows.go
@@ -8,8 +8,8 @@ import (
 	"syscall"
 
 	"go.aporeto.io/trireme-lib/collector"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/enforcer/nfqdatapath/nfq_windows.go
+++ b/controller/internal/enforcer/nfqdatapath/nfq_windows.go
@@ -10,10 +10,10 @@ import (
 
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/afinetrawsocket"
 	"go.aporeto.io/trireme-lib/controller/internal/enforcer/nfqdatapath/nflog"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
 	"go.aporeto.io/trireme-lib/controller/pkg/connection"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
 	"go.aporeto.io/trireme-lib/controller/pkg/pucontext"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 	"go.uber.org/zap"
 )
 

--- a/controller/internal/supervisor/iptablesctrl/acls_windows_test.go
+++ b/controller/internal/supervisor/iptablesctrl/acls_windows_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"go.aporeto.io/trireme-lib/controller/internal/windows"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/common"

--- a/controller/internal/supervisor/iptablesctrl/iptables_windows_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables_windows_test.go
@@ -302,6 +302,14 @@ func (a *abi) DeleteFilterCriteria(driverHandle, filterName, criteriaName uintpt
 	return 1, nil
 }
 
+func (a *abi) ListIpsetsDetail(driverHandle, format, ipsetNames, ipsetNamesSize, bytesReturned uintptr) (uintptr, error) {
+	return 1, nil
+}
+
+func (a *abi) GetCriteriaList(driverHandle, format, criteriaList, criteriaListSize, bytesReturned uintptr) (uintptr, error) {
+	return 1, nil
+}
+
 func Test_WindowsConfigureRulesV4(t *testing.T) {
 
 	a := &abi{

--- a/controller/internal/supervisor/iptablesctrl/iptables_windows_test.go
+++ b/controller/internal/supervisor/iptablesctrl/iptables_windows_test.go
@@ -14,12 +14,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/trireme-lib/common"
 	"go.aporeto.io/trireme-lib/controller/constants"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
 	provider "go.aporeto.io/trireme-lib/controller/pkg/aclprovider"
 	"go.aporeto.io/trireme-lib/controller/pkg/fqconfig"
 	"go.aporeto.io/trireme-lib/controller/pkg/ipsetmanager"
 	"go.aporeto.io/trireme-lib/controller/runtime"
 	"go.aporeto.io/trireme-lib/policy"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 )
 
 const (

--- a/controller/internal/windows/rulespec_windows.go
+++ b/controller/internal/windows/rulespec_windows.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	"github.com/DavidGamba/go-getoptions"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 	"golang.org/x/net/ipv6"
 )
 

--- a/controller/internal/windows/rulespec_windows_test.go
+++ b/controller/internal/windows/rulespec_windows_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
 	"go.aporeto.io/trireme-lib/controller/pkg/packet"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 )
 
 func TestParseRuleSpecMatchSet(t *testing.T) {

--- a/controller/pkg/aclprovider/ipsetprovider_windows.go
+++ b/controller/pkg/aclprovider/ipsetprovider_windows.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/aporeto-inc/go-ipset/ipset"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 )
 
 // IpsetProvider returns a fabric for Ipset.

--- a/controller/pkg/aclprovider/iptablesprovider_windows.go
+++ b/controller/pkg/aclprovider/iptablesprovider_windows.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 
 	winipt "go.aporeto.io/trireme-lib/controller/internal/windows"
-	"go.aporeto.io/trireme-lib/controller/internal/windows/frontman"
+	"go.aporeto.io/trireme-lib/utils/frontman"
 	"go.uber.org/zap"
 )
 

--- a/utils/frontman/driver_windows.go
+++ b/utils/frontman/driver_windows.go
@@ -311,13 +311,13 @@ const (
 // See Filter_set.h
 const (
 	CriteriaListFormatString = iota + 1
-	CriteriaListFormatJson
+	CriteriaListFormatJSON
 )
 
 // See Ipset.h
 const (
 	IpsetsDetailFormatString = iota + 1
-	IpsetsDetailFormatJson
+	IpsetsDetailFormatJSON
 )
 
 // DestInfo mirrors frontman's DEST_INFO struct

--- a/utils/frontman/driver_windows.go
+++ b/utils/frontman/driver_windows.go
@@ -16,6 +16,7 @@ type ABI interface {
 	GetIpset(driverHandle, name, ipset uintptr) (uintptr, error)
 	DestroyAllIpsets(driverHandle, prefix uintptr) (uintptr, error)
 	ListIpsets(driverHandle, ipsetNames, ipsetNamesSize, bytesReturned uintptr) (uintptr, error)
+	ListIpsetsDetail(driverHandle, format, ipsetNames, ipsetNamesSize, bytesReturned uintptr) (uintptr, error)
 	IpsetAdd(driverHandle, ipset, entry, timeout uintptr) (uintptr, error)
 	IpsetAddOption(driverHandle, ipset, entry, option, timeout uintptr) (uintptr, error)
 	IpsetDelete(driverHandle, ipset, entry uintptr) (uintptr, error)
@@ -32,6 +33,7 @@ type ABI interface {
 	GetFilterList(driverHandle, outbound, buffer, bufferSize, bytesReturned uintptr) (uintptr, error)
 	AppendFilterCriteria(driverHandle, filterName, criteriaName, ruleSpec, ipsetRuleSpecs, ipsetRuleSpecCount uintptr) (uintptr, error)
 	DeleteFilterCriteria(driverHandle, filterName, criteriaName uintptr) (uintptr, error)
+	GetCriteriaList(driverHandle, format, criteriaList, criteriaListSize, bytesReturned uintptr) (uintptr, error)
 }
 
 type driver struct {
@@ -98,6 +100,14 @@ func (d *driver) DestroyAllIpsets(driverHandle, prefix uintptr) (uintptr, error)
 
 func (d *driver) ListIpsets(driverHandle, ipsetNames, ipsetNamesSize, bytesReturned uintptr) (uintptr, error) {
 	ret, _, err := listIpsetsProc.Call(driverHandle, ipsetNames, ipsetNamesSize, bytesReturned)
+	if err == syscall.Errno(0) {
+		err = nil
+	}
+	return ret, err
+}
+
+func (d *driver) ListIpsetsDetail(driverHandle, format, ipsetNames, ipsetNamesSize, bytesReturned uintptr) (uintptr, error) {
+	ret, _, err := listIpsetsDetailProc.Call(driverHandle, format, ipsetNames, ipsetNamesSize, bytesReturned)
 	if err == syscall.Errno(0) {
 		err = nil
 	}
@@ -232,6 +242,14 @@ func (d *driver) DeleteFilterCriteria(driverHandle, filterName, criteriaName uin
 	return ret, err
 }
 
+func (d *driver) GetCriteriaList(driverHandle, format, criteriaList, criteriaListSize, bytesReturned uintptr) (uintptr, error) {
+	ret, _, err := getCriteriaListProc.Call(driverHandle, format, criteriaList, criteriaListSize, bytesReturned)
+	if err == syscall.Errno(0) {
+		err = nil
+	}
+	return ret, err
+}
+
 // Frontman.dll procs to be called from Go
 var (
 	driverDll        = syscall.NewLazyDLL("Frontman.dll")
@@ -251,6 +269,7 @@ var (
 	getIpsetProc         = driverDll.NewProc("IpsetProvider_GetIpset")
 	destroyAllIpsetsProc = driverDll.NewProc("IpsetProvider_DestroyAll")
 	listIpsetsProc       = driverDll.NewProc("IpsetProvider_ListIPSets")
+	listIpsetsDetailProc = driverDll.NewProc("IpsetProvider_ListIPSetsDetail")
 	ipsetAddProc         = driverDll.NewProc("Ipset_Add")
 	ipsetAddOptionProc   = driverDll.NewProc("Ipset_AddOption")
 	ipsetDeleteProc      = driverDll.NewProc("Ipset_Delete")
@@ -269,6 +288,7 @@ var (
 	getFilterListProc        = driverDll.NewProc("GetFilterList")
 	appendFilterCriteriaProc = driverDll.NewProc("AppendFilterCriteria")
 	deleteFilterCriteriaProc = driverDll.NewProc("DeleteFilterCriteria")
+	getCriteriaListProc      = driverDll.NewProc("GetCriteriaList")
 )
 
 // See frontmanIO.h for #defines
@@ -286,6 +306,18 @@ const (
 	BytesMatchStartIPHeader = iota + 1
 	BytesMatchStartProtocolHeader
 	BytesMatchStartPayload
+)
+
+// See Filter_set.h
+const (
+	CriteriaListFormatString = iota + 1
+	CriteriaListFormatJson
+)
+
+// See Ipset.h
+const (
+	IpsetsDetailFormatString = iota + 1
+	IpsetsDetailFormatJson
 )
 
 // DestInfo mirrors frontman's DEST_INFO struct

--- a/utils/frontman/driver_windows_test.go
+++ b/utils/frontman/driver_windows_test.go
@@ -376,6 +376,17 @@ func TestFrontmanFunctionArguments(t *testing.T) {
 			So(funcArgs[3].Size, ShouldEqual, pointerSize)
 		})
 
+		Convey("The arguments to IpsetProvider_ListIPSetsDetail should be as expected", func() {
+			funcArgs, err := pdb.GetFunctionArguments("IpsetProvider_ListIPSetsDetail")
+			So(err, ShouldBeNil)
+			So(len(funcArgs), ShouldEqual, 5)
+			So(funcArgs[0].Size, ShouldEqual, pointerSize)
+			So(funcArgs[1].Size, ShouldEqual, unsafe.Sizeof(int32(0)))
+			So(funcArgs[2].Size, ShouldEqual, pointerSize)
+			So(funcArgs[3].Size, ShouldEqual, unsafe.Sizeof(uint32(0)))
+			So(funcArgs[4].Size, ShouldEqual, pointerSize)
+		})
+
 		Convey("The arguments to Ipset_Add should be as expected", func() {
 			funcArgs, err := pdb.GetFunctionArguments("Ipset_Add")
 			So(err, ShouldBeNil)
@@ -520,6 +531,17 @@ func TestFrontmanFunctionArguments(t *testing.T) {
 			So(funcArgs[0].Size, ShouldEqual, pointerSize)
 			So(funcArgs[1].Size, ShouldEqual, pointerSize)
 			So(funcArgs[2].Size, ShouldEqual, pointerSize)
+		})
+
+		Convey("The arguments to GetCriteriaList should be as expected", func() {
+			funcArgs, err := pdb.GetFunctionArguments("GetCriteriaList")
+			So(err, ShouldBeNil)
+			So(len(funcArgs), ShouldEqual, 5)
+			So(funcArgs[0].Size, ShouldEqual, pointerSize)
+			So(funcArgs[1].Size, ShouldEqual, unsafe.Sizeof(int32(0)))
+			So(funcArgs[2].Size, ShouldEqual, pointerSize)
+			So(funcArgs[3].Size, ShouldEqual, unsafe.Sizeof(uint32(0)))
+			So(funcArgs[4].Size, ShouldEqual, pointerSize)
 		})
 
 	})


### PR DESCRIPTION
#### Description
- Moved internal frontman APIs to the trireme-lib/utils/frontman directory.  This was needed so that eforcerd could retrieve ipsets and rules for diagnostics.

- Add frontman APIs ListIpsetsDetail and GetCriteriaList to get ipsets and rules.  

