### PR TITLE
Dont use hmark for legacy acls (#1016)

### DIFF
--- a/controller/internal/supervisor/iptablesctrl/acls.go
+++ b/controller/internal/supervisor/iptablesctrl/acls.go
@@ -45,7 +45,7 @@ func (i *iptables) cgroupChainRules(cfg *ACLInfo) [][]string {
 			cfg.ContextID,
 			cfg.AppChain,
 			cfg.NetChain,
-			cfg.CgroupMark,
+			cfg.PacketMark,
 			cfg.TCPPorts,
 			cfg.UDPPorts,
 			cfg.ProxyPort,

--- a/controller/internal/supervisor/iptablesctrl/templates.go
+++ b/controller/internal/supervisor/iptablesctrl/templates.go
@@ -95,8 +95,9 @@ type ACLInfo struct {
 	MarkMask        string
 	HMarkRandomSeed string
 	// IPv4 IPv6
-	DefaultIP     string
-	needICMPRules bool
+	DefaultIP      string
+	needICMPRules  bool
+	IsLegacyKernel bool
 
 	// UDP rules
 	Numpackets   string
@@ -298,11 +299,11 @@ func (i *iptables) newACLInfo(version int, contextID string, p *policy.PUInfo, p
 		ProxySetName: proxySetName,
 
 		// // UID PUs
-		UID:        uid,
-		PacketMark: packetMark,
-		Mark:       mark,
-		PortSet:    portSetName,
-
+		UID:                    uid,
+		PacketMark:             packetMark,
+		Mark:                   mark,
+		PortSet:                portSetName,
+		IsLegacyKernel:         i.isLegacyKernel,
 		NFLOGPrefix:            policy.DefaultLogPrefix(contextID),
 		NFLOGAcceptPrefix:      policy.DefaultAcceptLogPrefix(contextID),
 		DefaultNFLOGDropPrefix: policy.DefaultDroppedPacketLogPrefix(contextID),


### PR DESCRIPTION
* Fixing Changes for rhel6 moving back to queue-balance on legacy platform

* Change mark value to packetMark

Co-authored-by: Amit Limaye <alimaye@paloaltonetworks.com>

#### Description
*Changes proposed in this pull request.*

#### Test plan
*Outline the test plan used to test this change before merging it.*

> Fixes #.
